### PR TITLE
Add lineClass to lineInfo.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1336,7 +1336,7 @@ var CodeMirror = (function() {
         if (n == null) return null;
       }
       var marker = line.gutterMarker;
-      return {line: n, text: line.text, markerText: marker && marker.text, markerClass: marker && marker.style};
+      return {line: n, text: line.text, markerText: marker && marker.text, markerClass: marker && marker.style, lineClass: line.className};
     }
 
     function stringWidth(str) {


### PR DESCRIPTION
The setLineClass() function can set a class to a line, but
there's not way to get the current class of a line. This
commit adds the information to the lineInfo function as a
new property called "lineClass".
