### PR TITLE
Add position to runmode callback.

### DIFF
--- a/lib/runmode.js
+++ b/lib/runmode.js
@@ -18,7 +18,7 @@ CodeMirror.runMode = function(string, modespec, callback) {
     var stream = new CodeMirror.StringStream(lines[i]);
     while (!stream.eol()) {
       var style = mode.token(stream, state);
-      callback(stream.current(), style);
+      callback(stream.current(), style, {line: i, ch: stream.start});
       stream.start = stream.pos;
     }
   }


### PR DESCRIPTION
The callback in runmode currently returns for every token
only the text and the style. This commit adds the position,
the line and the character, to the callback. It's an object
with "line" and "ch" as properties.

With this commit you can easily add markers to the code (e.g. for errors) that need the parsing of the full source.
