### PR TITLE
Fix eltOffset using getBoundingClientRect when the page has been scrolled

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2546,9 +2546,16 @@ var CodeMirror = (function() {
   }
   // Use the faster and saner getBoundingClientRect method when possible.
   if (document.documentElement.getBoundingClientRect != null) eltOffset = function(node, screen) {
-    try { var box = node.getBoundingClientRect(); }
-    catch(e) { var box = {top: 0, left: 0}; }
-    if (!screen) { box.top += document.body.scrollTop; box.left += document.body.scrollLeft; }
+	var t, box;
+    // Take the parts of bounding client rect that we are interested in so we are able to edit if need be,
+	// since the returned value cannot be changed externally (they are kept in sync as the element moves within the page)
+    try { box = node.getBoundingClientRect(); box = { top: box.top, left: box.left }; }
+    catch(e) { box = {top: 0, left: 0}; }
+    if (!screen) {
+		//Get the amount scrolled in a method that works more reliably
+		box.top += window.pageYOffset || (((t = document.documentElement) || (t = document.body.parentNode)) && typeof t.scrollTop == 'number' ? t : document.body).scrollTop;
+		box.left += window.pageXOffset || (((t = document.documentElement) || (t = document.body.parentNode)) && typeof t.scrollLeft == 'number' ? t : document.body).scrollLeft;
+	}
     return box;
   };
 


### PR DESCRIPTION
This fixes the auto completion demo when we have scrolled the page.
