### PR TITLE
Plug-ins system for CodeMirror

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4,6 +4,9 @@
 
 // CodeMirror is the only global var we claim
 var CodeMirror = (function() {
+  // ================ Added by A.K. ====================
+  CodeMirror.modeExtenders = [];
+
   // This is the function that produces an editor instance. It's
   // closure is used to store the editor state.
   function CodeMirror(place, givenOptions) {
@@ -182,6 +185,16 @@ var CodeMirror = (function() {
       getInputField: function(){return input;},
       getWrapperElement: function(){return wrapper;}
     };
+    // ===================== Extended by A.K. ====================
+    if (typeof(givenOptions.pluginFunctions) !== "undefined"
+      && givenOptions.pluginFunctions != null)
+    {
+      for (var fName in givenOptions.pluginFunctions)
+      {
+        eval("instance." + fName + "=" + givenOptions.pluginFunctions[fName]);
+      }
+    }
+    // ===========================================================
 
     function setValue(code) {
       history = null;
@@ -1446,7 +1459,16 @@ var CodeMirror = (function() {
       if (window.console) console.warn("No mode " + mname + " found, falling back to plain text.");
       return CodeMirror.getMode(options, "text/plain");
     }
-    return mfactory(options, config || {});
+    //return mfactory(options, config || {});
+    // ======== Changed by A.K. ============================
+    //return mfactory(options, config);
+    var res = mfactory(options, config || {});
+    if (typeof(CodeMirror.modeExtenders[mname]) != "undefined")
+    { // Extend the mode
+      CodeMirror.modeExtenders[mname].call(res, options);
+    }
+    return res;
+    // =====================================================
   }
   CodeMirror.listModes = function() {
     var list = [];


### PR DESCRIPTION
Here are the changes discussed here:
http://groups.google.com/group/codemirror/browse_thread/thread/8f4a48cd1bc3f176

The changes make it possible to extend CodeMirror with new API functions which have access both to other API functions and to CodeMirror internal objects (like "sel", for example). Also, they allow adding new methods and properties to modes registered in the CodeMirror object (the modes are extended when retrieved via CodeMirror.getMode).

The three lines marked as removed and added in the middle of codemirror.js are not my changes - looks like a bug at github, because I only copy-pasted the source from your branch and inserted the three portions of new code.
