### PR TITLE
Make Markdown and Diff modes theme-independant

### DIFF
--- a/mode/diff/diff.css
+++ b/mode/diff/diff.css
@@ -1,3 +1,3 @@
-.cm-s-default span.cm-rangeinfo {color: #a0b;}
-.cm-s-default span.cm-minus {color: #a22;}
-.cm-s-default span.cm-plus {color: #2b2;}
+span.cm-rangeinfo {color: #a0b;}
+span.cm-minus {color: red;}
+span.cm-plus {color: #2b2;}

--- a/mode/markdown/markdown.css
+++ b/mode/markdown/markdown.css
@@ -1,10 +1,7 @@
-.cm-s-default span.cm-header {color: #2f2f4f; font-weight:bold;}
-.cm-s-default span.cm-code {color: #666;}
+span.cm-header, span.cm-strong {font-weight: bold;}
+span.cm-em {font-style: italic;}
+span.cm-emstrong {font-style: italic; font-weight: bold;}
+
+.cm-s-default span.cm-header {color: #2f2f4f;}
 .cm-s-default span.cm-quote {color: #090;}
-.cm-s-default span.cm-list {color: #a50;}
 .cm-s-default span.cm-hr {color: #999;}
-.cm-s-default span.cm-linktext {color: #00c; text-decoration: underline;}
-.cm-s-default span.cm-linkhref {color: #00c;}
-.cm-s-default span.cm-em {font-style: italic;}
-.cm-s-default span.cm-strong {font-weight: bold;}
-.cm-s-default span.cm-emstrong {font-style: italic; font-weight: bold;}

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -3,12 +3,12 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   var htmlMode = CodeMirror.getMode(cmCfg, { name: 'xml', htmlMode: true });
 
   var header   = 'header'
-  ,   code     = 'code'
+  ,   code     = 'comment'
   ,   quote    = 'quote'
-  ,   list     = 'list'
+  ,   list     = 'string'
   ,   hr       = 'hr'
-  ,   linktext = 'linktext'
-  ,   linkhref = 'linkhref'
+  ,   linktext = 'link'
+  ,   linkhref = 'string'
   ,   em       = 'em'
   ,   strong   = 'strong'
   ,   emstrong = 'emstrong';

--- a/theme/cobalt.css
+++ b/theme/cobalt.css
@@ -15,3 +15,4 @@
 .cm-s-cobalt span.cm-error { color: #9d1e15; }
 .cm-s-cobalt span.cm-bracket { color: #d8d8d8; }
 .cm-s-cobalt span.cm-builtin, .cm-s-cobalt span.cm-special { color: #ff9e59; }
+.cm-s-cobalt span.cm-link { color: #845dc4; text-decoration: underline; }

--- a/theme/default.css
+++ b/theme/default.css
@@ -17,3 +17,4 @@
 .cm-s-default span.cm-bracket {color: #cc7;}
 .cm-s-default span.cm-tag {color: #170;}
 .cm-s-default span.cm-attribute {color: #00c;}
+.cm-s-default span.cm-link {color: #00c; text-decoration: underline;}

--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -17,6 +17,7 @@
 .cm-s-eclipse span.cm-bracket {color: #cc7;}
 .cm-s-eclipse span.cm-tag {color: #170;}
 .cm-s-eclipse span.cm-attribute {color: #00c;}
+.cm-s-eclipse span.cm-link {color: #219; text-decoration: underline;}
 
 .CodeMirror-matchingbracket{
 	border:1px solid grey;

--- a/theme/elegant.css
+++ b/theme/elegant.css
@@ -7,3 +7,4 @@
 .cm-s-elegant span.cm-keyword {color: #730;}
 .cm-s-elegant span.cm-builtin {color: #30a;}
 .cm-s-elegant span.cm-error {background-color: #fdd;}
+.cm-s-elegant span.cm-link {color: #762; text-decoration: underline;}

--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -1,27 +1,28 @@
 /* Based on Sublime Text's Monokai theme */
 
-.cm-s-monokai { background: #272822; color: #F8F8F2; }
-.cm-s-monokai span.CodeMirror-selected { background: #FFE792 !important; }
-.cm-s-monokai .CodeMirror-gutter { background: #272822; border-right: 0px; }
-.cm-s-monokai .CodeMirror-gutter-text { color: #d0d0d0; }
-.cm-s-monokai .CodeMirror-cursor { border-left: 1px solid #F8F8F0 !important; }
+.cm-s-monokai {background: #272822; color: #f8f8f2;}
+.cm-s-monokai span.CodeMirror-selected {background: #ffe792 !important;}
+.cm-s-monokai .CodeMirror-gutter {background: #272822; border-right: 0px;}
+.cm-s-monokai .CodeMirror-gutter-text {color: #d0d0d0;}
+.cm-s-monokai .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
 
-.cm-s-monokai span.cm-comment { color: #75715E; }
-.cm-s-monokai span.cm-atom { color: #AE81FF; }
-.cm-s-monokai span.cm-number { color: #AE81FF; }
+.cm-s-monokai span.cm-comment {color: #75715e;}
+.cm-s-monokai span.cm-atom {color: #ae81ff;}
+.cm-s-monokai span.cm-number {color: #ae81ff;}
 
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #A6E22E;}
-.cm-s-monokai span.cm-keyword { color: #F92672; }
-.cm-s-monokai span.cm-string { color: #E6DB74; }
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
+.cm-s-monokai span.cm-keyword {color: #f92672;}
+.cm-s-monokai span.cm-string {color: #e6db74;}
 
-.cm-s-monokai span.cm-variable {color: #A6E22E;}
-.cm-s-monokai span.cm-variable-2 { color: #9effff; }
-.cm-s-monokai span.cm-def { color: #FD971F; }
-.cm-s-monokai span.cm-error { background: #F92672; color: #F8F8F0; }
-.cm-s-monokai span.cm-bracket { color: #f8F8F2; }
-.cm-s-monokai span.cm-tag {color: #F92672;}
+.cm-s-monokai span.cm-variable {color: #a6e22e;}
+.cm-s-monokai span.cm-variable-2 {color: #9effff;}
+.cm-s-monokai span.cm-def {color: #fd971f;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
+.cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-link {color: #ae81ff; text-decoration: underline;}
 
-.CodeMirror-matchingbracket{
-	text-decoration: underline;
-	color: white !important;
+.CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
 }

--- a/theme/neat.css
+++ b/theme/neat.css
@@ -6,3 +6,4 @@
 .cm-s-neat span.cm-variable { color: black; }
 .cm-s-neat span.cm-number, .cm-s-neat span.cm-atom { color: #3a3; }
 .cm-s-neat span.cm-meta {color: #555;}
+.cm-s-neat span.cm-link { color: #3a3; text-decoration: underline; }

--- a/theme/night.css
+++ b/theme/night.css
@@ -18,3 +18,4 @@
 .cm-s-night span.cm-bracket { color: #8da6ce; }
 .cm-s-night span.cm-comment { color: #6900a1; }
 .cm-s-night span.cm-builtin, .cm-s-night span.cm-special { color: #ff9e59; }
+.cm-s-night span.cm-link { color: #845dc4; text-decoration: underline; }

--- a/theme/rubyblue.css
+++ b/theme/rubyblue.css
@@ -16,5 +16,6 @@
 .cm-s-rubyblue span.cm-variable-3, .cm-s-rubyblue span.cm-def { color: white; }
 .cm-s-rubyblue span.cm-error { color: #AF2018; }
 .cm-s-rubyblue span.cm-bracket { color: #F0F; }
+.cm-s-rubyblue span.cm-link { color: #F4C20B; text-decoration: underline; }
 .cm-s-rubyblue span.CodeMirror-matchingbracket { color:#F0F !important; }
 .cm-s-rubyblue span.cm-builtin, .cm-s-rubyblue span.cm-special { color: #FF9D00; }


### PR DESCRIPTION
Hi Marijn,

As promised, I tried to make Markdown and Diff modes work with other themes than default. Here is what I did:
- In `mode/diff/diff.css`, I applied the current styling to all themes. This actually works well, even with themes having a dark background.
- In `mode/markdown/markdown.js` and `.css`, I changed a few mode-specific words to more standard programming words (eg `cm-linktext` became `cm-string`) and I defined a new standard word `cm-link`. I also separated theme-independant text formatting from theme-dependant colors.
- In every `theme/*.css`, I added styling for the new `cm-link` word, generally reusing the color of `cm-atom` with underlining.

I'm not sure I did everything the right way here, so please feel free to comment on the patch before accepting. I'll be happy to amend.

Cheers,
Jan
