### PR TITLE
XML parser re-written

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -1,231 +1,421 @@
+/**
+ * xml.js
+ * 
+ * Building upon and improving the CodeMirror 2 XML parser
+ * @author: Dror BG (deebug.dev@gmail.com)
+ * @date: July, 2011
+ */
+
 CodeMirror.defineMode("xml", function(config, parserConfig) {
-  var indentUnit = config.indentUnit;
-  var Kludges = parserConfig.htmlMode ? {
-    autoSelfClosers: {"br": true, "img": true, "hr": true, "link": true, "input": true,
-                      "meta": true, "col": true, "frame": true, "base": true, "area": true},
-    doNotIndent: {"pre": true, "!cdata": true},
-    allowUnquoted: true
-  } : {autoSelfClosers: {}, doNotIndent: {"!cdata": true}, allowUnquoted: false};
-  var alignCDATA = parserConfig.alignCDATA;
-
-  // Return variables for tokenizers
-  var tagName, type;
-
-  function inText(stream, state) {
-    function chain(parser) {
-      state.tokenize = parser;
-      return parser(stream, state);
-    }
-
-    var ch = stream.next();
-    if (ch == "<") {
-      if (stream.eat("!")) {
-        if (stream.eat("[")) {
-          if (stream.match("CDATA[")) return chain(inBlock("atom", "]]>"));
-          else return null;
-        }
-        else if (stream.match("--")) return chain(inBlock("comment", "-->"));
-        else if (stream.match("DOCTYPE", true, true)) {
-          stream.eatWhile(/[\w\._\-]/);
-          return chain(inBlock("meta", ">"));
-        }
-        else return null;
-      }
-      else if (stream.eat("?")) {
-        stream.eatWhile(/[\w\._\-]/);
-        state.tokenize = inBlock("meta", "?>");
-        return "meta";
-      }
-      else {
-        type = stream.eat("/") ? "closeTag" : "openTag";
-        stream.eatSpace();
-        tagName = "";
-        var c;
-        while ((c = stream.eat(/[^\s\u00a0=<>\"\'\/?]/))) tagName += c;
-        state.tokenize = inTag;
-        return "tag";
-      }
-    }
-    else if (ch == "&") {
-      stream.eatWhile(/[^;]/);
-      stream.eat(";");
-      return "atom";
-    }
-    else {
-      stream.eatWhile(/[^&<]/);
-      return null;
-    }
-  }
-
-  function inTag(stream, state) {
-    var ch = stream.next();
-    if (ch == ">" || (ch == "/" && stream.eat(">"))) {
-      state.tokenize = inText;
-      type = ch == ">" ? "endTag" : "selfcloseTag";
-      return "tag";
-    }
-    else if (ch == "=") {
-      type = "equals";
-      return null;
-    }
-    else if (/[\'\"]/.test(ch)) {
-      state.tokenize = inAttribute(ch);
-      return state.tokenize(stream, state);
-    }
-    else {
-      stream.eatWhile(/[^\s\u00a0=<>\"\'\/?]/);
-      return "word";
-    }
-  }
-
-  function inAttribute(quote) {
-    return function(stream, state) {
-      while (!stream.eol()) {
-        if (stream.next() == quote) {
-          state.tokenize = inTag;
-          break;
-        }
-      }
-      return "string";
+    // constants
+    var STYLE_ERROR = "error";
+    var STYLE_DECLARATION = "comment";
+    var STYLE_COMMENT = "comment";
+    var STYLE_ELEMENT_NAME = "tag";
+    var STYLE_ATTRIBUTE = "attribute";
+    var STYLE_WORD = "string";
+    var STYLE_TEXT = "atom";
+    
+    var TAG_CDATA = "!cdata";
+    var TAG_COMMENT = "!comment";
+    var TAG_TEXT = "!text";
+    
+    var doNotIndent = {
+        "!cdata": true,
+        "!comment": true,
+        "!text": true
     };
-  }
 
-  function inBlock(style, terminator) {
-    return function(stream, state) {
-      while (!stream.eol()) {
-        if (stream.match(terminator)) {
-          state.tokenize = inText;
-          break;
+    // options
+    var indentUnit = config.indentUnit;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // helper functions
+    
+    // chain a parser to another parser
+    function chain(stream, state, parser) {
+        state.tokenize = parser;
+        return parser(stream, state);
+    }
+    
+    // parse a block (comment, CDATA or text)
+    function inBlock(style, terminator, nextTokenize) {
+        return function(stream, state) {
+            while (!stream.eol()) {
+                if (stream.match(terminator)) {
+                    popContext(state);
+                    state.tokenize = nextTokenize;
+                    break;
+                }
+                stream.next();
+            }
+            return style;
+        };
+    }
+    
+    // go down a level in the document
+    // (hint: look at who calls this function to know what the contexts are)
+    function pushContext(state, tagName) {
+        var noIndent = doNotIndent.hasOwnProperty(tagName) || (state.context && state.context.doIndent);
+        var newContext = {
+            tagName: tagName,
+            prev: state.context,
+            indent: state.context ? state.context.indent + indentUnit : 0,
+            lineNumber: state.lineNumber,
+            indented: state.indented,
+            noIndent: noIndent
+        };
+        state.context = newContext;
+    }
+    
+    // go up a level in the document
+    function popContext(state) {
+        if (state.context) {
+            var oldContext = state.context;
+            state.context = oldContext.prev;
+            return oldContext;
         }
-        stream.next();
-      }
-      return style;
-    };
-  }
-
-  var curState, setStyle;
-  function pass() {
-    for (var i = arguments.length - 1; i >= 0; i--) curState.cc.push(arguments[i]);
-  }
-  function cont() {
-    pass.apply(null, arguments);
-    return true;
-  }
-
-  function pushContext(tagName, startOfLine) {
-    var noIndent = Kludges.doNotIndent.hasOwnProperty(tagName) || (curState.context && curState.context.noIndent);
-    curState.context = {
-      prev: curState.context,
-      tagName: tagName,
-      indent: curState.indented,
-      startOfLine: startOfLine,
-      noIndent: noIndent
-    };
-  }
-  function popContext() {
-    if (curState.context) curState.context = curState.context.prev;
-  }
-
-  function element(type) {
-    if (type == "openTag") {curState.tagName = tagName; return cont(attributes, endtag(curState.startOfLine));}
-    else if (type == "closeTag") {
-      var err = false;
-      if (curState.context) {
-        err = curState.context.tagName != tagName;
-        popContext();
-      } else {
-        err = true;
-      }
-      if (err) setStyle = "error";
-      return cont(endclosetag(err));
+        
+        // we shouldn't be here - it means we didn't have a context to pop
+        return null;
     }
-    else if (type == "string") {
-      if (!curState.context || curState.context.name != "!cdata") pushContext("!cdata");
-      if (curState.tokenize == inText) popContext();
-      return cont();
-    }
-    else return cont();
-  }
-  function endtag(startOfLine) {
-    return function(type) {
-      if (type == "selfcloseTag" ||
-          (type == "endTag" && Kludges.autoSelfClosers.hasOwnProperty(curState.tagName.toLowerCase())))
-        return cont();
-      if (type == "endTag") {pushContext(curState.tagName, startOfLine); return cont();}
-      return cont();
-    };
-  }
-  function endclosetag(err) {
-    return function(type) {
-      if (err) setStyle = "error";
-      if (type == "endTag") return cont();
-      return pass();
-    }
-  }
-
-  function attributes(type) {
-    if (type == "word") {setStyle = "attribute"; return cont(attributes);}
-    if (type == "equals") return cont(attvalue, attributes);
-    return pass();
-  }
-  function attvalue(type) {
-    if (type == "word" && Kludges.allowUnquoted) {setStyle = "string"; return cont();}
-    if (type == "string") return cont(attvaluemaybe);
-    return pass();
-  }
-  function attvaluemaybe(type) {
-    if (type == "string") return cont(attvaluemaybe);
-    else return pass();
-  }
-
-  return {
-    startState: function() {
-      return {tokenize: inText, cc: [], indented: 0, startOfLine: true, tagName: null, context: null};
-    },
-
-    token: function(stream, state) {
-      if (stream.sol()) {
-        state.startOfLine = true;
-        state.indented = stream.indentation();
-      }
-      if (stream.eatSpace()) return null;
-
-      setStyle = type = tagName = null;
-      var style = state.tokenize(stream, state);
-      if ((style || type) && style != "comment") {
-        curState = state;
-        while (true) {
-          var comb = state.cc.pop() || element;
-          if (comb(type || style)) break;
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // context: document
+    // 
+    // an XML document can contain:
+    // - a single declaration (if defined, it must be the very first line)
+    // - exactly one root element
+    // @todo try to actually limit the number of root elements to 1
+    // - zero or more comments
+    function parseDocument(stream, state) {
+        if(stream.eat("<")) {
+            if(stream.match("?xml")) {
+                // declaration
+                state.tokenize = parseDeclarationVersion;
+                if(state.lineNumber > 1 ||
+                    stream.pos > 5 ||
+                    (!stream.eol() && !stream.eatSpace())) {
+                    return STYLE_ERROR;
+                } else {
+                    return STYLE_DECLARATION;
+                }
+            } else if(stream.match("!--")) {
+                // new context: comment
+                pushContext(state, TAG_COMMENT);
+                return chain(stream, state, inBlock(STYLE_COMMENT, "-->", parseDocument));
+            } else {
+                // element
+                state.tokenize = parseElementTagName;
+                return STYLE_ELEMENT_NAME;
+            }
         }
-      }
-      state.startOfLine = false;
-      return setStyle || style;
-    },
+        
+        // error on line
+        stream.skipToEnd();
+        return STYLE_ERROR;
+    }
 
-    indent: function(state, textAfter) {
-      var context = state.context;
-      if (context && context.noIndent) return 0;
-      if (alignCDATA && /<!\[CDATA\[/.test(textAfter)) return 0;
-      if (context && /^<\//.test(textAfter))
-        context = context.prev;
-      while (context && !context.startOfLine)
-        context = context.prev;
-      if (context) return context.indent + indentUnit;
-      else return 0;
-    },
+    ///////////////////////////////////////////////////////////////////////////
+    // context: XML element start-tag or end-tag
+    //
+    // - element start-tag can contain attributes
+    // - element start-tag may self-close (or start an element block if it doesn't)
+    // - element end-tag can contain only the tag name
+    function parseElementTagName(stream, state) {
+        // get the name of the tag
+        var startPos = stream.pos;
+        if(stream.match(/^[a-zA-Z_:][-a-zA-Z0-9_:.]*/)) {
+            // element start-tag
+            var tagName = stream.string.substring(startPos, stream.pos);
+            pushContext(state, tagName);
+            state.tokenize = parseElement;
+            return STYLE_ELEMENT_NAME;
+        } else if(stream.match(/^\/[a-zA-Z_:][-a-zA-Z0-9_:.]*( )*>/)) {
+            // element end-tag
+            var endTagName = stream.string.substring(startPos + 1, stream.pos - 1).trim();
+            var oldContext = popContext(state);
+            state.tokenize = state.context == null ? parseDocument : parseElementBlock;
+            if(oldContext == null || endTagName != oldContext.tagName) {
+                // the start and end tag names should match - error
+                return STYLE_ERROR;
+            }
+            return STYLE_ELEMENT_NAME;
+        } else {
+            // no tag name - error
+            state.tokenize = state.context == null ? parseDocument : parseElementBlock;
+            stream.eatWhile(/[^>]/);
+            stream.eat(">");
+            return STYLE_ERROR;
+        }
+        
+        stream.skipToEnd();
+        return null;
+    }
+    
+    function parseElement(stream, state) {
+        if(stream.match(/^\/>/)) {
+            // self-closing tag
+            popContext(state);
+            state.tokenize = state.context == null ? parseDocument : parseElementBlock;
+            return STYLE_ELEMENT_NAME;
+        } else if(stream.eat(/^>/)) {
+            state.tokenize = parseElementBlock;
+            return STYLE_ELEMENT_NAME;
+        } else if(stream.match(/^[a-zA-Z_:][-a-zA-Z0-9_:.]*( )*=/)) {
+            // attribute
+            state.tokenize = parseAttribute;
+            return STYLE_ATTRIBUTE;
+        }
+        
+        // no other options - this is an error
+        state.tokenize = state.context == null ? parseDocument : parseDocument;
+        stream.eatWhile(/[^>]/);
+        stream.eat(">");
+        return STYLE_ERROR;
+    }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // context: attribute
+    // 
+    // attribute values may contain everything, except:
+    // - the ending quote (with ' or ") - this marks the end of the value
+    // - the character "<" - should never appear
+    // - ampersand ("&") - unless it starts a reference: a string that ends with a semi-colon (";")
+    // ---> note: this parser is lax in what may be put into a reference string,
+    // ---> consult http://www.w3.org/TR/REC-xml/#NT-Reference if you want to make it tighter
+    function parseAttribute(stream, state) {
+        var quote = stream.next();
+        if(quote != "\"" && quote != "'") {
+            // attribute must be quoted
+            stream.skipToEnd();
+            state.tokenize = parseElement;
+            return STYLE_ERROR;
+        }
+        
+        state.tokParams.quote = quote;    
+        state.tokenize = parseAttributeValue;
+        return STYLE_WORD;
+    }
 
-    compareStates: function(a, b) {
-      if (a.indented != b.indented || a.tagName != b.tagName) return false;
-      for (var ca = a.context, cb = b.context; ; ca = ca.prev, cb = cb.prev) {
-        if (!ca || !cb) return ca == cb;
-        if (ca.tagName != cb.tagName) return false;
-      }
-    },
+    // @todo: find out whether this attribute value spans multiple lines,
+    //        and if so, push a context for it in order not to indent it
+    //        (or something of the sort..)
+    function parseAttributeValue(stream, state) {
+        var ch = "";
+        while(!stream.eol()) {
+            ch = stream.next();
+            if(ch == state.tokParams.quote) {
+                // end quote found
+                state.tokenize = parseElement;
+                return STYLE_WORD;
+            } else if(ch == "<") {
+                // can't have less-than signs in an attribute value, ever
+                stream.skipToEnd()
+                state.tokenize = parseElement;
+                return STYLE_ERROR;
+            } else if(ch == "&") {
+                // reference - look for a semi-colon, or return error if none found
+                ch = stream.next();
+                
+                // make sure that semi-colon isn't right after the ampersand
+                if(ch == ';') {
+                    stream.skipToEnd()
+                    state.tokenize = parseElement;
+                    return STYLE_ERROR;
+                }
+                
+                // make sure no less-than characters slipped in
+                while(!stream.eol() && ch != ";") {
+                    if(ch == "<") {
+                        // can't have less-than signs in an attribute value, ever
+                        stream.skipToEnd()
+                        state.tokenize = parseElement;
+                        return STYLE_ERROR;
+                    }
+                    ch = stream.next();
+                }
+                if(stream.eol() && ch != ";") {
+                    // no ampersand found - error
+                    stream.skipToEnd();
+                    state.tokenize = parseElement;
+                    return STYLE_ERROR;
+                }                
+            }
+        }
+        
+        // attribute value continues to next line
+        return STYLE_WORD;
+    }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // context: element block
+    //
+    // a block can contain:
+    // - elements
+    // - text
+    // - CDATA sections
+    // - comments
+    function parseElementBlock(stream, state) {
+        if(stream.eat("<")) {
+            if(stream.match("!--")) {
+                // new context: comment
+                pushContext(state, TAG_COMMENT);
+                return chain(stream, state, inBlock(STYLE_COMMENT, "-->",
+                    state.context == null ? parseDocument : parseElementBlock));
+            } else if(stream.match("![CDATA[")) {
+                // new context: CDATA section
+                pushContext(state, TAG_CDATA);
+                return chain(stream, state, inBlock(STYLE_TEXT, "]]>",
+                    state.context == null ? parseDocument : parseElementBlock));
+            } else {
+                // element
+                state.tokenize = parseElementTagName;
+                return STYLE_ELEMENT_NAME;
+            }
+        } else {
+            // new context: text
+            pushContext(state, TAG_TEXT);
+            state.tokenize = parseText;
+            return null;
+        }
+        
+        state.tokenize = state.context == null ? parseDocument : parseElementBlock;
+        stream.skipToEnd();
+        return null;
+    }
+    
+    function parseText(stream, state) {
+        stream.eatWhile(/[^<]/);
+        if(!stream.eol()) {
+            // we cannot possibly be in the document context,
+            // just inside an element block
+            popContext(state);
+            state.tokenize = parseElementBlock;
+        }
+        return STYLE_TEXT;
+    }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // context: XML declaration
+    //
+    // XML declaration is of the following format:
+    // <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+    // - must start at the first character of the first line
+    // - may span multiple lines
+    // - must include 'version'
+    // - may include 'encoding' and 'standalone' (in that order after 'version')
+    // - attribute names must be lowercase
+    // - cannot contain anything else on the line
+    function parseDeclarationVersion(stream, state) {
+        if(stream.match(/^version( )*=( )*"([a-zA-Z0-9_.:]|\-)+"/) && (stream.eol() || stream.eatSpace())) {
+            state.tokenize = parseDeclarationEncoding;
+            return STYLE_DECLARATION;
+        }
+        state.tokenize = parseDocument;
+        stream.skipToEnd();
+        return STYLE_ERROR;
+    }
 
-    electricChars: "/"
-  };
+    function parseDeclarationEncoding(stream, state) {
+        state.tokenize = parseDeclarationStandalone;
+        if(stream.match(/^encoding( )*=( )*"[A-Za-z]([A-Za-z0-9._]|\-)*"/)) {
+            if((stream.eol() || stream.eatSpace())) {
+                return STYLE_DECLARATION;
+            } else {
+                return STYLE_ERROR;
+            }
+        }
+        return null;
+    }
+
+    function parseDeclarationStandalone(stream, state) {
+        state.tokenize = parseDeclarationEndTag;
+        if(stream.match(/^standalone( )*=( )*"(yes|no)"/)) {
+            if((stream.eol() || stream.eatSpace())) {
+                return STYLE_DECLARATION;
+            } else {
+                return STYLE_ERROR;
+            }
+        }
+        return null;
+    }
+
+    function parseDeclarationEndTag(stream, state) {
+        state.tokenize = parseDocument;
+        if(stream.match("?>") && stream.eol()) {
+            return STYLE_DECLARATION;
+        }
+        return STYLE_ERROR;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // returned object
+    return {
+        electricChars: "/",
+        
+        startState: function() {
+            return {
+                tokenize: parseDocument,
+                tokParams: {},
+                lineNumber: 0,
+                lineError: false,
+                context: null,
+                indented: 0
+            };
+        },
+
+        token: function(stream, state) {
+            if(stream.sol()) {
+                // initialize a new line
+                state.lineNumber++;
+                state.lineError = false;
+                state.indented = stream.indentation();
+            }
+
+            // eat all (the spaces) you can
+            if(stream.eatSpace()) return null;
+
+            // run the current tokenize function, according to the state
+            var style = state.tokenize(stream, state);
+            
+            // is there an error somewhere in the line?
+            state.lineError = (state.lineError || style == "error");
+
+            return style;
+        },
+        
+        blankLine: function(state) {
+            // blank lines are lines too!
+            state.lineNumber++;
+            state.lineError = false;
+        },
+        
+        indent: function(state, textAfter) {
+            if(state.context) {
+                if(state.context.noIndent == true) {
+                    // do not indent - no return value at all
+                    return;
+                }
+                if(textAfter.match(/<\/.*/)) {
+                    // eng-tag - indent back to last context
+                    return state.context.indent;
+                }
+                // indent to last context + regular indent unit
+                return state.context.indent + indentUnit;
+            }
+            return 0;
+        },
+        
+        compareStates: function(a, b) {
+            if (a.indented != b.indented) return false;
+            for (var ca = a.context, cb = b.context; ; ca = ca.prev, cb = cb.prev) {
+                if (!ca || !cb) return ca == cb;
+                if (ca.tagName != cb.tagName) return false;
+            }
+        }
+    };
 });
 
 CodeMirror.defineMIME("application/xml", "xml");
-CodeMirror.defineMIME("text/html", {name: "xml", htmlMode: true});
+CodeMirror.defineMIME("text/xml", "xml");


### PR DESCRIPTION
Re-write of the original CM2 XML parser to provide a more extensive (albeit not full) support for XML constructs:
- More error detection capabilities
- XML declaration parsing
- Illegal attributes and element names
- Blocks (text, CDATA and comments) fully supported
- Indentation / non-indentation mechanism
- Line number in the state object

Todo stuff:
- Make sure only a single root element exists at the document level
- Multi-line attributes should NOT indent
