### PR TITLE
Enter-key disabled when ReadOnly is activated

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -304,6 +304,8 @@ var CodeMirror = (function() {
         if (!anyMod && code == 9 && handleTab(e.e.shiftKey)) return e.stop(); // tab
         if (mod && code == 90) {undo(); return e.stop();} // ctrl-z
         if (mod && ((e.e.shiftKey && code == 90) || code == 89)) {redo(); return e.stop();} // ctrl-shift-z, ctrl-y
+      }else{
+        if (code == 13) {e.stop();}
       }
 
       // Key id to use in the movementKeys map. We also pass it to


### PR DESCRIPTION
This patch should close the issue #78.

It was happening on Windows too.
