### PR TITLE
More scheme mode fixes

### DIFF
--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -33,7 +33,7 @@ CodeMirror.defineMode("scheme", function (config, mode) {
     /**
      * Scheme numbers are complicated unfortunately.
      * Checks if we're looking at a number, which might be possibly a fraction.
-     * Also checks that it is not part of a longer procedure name. Returns true/false accordingly.
+     * Also checks that it is not part of a longer identifier. Returns true/false accordingly.
      */
     function isNumber(ch, stream){ 
         if(/[0-9]/.exec(ch) != null){ 


### PR DESCRIPTION
Further fixed scheme numbers (hopefully definitively). 

Previous version was a bit sloppy and highlighted fractions like 3/4/5 (not actually supported), and also the "3" in identifiers like 3x+1.
