### PR TITLE
Edited lib/codemirror.js via GitHub

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -22,7 +22,7 @@ var CodeMirror = (function() {
       '<div style="overflow: hidden; position: relative; width: 1px; height: 0px;">' + // Wraps and hides input textarea
         '<textarea style="position: absolute; width: 2px;" wrap="off"></textarea></div>' +
       '<div class="CodeMirror-scroll cm-s-' + options.theme + '">' +
-        '<div style="position: relative">' + // Set to the height of the text, causes scrolling
+        '<div class="CodeMirror-scroll-inner" style="position: relative">' + // Set to the height of the text, causes scrolling
           '<div style="position: absolute; height: 0; width: 0; overflow: hidden;"></div>' +
           '<div style="position: relative">' + // Moved around its parent to cover visible view
             '<div class="CodeMirror-gutter"><div class="CodeMirror-gutter-text"></div></div>' +


### PR DESCRIPTION
Hi,

I've looking at CodeMirror2 for a project and I've found it to be excellent! It makes editing HTML markup in browsers so much easier. Thanks for the great product. 

I ran into an issue that was reported earlier:

http://groups.google.com/group/codemirror/browse_thread/thread/872a07b1fa744b42/7a04f6e7b8f54694

In trying the fix (to set the width explictly) reported by the original submitter of the above issue, I encountered another one: I couldn't find an event that I can listen to that'll tell me when the CodeMirror DOM nodes have been setup. Is there one that I might have missed?

While I suppose supporting an "onLoad" option that accepts a callback that will be called after the CodeMirror object has been created might be a better solution, I'm submitting the following pull request for consideration that adds a class to the relevant DOM node that allows one to set the width via CSS. 

Thank you.
