### PR TITLE
Various minor parser bugs noticed by the Closure compiler.

### DIFF
--- a/mode/haskell/haskell.js
+++ b/mode/haskell/haskell.js
@@ -114,7 +114,7 @@ CodeMirror.defineMode("haskell", function(cmCfg, modeCfg) {
     return function(source, setState) {
       var currNest = nest;
       while (!source.eol()) {
-        ch = source.next();
+        var ch = source.next();
         if (ch == '{' && source.eat('-')) {
           ++currNest;
         }

--- a/mode/rst/rst.js
+++ b/mode/rst/rst.js
@@ -193,7 +193,7 @@ CodeMirror.defineMode('rst', function(config, options) {
                         ch: orig,               // inline() has to know what to search for
                         wide: wide,             // are we looking for `ch` or `chch`
                         prev: null,             // terminator must not be preceeded with whitespace
-                        token: token,           // I don't want to recompute this all the time
+                        token: token            // I don't want to recompute this all the time
                     });
 
                     return token;

--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -24,7 +24,7 @@ CodeMirror.defineMode("stex", function(cmCfg, modeCfg)
     }
 
     function applyMostPowerful(state) {
-      context = state.cmdState;
+      var context = state.cmdState;
       for (var i = context.length - 1; i >= 0; i--) {
 	  var plug = context[i];
 	  if (plug.name=="DEFAULT")
@@ -83,7 +83,7 @@ CodeMirror.defineMode("stex", function(cmCfg, modeCfg)
 
     function normal(source, state) {
 	if (source.match(/^\\[a-z]+/)) {
-	    cmdName = source.current();
+	    var cmdName = source.current();
 	    cmdName = cmdName.substr(1, cmdName.length-1);
 	    var plug = plugins[cmdName];
 	    if (typeof(plug) == 'undefined') {
@@ -133,8 +133,8 @@ CodeMirror.defineMode("stex", function(cmCfg, modeCfg)
     function beginParams(source, state) {
 	var ch = source.peek();
 	if (ch == '{' || ch == '[') {
-	   lastPlug = peekCommand(state);
-	   style = lastPlug.openBracket(ch);
+	   var lastPlug = peekCommand(state);
+	   var style = lastPlug.openBracket(ch);
 	   source.eat(ch);
 	   setState(state, normal);
 	   return "stex-bracket";


### PR DESCRIPTION
- Trailing commas in object literals are not allowed by the spec and are handled poorly in some browsers.
- Added var to some variable declarations that were not meant to be globals.
