### PR TITLE
Added preliminary reStructuredText mode

### DIFF
--- a/compress.html
+++ b/compress.html
@@ -47,6 +47,7 @@
           <option value="http://codemirror.net/2/mode/diff/diff.js">diff.js</option>
           <option value="http://codemirror.net/2/mode/stex/stex.js">stex.js</option>
           <option value="http://codemirror.net/2/mode/smalltalk/smalltalk.js">smalltalk.js</option>
+          <option value="http://codemirror.net/2/mode/rst/rst.js">rst.js</option>
         </optgroup>
       </select></p>
 
@@ -76,3 +77,4 @@
 
   </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   actively developed, and recommended
   version. <a href="1/index.html">CodeMirror 1</a> is still available
   from here.</p>
- 
+
   <div class="clear"><div class="left1 blk">
 
     <h2 style="margin-top: 0">Supported modes:</h2>
@@ -44,6 +44,7 @@
       <li><a href="mode/stex/index.html">sTeX, LaTeX</a></li>
       <li><a href="mode/haskell/index.html">Haskell</a></li>
       <li><a href="mode/smalltalk/index.html">Smalltalk</a></li>
+      <li><a href="mode/rst/index.html">reStructuredText</a></li>
     </ul>
 
   </div><div class="left2 blk">
@@ -224,3 +225,4 @@
 
   </body>
 </html>
+

--- a/mode/rst/index.html
+++ b/mode/rst/index.html
@@ -1,0 +1,526 @@
+<!doctype html>
+<html>
+  <head>
+    <title>CodeMirror 2: reStructuredText mode</title>
+    <link rel="stylesheet" href="../../lib/codemirror.css">
+    <script src="../../lib/codemirror.js"></script>
+    <script src="rst.js"></script>
+    <link rel="stylesheet" href="rst.css">
+    <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+    <link rel="stylesheet" href="../../css/docs.css">
+  </head>
+  <body>
+    <h1>CodeMirror 2: reStructuredText mode</h1>
+
+<form><textarea id="code" name="code">
+.. This is an excerpt from Sphinx documentation: http://sphinx.pocoo.org/_sources/rest.txt
+
+.. highlightlang:: rest
+
+.. _rst-primer:
+
+reStructuredText Primer
+=======================
+
+This section is a brief introduction to reStructuredText (reST) concepts and
+syntax, intended to provide authors with enough information to author documents
+productively.  Since reST was designed to be a simple, unobtrusive markup
+language, this will not take too long.
+
+.. seealso::
+
+   The authoritative `reStructuredText User Documentation
+   &lt;http://docutils.sourceforge.net/rst.html&gt;`_.  The "ref" links in this
+   document link to the description of the individual constructs in the reST
+   reference.
+
+
+Paragraphs
+----------
+
+The paragraph (:duref:`ref &lt;paragraphs&gt;`) is the most basic block in a reST
+document.  Paragraphs are simply chunks of text separated by one or more blank
+lines.  As in Python, indentation is significant in reST, so all lines of the
+same paragraph must be left-aligned to the same level of indentation.
+
+
+.. _inlinemarkup:
+
+Inline markup
+-------------
+
+The standard reST inline markup is quite simple: use
+
+* one asterisk: ``*text*`` for emphasis (italics),
+* two asterisks: ``**text**`` for strong emphasis (boldface), and
+* backquotes: ````text```` for code samples.
+
+If asterisks or backquotes appear in running text and could be confused with
+inline markup delimiters, they have to be escaped with a backslash.
+
+Be aware of some restrictions of this markup:
+
+* it may not be nested,
+* content may not start or end with whitespace: ``* text*`` is wrong,
+* it must be separated from surrounding text by non-word characters.  Use a
+  backslash escaped space to work around that: ``thisis\ *one*\ word``.
+
+These restrictions may be lifted in future versions of the docutils.
+
+reST also allows for custom "interpreted text roles"', which signify that the
+enclosed text should be interpreted in a specific way.  Sphinx uses this to
+provide semantic markup and cross-referencing of identifiers, as described in
+the appropriate section.  The general syntax is ``:rolename:`content```.
+
+Standard reST provides the following roles:
+
+* :durole:`emphasis` -- alternate spelling for ``*emphasis*``
+* :durole:`strong` -- alternate spelling for ``**strong**``
+* :durole:`literal` -- alternate spelling for ````literal````
+* :durole:`subscript` -- subscript text
+* :durole:`superscript` -- superscript text
+* :durole:`title-reference` -- for titles of books, periodicals, and other
+  materials
+
+See :ref:`inline-markup` for roles added by Sphinx.
+
+
+Lists and Quote-like blocks
+---------------------------
+
+List markup (:duref:`ref &lt;bullet-lists&gt;`) is natural: just place an asterisk at
+the start of a paragraph and indent properly.  The same goes for numbered lists;
+they can also be autonumbered using a ``#`` sign::
+
+   * This is a bulleted list.
+   * It has two items, the second
+     item uses two lines.
+
+   1. This is a numbered list.
+   2. It has two items too.
+
+   #. This is a numbered list.
+   #. It has two items too.
+
+
+Nested lists are possible, but be aware that they must be separated from the
+parent list items by blank lines::
+
+   * this is
+   * a list
+
+     * with a nested list
+     * and some subitems
+
+   * and here the parent list continues
+
+Definition lists (:duref:`ref &lt;definition-lists&gt;`) are created as follows::
+
+   term (up to a line of text)
+      Definition of the term, which must be indented
+
+      and can even consist of multiple paragraphs
+
+   next term
+      Description.
+
+Note that the term cannot have more than one line of text.
+
+Quoted paragraphs (:duref:`ref &lt;block-quotes&gt;`) are created by just indenting
+them more than the surrounding paragraphs.
+
+Line blocks (:duref:`ref &lt;line-blocks&gt;`) are a way of preserving line breaks::
+
+   | These lines are
+   | broken exactly like in
+   | the source file.
+
+There are also several more special blocks available:
+
+* field lists (:duref:`ref &lt;field-lists&gt;`)
+* option lists (:duref:`ref &lt;option-lists&gt;`)
+* quoted literal blocks (:duref:`ref &lt;quoted-literal-blocks&gt;`)
+* doctest blocks (:duref:`ref &lt;doctest-blocks&gt;`)
+
+
+Source Code
+-----------
+
+Literal code blocks (:duref:`ref &lt;literal-blocks&gt;`) are introduced by ending a
+paragraph with the special marker ``::``.  The literal block must be indented
+(and, like all paragraphs, separated from the surrounding ones by blank lines)::
+
+   This is a normal text paragraph. The next paragraph is a code sample::
+
+      It is not processed in any way, except
+      that the indentation is removed.
+
+      It can span multiple lines.
+
+   This is a normal text paragraph again.
+
+The handling of the ``::`` marker is smart:
+
+* If it occurs as a paragraph of its own, that paragraph is completely left
+  out of the document.
+* If it is preceded by whitespace, the marker is removed.
+* If it is preceded by non-whitespace, the marker is replaced by a single
+  colon.
+
+That way, the second sentence in the above example's first paragraph would be
+rendered as "The next paragraph is a code sample:".
+
+
+.. _rst-tables:
+
+Tables
+------
+
+Two forms of tables are supported.  For *grid tables* (:duref:`ref
+&lt;grid-tables&gt;`), you have to "paint" the cell grid yourself.  They look like
+this::
+
+   +------------------------+------------+----------+----------+
+   | Header row, column 1   | Header 2   | Header 3 | Header 4 |
+   | (header rows optional) |            |          |          |
+   +========================+============+==========+==========+
+   | body row 1, column 1   | column 2   | column 3 | column 4 |
+   +------------------------+------------+----------+----------+
+   | body row 2             | ...        | ...      |          |
+   +------------------------+------------+----------+----------+
+
+*Simple tables* (:duref:`ref &lt;simple-tables&gt;`) are easier to write, but
+limited: they must contain more than one row, and the first column cannot
+contain multiple lines.  They look like this::
+
+   =====  =====  =======
+   A      B      A and B
+   =====  =====  =======
+   False  False  False
+   True   False  False
+   False  True   False
+   True   True   True
+   =====  =====  =======
+
+
+Hyperlinks
+----------
+
+External links
+^^^^^^^^^^^^^^
+
+Use ```Link text &lt;http://example.com/&gt;`_`` for inline web links.  If the link
+text should be the web address, you don't need special markup at all, the parser
+finds links and mail addresses in ordinary text.
+
+You can also separate the link and the target definition (:duref:`ref
+&lt;hyperlink-targets&gt;`), like this::
+
+   This is a paragraph that contains `a link`_.
+
+   .. _a link: http://example.com/
+
+
+Internal links
+^^^^^^^^^^^^^^
+
+Internal linking is done via a special reST role provided by Sphinx, see the
+section on specific markup, :ref:`ref-role`.
+
+
+Sections
+--------
+
+Section headers (:duref:`ref &lt;sections&gt;`) are created by underlining (and
+optionally overlining) the section title with a punctuation character, at least
+as long as the text::
+
+   =================
+   This is a heading
+   =================
+
+Normally, there are no heading levels assigned to certain characters as the
+structure is determined from the succession of headings.  However, for the
+Python documentation, this convention is used which you may follow:
+
+* ``#`` with overline, for parts
+* ``*`` with overline, for chapters
+* ``=``, for sections
+* ``-``, for subsections
+* ``^``, for subsubsections
+* ``"``, for paragraphs
+
+Of course, you are free to use your own marker characters (see the reST
+documentation), and use a deeper nesting level, but keep in mind that most
+target formats (HTML, LaTeX) have a limited supported nesting depth.
+
+
+Explicit Markup
+---------------
+
+"Explicit markup" (:duref:`ref &lt;explicit-markup-blocks&gt;`) is used in reST for
+most constructs that need special handling, such as footnotes,
+specially-highlighted paragraphs, comments, and generic directives.
+
+An explicit markup block begins with a line starting with ``..`` followed by
+whitespace and is terminated by the next paragraph at the same level of
+indentation.  (There needs to be a blank line between explicit markup and normal
+paragraphs.  This may all sound a bit complicated, but it is intuitive enough
+when you write it.)
+
+
+.. _directives:
+
+Directives
+----------
+
+A directive (:duref:`ref &lt;directives&gt;`) is a generic block of explicit markup.
+Besides roles, it is one of the extension mechanisms of reST, and Sphinx makes
+heavy use of it.
+
+Docutils supports the following directives:
+
+* Admonitions: :dudir:`attention`, :dudir:`caution`, :dudir:`danger`,
+  :dudir:`error`, :dudir:`hint`, :dudir:`important`, :dudir:`note`,
+  :dudir:`tip`, :dudir:`warning` and the generic :dudir:`admonition`.
+  (Most themes style only "note" and "warning" specially.)
+
+* Images:
+
+  - :dudir:`image` (see also Images_ below)
+  - :dudir:`figure` (an image with caption and optional legend)
+
+* Additional body elements:
+
+  - :dudir:`contents` (a local, i.e. for the current file only, table of
+    contents)
+  - :dudir:`container` (a container with a custom class, useful to generate an
+    outer ``&lt;div&gt;`` in HTML)
+  - :dudir:`rubric` (a heading without relation to the document sectioning)
+  - :dudir:`topic`, :dudir:`sidebar` (special highlighted body elements)
+  - :dudir:`parsed-literal` (literal block that supports inline markup)
+  - :dudir:`epigraph` (a block quote with optional attribution line)
+  - :dudir:`highlights`, :dudir:`pull-quote` (block quotes with their own
+    class attribute)
+  - :dudir:`compound` (a compound paragraph)
+
+* Special tables:
+
+  - :dudir:`table` (a table with title)
+  - :dudir:`csv-table` (a table generated from comma-separated values)
+  - :dudir:`list-table` (a table generated from a list of lists)
+
+* Special directives:
+
+  - :dudir:`raw` (include raw target-format markup)
+  - :dudir:`include` (include reStructuredText from another file)
+    -- in Sphinx, when given an absolute include file path, this directive takes
+    it as relative to the source directory
+  - :dudir:`class` (assign a class attribute to the next element) [1]_
+
+* HTML specifics:
+
+  - :dudir:`meta` (generation of HTML ``&lt;meta&gt;`` tags)
+  - :dudir:`title` (override document title)
+
+* Influencing markup:
+
+  - :dudir:`default-role` (set a new default role)
+  - :dudir:`role` (create a new role)
+
+  Since these are only per-file, better use Sphinx' facilities for setting the
+  :confval:`default_role`.
+
+Do *not* use the directives :dudir:`sectnum`, :dudir:`header` and
+:dudir:`footer`.
+
+Directives added by Sphinx are described in :ref:`sphinxmarkup`.
+
+Basically, a directive consists of a name, arguments, options and content. (Keep
+this terminology in mind, it is used in the next chapter describing custom
+directives.)  Looking at this example, ::
+
+   .. function:: foo(x)
+                 foo(y, z)
+      :module: some.module.name
+
+      Return a line of text input from the user.
+
+``function`` is the directive name.  It is given two arguments here, the
+remainder of the first line and the second line, as well as one option
+``module`` (as you can see, options are given in the lines immediately following
+the arguments and indicated by the colons).  Options must be indented to the
+same level as the directive content.
+
+The directive content follows after a blank line and is indented relative to the
+directive start.
+
+
+Images
+------
+
+reST supports an image directive (:dudir:`ref &lt;image&gt;`), used like so::
+
+   .. image:: gnu.png
+      (options)
+
+When used within Sphinx, the file name given (here ``gnu.png``) must either be
+relative to the source file, or absolute which means that they are relative to
+the top source directory.  For example, the file ``sketch/spam.rst`` could refer
+to the image ``images/spam.png`` as ``../images/spam.png`` or
+``/images/spam.png``.
+
+Sphinx will automatically copy image files over to a subdirectory of the output
+directory on building (e.g. the ``_static`` directory for HTML output.)
+
+Interpretation of image size options (``width`` and ``height``) is as follows:
+if the size has no unit or the unit is pixels, the given size will only be
+respected for output channels that support pixels (i.e. not in LaTeX output).
+Other units (like ``pt`` for points) will be used for HTML and LaTeX output.
+
+Sphinx extends the standard docutils behavior by allowing an asterisk for the
+extension::
+
+   .. image:: gnu.*
+
+Sphinx then searches for all images matching the provided pattern and determines
+their type.  Each builder then chooses the best image out of these candidates.
+For instance, if the file name ``gnu.*`` was given and two files :file:`gnu.pdf`
+and :file:`gnu.png` existed in the source tree, the LaTeX builder would choose
+the former, while the HTML builder would prefer the latter.
+
+.. versionchanged:: 0.4
+   Added the support for file names ending in an asterisk.
+
+.. versionchanged:: 0.6
+   Image paths can now be absolute.
+
+
+Footnotes
+---------
+
+For footnotes (:duref:`ref &lt;footnotes&gt;`), use ``[#name]_`` to mark the footnote
+location, and add the footnote body at the bottom of the document after a
+"Footnotes" rubric heading, like so::
+
+   Lorem ipsum [#f1]_ dolor sit amet ... [#f2]_
+
+   .. rubric:: Footnotes
+
+   .. [#f1] Text of the first footnote.
+   .. [#f2] Text of the second footnote.
+
+You can also explicitly number the footnotes (``[1]_``) or use auto-numbered
+footnotes without names (``[#]_``).
+
+
+Citations
+---------
+
+Standard reST citations (:duref:`ref &lt;citations&gt;`) are supported, with the
+additional feature that they are "global", i.e. all citations can be referenced
+from all files.  Use them like so::
+
+   Lorem ipsum [Ref]_ dolor sit amet.
+
+   .. [Ref] Book or article reference, URL or whatever.
+
+Citation usage is similar to footnote usage, but with a label that is not
+numeric or begins with ``#``.
+
+
+Substitutions
+-------------
+
+reST supports "substitutions" (:duref:`ref &lt;substitution-definitions&gt;`), which
+are pieces of text and/or markup referred to in the text by ``|name|``.  They
+are defined like footnotes with explicit markup blocks, like this::
+
+   .. |name| replace:: replacement *text*
+
+or this::
+
+   .. |caution| image:: warning.png
+                :alt: Warning!
+
+See the :duref:`reST reference for substitutions &lt;substitution-definitions&gt;`
+for details.
+
+If you want to use some substitutions for all documents, put them into
+:confval:`rst_prolog` or put them into a separate file and include it into all
+documents you want to use them in, using the :rst:dir:`include` directive.  (Be
+sure to give the include file a file name extension differing from that of other
+source files, to avoid Sphinx finding it as a standalone document.)
+
+Sphinx defines some default substitutions, see :ref:`default-substitutions`.
+
+
+Comments
+--------
+
+Every explicit markup block which isn't a valid markup construct (like the
+footnotes above) is regarded as a comment (:duref:`ref &lt;comments&gt;`).  For
+example::
+
+   .. This is a comment.
+
+You can indent text after a comment start to form multiline comments::
+
+   ..
+      This whole indented block
+      is a comment.
+
+      Still in the comment.
+
+
+Source encoding
+---------------
+
+Since the easiest way to include special characters like em dashes or copyright
+signs in reST is to directly write them as Unicode characters, one has to
+specify an encoding.  Sphinx assumes source files to be encoded in UTF-8 by
+default; you can change this with the :confval:`source_encoding` config value.
+
+
+Gotchas
+-------
+
+There are some problems one commonly runs into while authoring reST documents:
+
+* **Separation of inline markup:** As said above, inline markup spans must be
+  separated from the surrounding text by non-word characters, you have to use a
+  backslash-escaped space to get around that.  See `the reference
+  &lt;http://docutils.sf.net/docs/ref/rst/restructuredtext.html#inline-markup&gt;`_
+  for the details.
+
+* **No nested inline markup:** Something like ``*see :func:`foo`*`` is not
+  possible.
+
+
+.. rubric:: Footnotes
+
+.. [1] When the default domain contains a :rst:dir:`class` directive, this directive
+       will be shadowed.  Therefore, Sphinx re-exports it as :rst:dir:`rst-class`.
+</textarea></form>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        lineNumbers: true,
+      });
+    </script>
+    <p>The reStructuredText mode supports one configuration parameter:</p>
+    <dl>
+      <dt><code>verbatim (string)</code></dt>
+      <dd>A name or MIME type of a mode that will be used for highlighting
+      verbatim blocks. By default, reStructuredText mode uses uniform color
+      for whole block of verbatim text if no mode is given.</dd>
+    </dl>
+    <p>If <code>python</code> mode is available (not a part of CodeMirror 2 yet),
+    it will be used for highlighting blocks containing Python/IPython terminal
+    sessions (blocks starting with <code>&gt;&gt;&gt;</code> (for Python) or
+    <code>In [num]:</code> (for IPython).
+
+    <p><strong>MIME types defined:</strong> <code>text/x-rst</code>.</p>
+  </body>
+</html>
+

--- a/mode/rst/rst.css
+++ b/mode/rst/rst.css
@@ -1,0 +1,77 @@
+
+span.rst-emphasis {
+    font-style: italic;
+}
+
+span.rst-strong {
+    font-weight: bold;
+}
+
+span.rst-interpreted {
+    color: #33cc66;
+}
+
+span.rst-inline {
+    color: #3399cc;
+}
+
+span.rst-role {
+    color: #666699;
+}
+
+span.rst-list {
+    color: #cc0099;
+    font-weight: bold;
+}
+
+span.rst-body {
+    color: #6699cc;
+}
+
+span.rst-verbatim {
+    color: #3366ff;
+}
+
+span.rst-comment {
+    color: #aa7700;
+}
+
+span.rst-directive {
+    font-weight: bold;
+    color: #3399ff;
+}
+
+span.rst-hyperlink {
+    font-weight: bold;
+    color: #3366ff;
+}
+
+span.rst-footnote {
+    font-weight: bold;
+    color: #3333ff;
+}
+
+span.rst-citation {
+    font-weight: bold;
+    color: #3300ff;
+}
+
+span.rst-replacement {
+    color: #9933cc;
+}
+
+span.rst-section {
+    font-weight: bold;
+    color: #cc0099;
+}
+
+span.rst-directive-marker {
+    font-weight: bold;
+    color: #3399ff;
+}
+
+span.rst-verbatim-marker {
+    font-weight: bold;
+    color: #9900ff;
+}
+

--- a/mode/rst/rst.js
+++ b/mode/rst/rst.js
@@ -1,0 +1,335 @@
+
+CodeMirror.defineMode('rst', function(config, options) {
+    function setState(state, fn, ctx) {
+        state.fn = fn;
+        setCtx(state, ctx);
+    }
+
+    function setCtx(state, ctx) {
+        state.ctx = ctx || {};
+    }
+
+    function setNormal(state, ch) {
+        if (ch && (typeof ch !== 'string')) {
+            var str = ch.current();
+            ch = str[str.length-1];
+        }
+
+        setState(state, normal, {back: ch});
+    }
+
+    function hasMode(mode) {
+        if (mode) {
+            var modes = CodeMirror.listModes();
+
+            for (var i in modes) {
+                if (modes[i] == mode) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    function getMode(mode) {
+        if (hasMode(mode)) {
+            return CodeMirror.getMode(config, mode);
+        } else {
+            return null;
+        }
+    }
+
+    var verbatimMode = getMode(options.verbatim);
+    var pythonMode = getMode('python');
+
+    var reSection = /^[!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]/;
+    var reDirective = /^\s*\w([-:.\w]*\w)?::(\s|$)/;
+    var reHyperlink = /^\s*_[\w-]+:(\s|$)/;
+    var reFootnote = /^\s*\[(\d+|#)\](\s|$)/;
+    var reCitation = /^\s*\[[A-Za-z][\w-]*\](\s|$)/;
+    var reFootnoteRef = /^\[(\d+|#)\]_/;
+    var reCitationRef = /^\[[A-Za-z][\w-]*\]_/;
+    var reDirectiveMarker = /^\.\.(\s|$)/;
+    var reVerbatimMarker = /^::\s*$/;
+    var rePreInline = /^[-\s"([{</:]/;
+    var rePostInline = /^[-\s`'")\]}>/:.,;!?\\_]/;
+    var reEnumeratedList = /^\s*((\d+|[A-Za-z#])[.)]|\((\d+|[A-Z-a-z#])\))\s/;
+    var reBulletedList = /^\s*[-\+\*]\s/;
+    var reExamples = /^\s+(>>>|In \[\d+\]:)\s/;
+
+    function normal(stream, state) {
+        var ch, sol, i;
+
+        if (stream.eat(/\\/)) {
+            ch = stream.next();
+            setNormal(state, ch);
+            return null;
+        }
+
+        sol = stream.sol();
+
+        if (sol && (ch = stream.eat(reSection))) {
+            for (i = 0; stream.eat(ch); i++);
+
+            if (i >= 3 && stream.match(/^\s*$/)) {
+                setNormal(state, null);
+                return 'rst-section';
+            } else {
+                stream.backUp(i + 1);
+            }
+        }
+
+        if (sol && stream.match(reDirectiveMarker)) {
+            if (!stream.eol()) {
+                setState(state, directive);
+            }
+
+            return 'rst-directive-marker';
+        }
+
+        if (stream.match(reVerbatimMarker)) {
+            if (!verbatimMode) {
+                setState(state, verbatim);
+            } else {
+                var mode = verbatimMode;
+
+                setState(state, verbatim, {
+                    mode: mode,
+                    local: mode.startState()
+                });
+            }
+
+            return 'rst-verbatim-marker';
+        }
+
+        if (sol && stream.match(reExamples, false)) {
+            if (!pythonMode) {
+                setState(state, verbatim);
+                return 'rst-verbatim-marker';
+            } else {
+                var mode = pythonMode;
+
+                setState(state, verbatim, {
+                    mode: mode,
+                    local: mode.startState()
+                });
+
+                return null;
+            }
+        }
+
+        if (sol && (stream.match(reEnumeratedList) ||
+                    stream.match(reBulletedList))) {
+            setNormal(state, stream);
+            return 'rst-list';
+        }
+
+        function testBackward(re) {
+            return sol || !state.ctx.back || re.test(state.ctx.back);
+        }
+
+        function testForward(re) {
+            return stream.eol() || stream.match(re, false);
+        }
+
+        function testInline(re) {
+            return stream.match(re) && testBackward(/\W/) && testForward(/\W/);
+        }
+
+        if (testInline(reFootnoteRef)) {
+            setNormal(state, stream);
+            return 'rst-footnote';
+        }
+
+        if (testInline(reCitationRef)) {
+            setNormal(state, stream);
+            return 'rst-citation';
+        }
+
+        ch = stream.next();
+
+        if (testBackward(rePreInline)) {
+            if ((ch === ':' || ch === '|') && stream.eat(/\S/)) {
+                var token;
+
+                if (ch === ':') {
+                    token = 'rst-role';
+                } else {
+                    token = 'rst-replacement';
+                }
+
+                setState(state, inline, {
+                    ch: ch,
+                    wide: false,
+                    prev: null,
+                    token: token
+                });
+
+                return token;
+            }
+
+            if (ch === '*' || ch === '`') {
+                var orig = ch,
+                    wide = false;
+
+                ch = stream.next();
+
+                if (ch == orig) {
+                    wide = true;
+                    ch = stream.next();
+                }
+
+                if (ch && !/\s/.test(ch)) {
+                    var token;
+
+                    if (orig === '*') {
+                        token = wide ? 'rst-strong' : 'rst-emphasis';
+                    } else {
+                        token = wide ? 'rst-inline' : 'rst-interpreted';
+                    }
+
+                    setState(state, inline, {
+                        ch: orig,               // inline() has to know what to search for
+                        wide: wide,             // are we looking for `ch` or `chch`
+                        prev: null,             // terminator must not be preceeded with whitespace
+                        token: token,           // I don't want to recompute this all the time
+                    });
+
+                    return token;
+                }
+            }
+        }
+
+        setNormal(state, ch);
+        return null;
+    }
+
+    function inline(stream, state) {
+        var ch = stream.next(),
+            token = state.ctx.token;
+
+        function finish(ch) {
+            state.ctx.prev = ch;
+            return token;
+        }
+
+        if (ch != state.ctx.ch) {
+            return finish(ch);
+        }
+
+        if (/\s/.test(state.ctx.prev)) {
+            return finish(ch);
+        }
+
+        if (state.ctx.wide) {
+            ch = stream.next();
+
+            if (ch != state.ctx.ch) {
+                return finish(ch);
+            }
+        }
+
+        if (!stream.eol() && !rePostInline.test(stream.peek())) {
+            if (state.ctx.wide) {
+                stream.backUp(1);
+            }
+
+            return finish(ch);
+        }
+
+        setState(state, normal);
+        setNormal(state, ch);
+
+        return token;
+    }
+
+    function directive(stream, state) {
+        var token = null;
+
+        if (stream.match(reDirective)) {
+            token = 'rst-directive';
+        } else if (stream.match(reHyperlink)) {
+            token = 'rst-hyperlink';
+        } else if (stream.match(reFootnote)) {
+            token = 'rst-footnote';
+        } else if (stream.match(reCitation)) {
+            token = 'rst-citation';
+        } else {
+            stream.eatSpace();
+
+            if (stream.eol()) {
+                setNormal(state, stream);
+                return null;
+            } else {
+                stream.skipToEnd();
+                setState(state, comment);
+                return 'rst-comment';
+            }
+        }
+
+        setState(state, body, {start: true});
+        return token;
+    }
+
+    function body(stream, state) {
+        var token = 'rst-body';
+
+        if (!state.ctx.start || stream.sol()) {
+            return block(stream, state, token);
+        }
+
+        stream.skipToEnd();
+        setCtx(state);
+
+        return token;
+    }
+
+    function comment(stream, state) {
+        return block(stream, state, 'rst-comment');
+    }
+
+    function verbatim(stream, state) {
+        if (!verbatimMode) {
+            return block(stream, state, 'rst-verbatim');
+        } else {
+            if (stream.sol()) {
+                if (!stream.eatSpace()) {
+                    setNormal(state, stream);
+                }
+
+                return null;
+            }
+
+            return verbatimMode.token(stream, state.ctx.local);
+        }
+    }
+
+    function block(stream, state, token) {
+        if (stream.eol() || stream.eatSpace()) {
+            stream.skipToEnd();
+            return token;
+        } else {
+            setNormal(state, stream);
+            return null;
+        }
+    }
+
+    return {
+        startState: function() {
+            return {fn: normal, ctx: {}};
+        },
+
+        copyState: function(state) {
+            return {fn: state.fn, ctx: state.ctx};
+        },
+
+        token: function(stream, state) {
+            var token = state.fn(stream, state);
+            return token;
+        }
+    };
+});
+
+CodeMirror.defineMIME("text/x-rst", "rst");
+


### PR DESCRIPTION
Hi,

this is a preliminary implementation of reStructuredText (RST, reST) mode. Currently most of the specification of this markup language have been covered: inline markup (emphasis, strong, interpreted, verbatim, replacements, roles), directives (comments, verbatim blocks, citations), code blocks, lists. The mode has been tested on Sphinx and SymPy documentation, among others, and works quite smoothly up to some corner cases (the mode is too restrictive or too permissive in certain contexts, this will have to be refined).

The mode can take advantage of the preliminary Python mode that was submitted for review (for code blocks with terminal sessions). It can use an arbitrary mode, via `verbatim` option,  for highlighting of verbatim blocks (in theory, tested only with Python mode).

In near future I'm going to improve support for directives (e.g. add highlighting of fields) and add math support (embedded TeX).

Mateusz
