### PR TITLE
Minor python mode style fix

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -171,7 +171,7 @@ CodeMirror.defineMode("python", function(conf) {
             }
             if (singleline) {
                 if (conf.mode.singleLineStringErrors) {
-                    OUTCLASS = ERRORCLASS
+                    return ERRORCLASS;
                 } else {
                     state.tokenize = tokenBase;
                 }


### PR DESCRIPTION
This fixes some minor style in returning the token value, and avoids redefining the constant OUTCLASS variable.
