### PR TITLE
XHTML support

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -28,7 +28,7 @@ var CodeMirror = (function() {
             '<textarea style="height: 1px; position: absolute;" wrap="off"></textarea></div>' +
           // Provides positioning relative to (visible) text origin
           '<div class="CodeMirror-lines"><div style="position: relative">' +
-            '<pre class="CodeMirror-cursor">&nbsp;</pre>' + // Absolutely positioned blinky cursor
+            '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor
             '<div></div></div></div></div></div>'; // This DIV contains the actual code
     if (place.appendChild) place.appendChild(wrapper); else place(wrapper);
     // I've never seen more elegant code in my life.


### PR DESCRIPTION
Hi Marijn,

just fixed a small bug that prevents CodeMirror from being used in XHTML documents.
A good explanation can be found at http://stackoverflow.com/questions/4162270/dom-exception-when-assigning-html-entities-to-innerhtml . Works great otherwise, thanks!

Cheers
