### PR TITLE
Small typo in overlay.js

### DIFF
--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -46,6 +46,6 @@ CodeMirror.overlayParser = function(base, overlay, combine) {
     indent: function(state, textAfter) {
       return base.indent(state.base, textAfter);
     },
-    electricChars: base.electicChars
+    electricChars: base.electricChars
   };
 };


### PR DESCRIPTION
I corrected a small typo in overlay.js (electicChars => electricChars).

Thanks for CodeMirror2, looks really nice :)

Henning
