### PR TITLE
Add a option for checking update by polling, for the IME user.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -13,6 +13,8 @@ var CodeMirror = (function() {
       if (defaults.hasOwnProperty(opt))
         options[opt] = (givenOptions && givenOptions.hasOwnProperty(opt) ? givenOptions : defaults)[opt];
 
+    var forcePollingIntervalId = null;
+
     var targetDocument = options["document"];
     // The element in which the editor lives.
     var wrapper = targetDocument.createElement("div");
@@ -425,6 +427,16 @@ var CodeMirror = (function() {
       // Don't save the key as a movementkey unless it had a modifier
       if (!mod && !e.altKey) curKeyId = null;
       fastPoll(curKeyId);
+
+      if (options.forcePolling) {
+        var last_value = input.value;
+        forcePollingIntervalId = setInterval(function() {
+          if (last_value != input.value) {
+            last_value = input.value;
+            fastPoll(null);
+          }
+        }, 10);
+      }
     }
     function onKeyUp(e) {
       if (options.onKeyEvent && options.onKeyEvent(instance, addStop(e))) return;
@@ -433,6 +445,11 @@ var CodeMirror = (function() {
         updateInput = true;
       }
       if (e.keyCode == 16) shiftSelecting = null;
+
+      if (forcePollingIntervalId) {
+        clearInterval(forcePollingIntervalId);
+        forcePollingIntervalId = null;
+      }
     }
     function onKeyPress(e) {
       if (options.onKeyEvent && options.onKeyEvent(instance, addStop(e))) return;
@@ -1605,6 +1622,11 @@ var CodeMirror = (function() {
     return instance;
   } // (end of function CodeMirror)
 
+  var gecko = /gecko\/\d{7}/i.test(navigator.userAgent);
+  var opera = /Opera/.test(navigator.userAgent);
+  var ie = /MSIE \d/.test(navigator.userAgent);
+  var safari = /Apple Computer/.test(navigator.vendor);
+
   // The default configuration options.
   CodeMirror.defaults = {
     value: "",
@@ -1632,6 +1654,7 @@ var CodeMirror = (function() {
     workDelay: 200,
     undoDepth: 40,
     tabindex: null,
+    forcePolling: (gecko || opera),
     document: window.document
   };
 
@@ -2058,10 +2081,6 @@ var CodeMirror = (function() {
     var div = document.createElement('div');
     return "ondragstart" in div && "ondrop" in div;
   })();
-
-  var gecko = /gecko\/\d{7}/i.test(navigator.userAgent);
-  var ie = /MSIE \d/.test(navigator.userAgent);
-  var safari = /Apple Computer/.test(navigator.vendor);
 
   var lineSep = "\n";
   // Feature-detect whether newlines in textareas are converted to \r\n


### PR DESCRIPTION
Hello,

The users who use multi byte character, need to use the IME for input. However, when using IME, the CodeMirror2 does not work correctly in the Firefox and the Opera.

When useing IME, these browsers won't trigger "keypress" and "keydown" event for the 2nd keystroke or later. therefore, the inputted characters are not immediately reflected to the editor.

And when useing IME, the method of detecting update is only polling.  

Thus, the user who use IME, needs the option to check for updates, and reflect.

It may be better that the default value of the "forcePolling" is "false" for the users who does not use IME.

IME: http://en.wikipedia.org/wiki/Input_method_editor
