### PR TITLE
Use absolute positioning for the autocompletion select box

### DIFF
--- a/lib/util/simple-hint.js
+++ b/lib/util/simple-hint.js
@@ -41,6 +41,7 @@
     var pos = editor.cursorCoords();
     complete.style.left = pos.x + "px";
     complete.style.top = pos.yBot + "px";
+    complete.style.position = "absolute";
     document.body.appendChild(complete);
     // Hack to hide the scrollbar.
     if (completions.length <= 10)


### PR DESCRIPTION
This fixes an issue I had with fitting autocompletion into my page where the autocompletion box would be relative to an element other than the editor, and meant that it was in completely the wrong place.
