### PR TITLE
Lua indentation fix for CodeMirror2

### DIFF
--- a/mode/lua/lua.js
+++ b/mode/lua/lua.js
@@ -123,8 +123,10 @@ CodeMirror.defineMode("lua", function(config, parserConfig) {
         else if (builtins.test(word)) style = "builtin";
 	else if (specials.test(word)) style = "variable-2";
       }
-      if (indentTokens.test(word)) ++state.indentDepth;
-      else if (dedentTokens.test(word)) --state.indentDepth;
+      if ((style != "lua-comment") && (style != "lua-string")){
+        if (indentTokens.test(word)) ++state.indentDepth;
+        else if (dedentTokens.test(word)) --state.indentDepth;
+      }
       return style;
     },
 


### PR DESCRIPTION
fsw already did the pull request for the fix in CodeMirror 1: https://github.com/marijnh/CodeMirror/pull/56 .  This is the corresponding fix for CodeMirror2.

Indentation bug fix related to multi-line comments and multi-line strings.  Previously if a multi-line comment or string contained the word 'end', it would throw off the indentation level for all following code.
