### PR TITLE
Define and use an arrayContains function.

### DIFF
--- a/lib/util/javascript-hint.js
+++ b/lib/util/javascript-hint.js
@@ -2,7 +2,20 @@
   function forEach(arr, f) {
     for (var i = 0, e = arr.length; i < e; ++i) f(arr[i]);
   }
-
+  
+  function arrayContains(arr, item) {
+    if (!Array.prototype.indexOf) {
+      var i = arr.length;
+      while (i--) {
+        if (arr[i] === item) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return arr.indexOf(item) != -1;
+  }
+  
   CodeMirror.javascriptHint = function(editor) {
     // Find the token at the cursor
     var cur = editor.getCursor(), token = editor.getTokenAt(cur), tprop = token;
@@ -35,7 +48,7 @@
   function getCompletions(token, context) {
     var found = [], start = token.string;
     function maybeAdd(str) {
-      if (str.indexOf(start) == 0 && found.indexOf(str) == -1) found.push(str);
+      if (str.indexOf(start) == 0 && !arrayContains(found, str)) found.push(str);
     }
     function gatherCompletions(obj) {
       if (typeof obj == "string") forEach(stringProps, maybeAdd);


### PR DESCRIPTION
Define and use an arrayContains function rather than directly using array.indexOf, this fixes the auto completion demo in IE6/7/8.

I did it this way rather than creating Array.prototype.indexOf when it doesn't exist as I expect you would rather not modify the Array prototype?  However if you would rather I did it that way I can create a pull request for that instead.
