### PR TITLE
Fix python string literal quitting on first quote / double quote

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -150,7 +150,6 @@ CodeMirror.defineMode("python", function(conf, parserConf) {
         while ('rub'.indexOf(delimiter.charAt(0).toLowerCase()) >= 0) {
             delimiter = delimiter.substr(1);
         }
-        var delim_re = new RegExp(delimiter);
         var singleline = delimiter.length == 1;
         var OUTCLASS = 'string';
         
@@ -162,7 +161,7 @@ CodeMirror.defineMode("python", function(conf, parserConf) {
                     if (singleline && stream.eol()) {
                         return OUTCLASS;
                     }
-                } else if (stream.match(delim_re)) {
+                } else if (stream.match(delimiter)) {
                     state.tokenize = tokenBase;
                     return OUTCLASS;
                 } else {


### PR DESCRIPTION
Consider we're parsing:
"""It's wrong"""

We entered string parsing, delimiter is """
Stream left to consume
It's wrong"""

We eat all non quotes and then quote arrives.

If we use """ regexp then we surely get match at the end of line.

But if we use """ string match then we get exactly what we want.
