### PR TITLE
Minor bug fix for python syntax file

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -99,6 +99,8 @@ CodeMirror.defineMode("python", function(conf) {
                 // TODO - Can you have imaginary longs?
                 intLiteral = true;
             }
+            // Zero by itself with no other piece of number.
+            if (stream.match(/^0(?![\dx])/i)) { intLiteral = true; }
             if (intLiteral) {
                 // Integer literals may be "long"
                 stream.eat(/L/i);


### PR DESCRIPTION
This patch fixes the python syntax file to prevent it from marking '0' as an invalid numeric literal. It continues to mark it as invalid if in the form '05' or '0x' without trailing hex characters etc.
