### PR TITLE
Cursor moves to bad position when go to next or previous line.

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -2,6 +2,13 @@
   overflow: auto;
   height: 300px;
   line-height: 1em;
+}
+
+/* Use Same font-family for these selectors, for proper cusror moving. */
+textarea.CodeMirror-input,
+div.CodeMirror-lines,
+div.CodeMirror-measure,
+div.CodeMirror-gutter {
   font-family: monospace;
 }
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -23,11 +23,11 @@ var CodeMirror = (function() {
     // This mess creates the base DOM structure for the editor.
     wrapper.innerHTML =
       '<div style="position: relative">' + // Set to the height of the text, causes scrolling
-        '<div style="position: absolute; height: 0; width: 0; overflow: hidden;"></div>' +
+        '<div class="CodeMirror-measure" style="position: absolute; height: 0; width: 0; overflow: hidden;"></div>' +
         '<div style="position: relative">' + // Moved around its parent to cover visible view
           '<div class="CodeMirror-gutter"><div class="CodeMirror-gutter-text"></div></div>' +
           '<div style="overflow: hidden; position: absolute; width: 0; left: 0">' + // Wraps and hides input textarea
-            '<textarea style="height: 1px; position: absolute; width: 1px;" wrap="off"></textarea></div>' +
+            '<textarea class="CodeMirror-input" style="height: 1px; position: absolute; width: 1px;" wrap="off"></textarea></div>' +
           // Provides positioning relative to (visible) text origin
           '<div class="CodeMirror-lines"><div style="position: relative">' +
             '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor


### PR DESCRIPTION
Hi

I got a strange cursor moving when hidden textarea uses a font which is different from other CodeMirror block.
I set up a simple demo at http://aklaswad.com/codemirror-cursormove.html
(that file has a css line "textarea { font-family: sans-serif; }" for to be able to reproduce on every browser.)

On my google chrome (sorry i don't know if it's default behavior or not), textarea has styled to use non monospace font by User Agent Styles, and font-family specification in codemirror.css can't override this because the selector ".CodeMirror" is weaker than it.
I think same thing will occur when user uses some kind of clear fix css includes font-family specification for textarea element.

To workaround this issue, just use more detailed CSS selector for textarea and some other input helpers in CodeMirror block.
