### PR TITLE
Added support for editor with fixed position

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1105,6 +1105,15 @@ var CodeMirror = (function() {
 
     function posFromMouse(e, liberal) {
       var offW = eltOffset(wrapper), x = e.pageX(), y = e.pageY();
+
+      // @ankit Support for editor with fixed position or with a parent with fixed position. E.g.: modal popups
+      // Adjusts the coordinates of click relative to window
+      //
+      if (isPositionFixed(wrapper)) {
+          x -= window.pageXOffset;
+          y -= window.pageYOffset;
+      }
+
       // This is a mess of a heuristic to try and determine whether a
       // scroll-bar was clicked or not, and to return null if one was
       // (and !liberal).
@@ -1877,6 +1886,7 @@ var CodeMirror = (function() {
     for (var n = node.parentNode; n != node.ownerDocument.body; n = n.parentNode) {x -= n.scrollLeft; y -= n.scrollTop;}
     return {left: x, top: y};
   }
+
   // Get a node's text content.
   function eltText(node) {
     return node.textContent || node.innerText || node.nodeValue || "";
@@ -1908,6 +1918,18 @@ var CodeMirror = (function() {
     for (var i = 0, e = collection.length; i < e; ++i)
       if (collection[i] == elt) return i;
     return -1;
+  }
+
+  // Returns true if an element or one of it's parent's position is fixed
+  // @ankit
+  function isPositionFixed(node) {
+      for (var n = node; n != node.ownerDocument.body; n = n.parentNode) {
+          var position = window.getComputedStyle(n, null).getPropertyValue('position');
+          if (position.indexOf('fixed') != -1)
+            return true;
+      }
+
+      return false;
   }
 
   // See if "".split is the broken IE version, if so, provide an


### PR DESCRIPTION
Fixed issue where if editor had a fixed position or had a parent with fixed position, the cursor was placed at the wrong position on clicks. Led to the editor becoming unresponsive.
