### PR TITLE
Improve support for Smalltalk

### DIFF
--- a/mode/smalltalk/smalltalk.js
+++ b/mode/smalltalk/smalltalk.js
@@ -23,6 +23,16 @@ CodeMirror.defineMode("smalltalk", function(config, parserConfig) {
       stream.eatWhile(/[\w\$_]/);
       return ret("string", "string");
     }
+    else if (ch == '$') {
+      if (stream.next() == "<") {
+        stream.eatWhile(/\d/);
+        stream.eat(/\>/);
+      }
+      return ret("string", "string");
+    }
+    else if (ch == "^" || (ch == ":" && stream.eat("="))) {
+      return ret("operator", "operator");
+    }
     else if (/\d/.test(ch)) {
       stream.eatWhile(/[\w\.]/)
       return ret("number", "number");


### PR DESCRIPTION
Patch adds support for:
- character constant syntax: `$x`
- return expression: `^variable`
- assign expression: `var := 1`
