### PR TITLE
Assigning a Marker an Id

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -143,6 +143,7 @@ var CodeMirror = (function() {
       getSearchCursor: function(query, pos, caseFold) {return new SearchCursor(query, pos, caseFold);},
       markText: operation(function(a, b, c){return operation(markText(a, b, c));}),
       setMarker: addGutterMarker,
+	  setMarkerData: addGutterMarkerData,
       clearMarker: removeGutterMarker,
       setLineClass: operation(setLineClass),
       lineInfo: lineInfo,
@@ -799,7 +800,11 @@ var CodeMirror = (function() {
           text = marker.text.replace("%N%", text != null ? text : "");
         else if (text == null)
           text = "\u00a0";
-        html.push((marker && marker.style ? '<pre class="' + marker.style + '">' : "<pre>"), text, "</pre>");
+        if (marker && marker.id) {
+          html.push((marker && marker.style ? '<pre id="' + marker.id + '" class="' + marker.style + '">' : '<pre id="' + marker.id + '">'), text, "</pre>");
+        } else {
+          html.push((marker && marker.style ? '<pre class="' + marker.style + '">' : "<pre>"), text, "</pre>");
+        }
       }
       gutter.style.display = "none";
       gutterText.innerHTML = html.join("");
@@ -1005,12 +1010,17 @@ var CodeMirror = (function() {
       };
     }
 
-    function addGutterMarker(line, text, className) {
+	function addGutterMarker(line, text, className) {
+      return addGuggerMarkerData(line, {text: text, style: className})
+    }
+
+    function addGutterMarkerData(line, data) {
       if (typeof line == "number") line = lines[clipLine(line)];
-      line.gutterMarker = {text: text, style: className};
+      line.gutterMarker = data;
       updateGutter();
       return line;
     }
+    
     function removeGutterMarker(line) {
       if (typeof line == "number") line = lines[clipLine(line)];
       line.gutterMarker = null;


### PR DESCRIPTION
added an option to pass in the marker data as an object when adding a marker. The marker data may now hold an id (along with the text and className) which will be the id of the <pre> element that is used for the marker. This is useful for binding actions to the marker (e.g. onclick, onmouseover events, etc...)
