### PR TITLE
Take the replacement text from the original completions as any whitespace

### DIFF
--- a/lib/util/simple-hint.js
+++ b/lib/util/simple-hint.js
@@ -53,7 +53,7 @@
       complete.parentNode.removeChild(complete);
     }
     function pick() {
-      insert(sel.options[sel.selectedIndex].text);
+      insert(completions[sel.selectedIndex].text);
       close();
       setTimeout(function(){editor.focus();}, 50);
     }


### PR DESCRIPTION
As the title states, this is useful for when completions may include spaces (for instance if the completion includes multiple words).
