### PR TITLE
make preview example work in IE 7/8

### DIFF
--- a/demo/preview.html
+++ b/demo/preview.html
@@ -36,6 +36,7 @@
     <meta charset=utf-8>
   </head>
   <body>
+   <p>Canvas pane goes here:</p>
     <canvas id=tutorial width=250 height=250></canvas>
     <script>
       var canvas = document.getElementById('tutorial');
@@ -65,21 +66,9 @@
       
       function updatePreview() {
         var previewFrame = document.getElementById('preview');
-        var preview = null;
-        if (previewFrame.contentWindow){ //Firefox, Opera
-            preview = previewFrame.contentWindow.document;
-        }
-        else if (previewFrame.contentDocument) { //IE
-            preview = previewFrame.contentDocument;
-        }
-        else if (previewFrame.document){ //others?
-            preview = previewFrame.document;
-        }
-        else {
-            throw ("Couldn't initialize preview frame");
-        }
+        var preview =  previewFrame.contentDocument ||  previewFrame.contentWindow.document;
         preview.open();
-        preview.write(editor2.getValue());
+        preview.write(editor.getValue());
         preview.close();
       }
       setTimeout(updatePreview, 300);


### PR DESCRIPTION
The preview example didn't work in IE due to a different IFrame API (contentWindow.document instead of contentDocument). Fixed this and also added some generic iframe detection.
