### PR TITLE
Drag & Drop fixes for firefox

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -266,11 +266,10 @@ var CodeMirror = (function() {
       lastDoubleClick = +new Date;
     }
     function onDrop(e) {
+      e.e.preventDefault();
       var pos = posFromMouse(e, true), files = e.e.dataTransfer.files;
       if (!pos || options.readOnly) return;
       if (files && files.length && window.FileReader && window.File) {
-        var n = files.length, text = Array(n), read = 0;
-        for (var i = 0; i < n; ++i) loadFile(files[i], i);
         function loadFile(file, i) {
           var reader = new FileReader;
           reader.onload = function() {
@@ -279,6 +278,8 @@ var CodeMirror = (function() {
           };
           reader.readAsText(file);
         }
+        var n = files.length, text = Array(n), read = 0;
+        for (var i = 0; i < n; ++i) loadFile(files[i], i);
       }
       else {
         try {


### PR DESCRIPTION
Drag & Drop never used to work on Firefox even though it had the FileReader API,
Turns out we have to prevent the default action of the event to get into our custom code.
Also, loadFile has to be declared before we can call it, otherwise we get a function not defined error.
