### PR TITLE
Pass 'keyup' event to onKeyEvent handler

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -324,6 +324,9 @@ var CodeMirror = (function() {
       fastPoll(curKeyId);
     }
     function onKeyUp(e) {
+      // Pass 'keyup' event to onKeyEvent handler
+      // @ankit
+      if (options.onKeyEvent && options.onKeyEvent(instance, addStop(e.e))) return;
       if (reducedSelection) {
         reducedSelection = null;
         updateInput = true;


### PR DESCRIPTION
Any particular reason you excluded 'keyup' and only included 'keydown' and 'keypress'?
