### PR TITLE
Added a fix to resolve "Microsoft Ajax Minifier" errors

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2031,8 +2031,9 @@ var CodeMirror = (function() {
 
   // See if "".split is the broken IE version, if so, provide an
   // alternative way to split lines.
+  var splitLines, selRange, setSelRange;
   if ("\n\nb".split(/\n/).length != 3)
-    var splitLines = function(string) {
+    splitLines = function(string) {
       var pos = 0, nl, result = [];
       while ((nl = string.indexOf("\n", pos)) > -1) {
         result.push(string.slice(pos, string.charAt(nl-1) == "\r" ? nl - 1 : nl));
@@ -2042,12 +2043,12 @@ var CodeMirror = (function() {
       return result;
     };
   else
-    var splitLines = function(string){return string.split(/\r?\n/);};
+    splitLines = function(string){return string.split(/\r?\n/);};
   CodeMirror.splitLines = splitLines;
 
   // Sane model of finding and setting the selection in a textarea
   if (window.getSelection) {
-    var selRange = function(te) {
+    selRange = function(te) {
       try {return {start: te.selectionStart, end: te.selectionEnd};}
       catch(e) {return null;}
     };
@@ -2058,7 +2059,7 @@ var CodeMirror = (function() {
       // the left. If you press shift-right, the anchor ends up at the
       // front. This is not what CodeMirror wants, so it does a
       // spurious modify() call to get out of limbo.
-      var setSelRange = function(te, start, end) {
+      setSelRange = function(te, start, end) {
         if (start == end)
           te.setSelectionRange(start, end);
         else {
@@ -2067,14 +2068,14 @@ var CodeMirror = (function() {
         }
       };
     else
-      var setSelRange = function(te, start, end) {
+      setSelRange = function(te, start, end) {
         try {te.setSelectionRange(start, end);}
         catch(e) {} // Fails on Firefox when textarea isn't part of the document
       };
   }
   // IE model. Don't ask.
   else {
-    var selRange = function(te) {
+    selRange = function(te) {
       try {var range = te.ownerDocument.selection.createRange();}
       catch(e) {return null;}
       if (!range || range.parentElement() != te) return null;
@@ -2096,7 +2097,7 @@ var CodeMirror = (function() {
       for (var i = val.indexOf("\r"); i > -1 && i < end; i = val.indexOf("\r", i+1), end++) {}
       return {start: start, end: end};
     };
-    var setSelRange = function(te, start, end) {
+    setSelRange = function(te, start, end) {
       var range = te.createTextRange();
       range.collapse(true);
       var endrange = range.duplicate();


### PR DESCRIPTION
Hi,

I have just started use this very nice project and I had faced the problem when I tried to minify "codemirror.js" by "Microsoft Ajax Minifier":

<pre><code>AjaxMin.exe codemirror.js -o codemirror.min.js
Microsoft Ajax Minifier - JavaScript and CSS minification and verification utility
Copyright 2010 Microsoft Corporation
Minifying file 'codemirror.js'...
codemirror.js(2045,9-19): run-time error JS1281: Ambiguous reference to named function ex
pression. Cross-browser behavior difference: splitLines
codemirror.js(2070,11-22): run-time error JS1281: Ambiguous reference to named function e
xpression. Cross-browser behavior difference: setSelRange
codemirror.js(2077,9-17): run-time error JS1281: Ambiguous reference to named function ex
pression. Cross-browser behavior difference: selRange
codemirror.js(2099,9-20): run-time error JS1281: Ambiguous reference to named function ex
pression. Cross-browser behavior difference: setSelRange
Original Size: 86367 bytes; reduced size: 36919 bytes (57.3% minification)
Gzip of output approximately 15346 bytes (58.4% compression)</code></pre>
