### PR TITLE
add (very) basic support for getting/setting the internal History object issue #135

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -161,6 +161,8 @@ var CodeMirror = (function() {
       }),
       historySize: function() {return {undo: history.done.length, redo: history.undone.length};},
       clearHistory: function() {history = new History();},
+      getHistory: function() {return history;},
+      setHistory: function(hist) {if (hist) { history = hist; }},
       matchBrackets: operation(function(){matchBrackets(true);}),
       getTokenAt: operation(function(pos) {
         pos = clipPos(pos);


### PR DESCRIPTION
It's not exactly rigorous in its safety checks, and this approach does involve exposing the History object as a sort of API, but it's enough to enable me to add the "store/restore" functionality I mentioned in issue #135.
