### PR TITLE
merge selection and marker styles with any mode styles

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -261,11 +261,6 @@ var CodeMirror = (function() {
         if (includePre) html.push("</pre>");
         return html.join("");
       }
-      if (!this.marked && sfrom === 0 && sto === null) {
-        span(this.text + " ", "CodeMirror-selected");
-        return finish();
-      }
-
       var st = this.styles, allText = this.text, marked = this.marked;
       if (sfrom === sto) sfrom = null;
 
@@ -275,59 +270,45 @@ var CodeMirror = (function() {
         for (var i = 0, e = st.length; i < e; i+=2) span(st[i], st[i+1]);
       else {
         var pos = 0, i = 0, text = "", style, sg = 0;
-        function copyUntil(end) {
+        function copyUntil(end, extraStyle) {
           for (;;) {
             var upto = pos + text.length;
-            span(upto > end ? text.slice(0, end - pos) : text, style);
+            var apliedStyle = style;
+            if (extraStyle) apliedStyle = style ? style + extraStyle : extraStyle;
+            span(upto > end ? text.slice(0, end - pos) : text, apliedStyle);
             if (upto >= end) {text = text.slice(end - pos); pos = end; break;}
             pos = upto;
             text = st[i++]; style = st[i++];
           }
         }
-        function chunkUntil(end, cStyle) {
-          var acc = [];
-          for (;;) {
-            var upto = pos + text.length;
-            if (upto >= end) {
-              var size = end - pos;
-              acc.push(text.slice(0, size));
-              span(acc.join(""), cStyle);
-              text = text.slice(size);
-              pos += size;
-              break;
-            }
-            acc.push(text);
-            pos = upto;
-            text = st[i++]; style = st[i++];
-          }
-        }
-        var markpos = 0, mark;
+        var markpos = -1, mark = null;
         function nextMark() {
-          if (!marked) return null;
-          for (; markpos < marked.length; markpos++) {
-            mark = marked[markpos];
-            var end = mark.to == null ? allText.length : mark.to;
-            if (end > pos) return Math.max(mark.from, pos);
+          if (marked) {
+            markpos += 1;
+            mark = (markpos < marked.length) ? marked[markpos] : null;
           }
         }
-
+        nextMark();        
         while (pos < allText.length) {
-          var nextmark = nextMark();
-          if (sfrom != null && sfrom >= pos && (nextmark == null || sfrom <= nextmark)) {
-            copyUntil(sfrom);
-            if (sto == null) {
-              span(allText.slice(pos) + " ", "CodeMirror-selected");
-              break;
+          var upto = allText.length;
+          var extraStyle = "";
+          if (sfrom != null) {
+            if (sfrom > pos) upto = sfrom;
+            else if (sto == null || sto > pos) {
+                extraStyle = " CodeMirror-selected";
+                if (sto != null) upto = Math.min(upto, sto);
             }
-            chunkUntil(sto, "CodeMirror-selected");
           }
-          else if (nextmark != null) {
-            copyUntil(nextmark);
-            var end = mark.to == null ? allText.length : mark.to;
-            chunkUntil(sfrom == null || sfrom < pos ? end : Math.min(sfrom, end), mark.style);
+          while (mark && mark.to != null && mark.to <= pos) nextMark();
+          if (mark) {
+            if (mark.from > pos) upto = Math.min(upto, mark.from);
+            else {
+                extraStyle += " " + mark.style;
+                if (mark.to != null) upto = Math.min(upto, mark.to);
           }
-          else copyUntil(allText.length);
         }
+          copyUntil(upto, extraStyle);
+      }
       }
       return finish();
     }


### PR DESCRIPTION
When selection and markers were applied, they overwrote the classes that the mode styling supplied. This meant that as you selected, the selected text lost any styling it had - which looked bad. For example, if comments are styled italics and pale green, then as you selected over them they became non-italic and black. This was quite jarring.

This patch recodes the algorithm in getHTML to handle merging the styles from both the selection and the markers with any styles from the mode. The code also got smaller, and I think more clear. In my tests it properly handles all cases of overlapping and intersecting ranges, though the markers are still assumed to be non-overlapping.
