### PR TITLE
When readOnly is true, cursor should not be visible 

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -345,6 +345,7 @@ var CodeMirror = (function() {
     }
 
     function onFocus() {
+      if (options.readOnly) return;
       if (!focused && options.onFocus) options.onFocus(instance);
       focused = true;
       slowPoll();
@@ -353,6 +354,7 @@ var CodeMirror = (function() {
       restartBlink();
     }
     function onBlur() {
+      if (options.readOnly) return;
       if (focused && options.onBlur) options.onBlur(instance);
       clearInterval(blinker);
       shiftSelecting = null;


### PR DESCRIPTION
With readOnly set to true, CodeMirror should ignore the onFocus and onBlur events. Closes #97
