### PR TITLE
css-mode bugfix

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -106,7 +106,7 @@ CodeMirror.defineMode("css", function(config) {
       }
       else if (type == "}") state.stack.pop();
       else if (type == "@media") state.stack.push("@media");
-      else if (context != "rule" && context != "@media" && type != "comment") state.stack.push("rule");
+      else if (context == "{") state.stack.push("rule");
       return style;
     },
 


### PR DESCRIPTION
Hi there

Tiny one-line fix for the css mode.
Multi-token selectors were being marked as css values, rather than selectors (visible [here](http://codemirror.net/mode/css/index.html) on the `#navigation a` and `h1:before, h2:before` lines)

Cheers for the great tool
