### PR TITLE
[Vim mode] Support arrow keys, add link to demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
       <li><a href="demo/changemode.html">Mode auto-changing</a></li>
       <li><a href="demo/visibletabs.html">Visible tabs</a></li>
       <li><a href="demo/emacs.html">Emacs keybindings</a></li>
+      <li><a href="demo/vim.html">Vim keybindings</a></li>
     </ul>
 
     <h2>Real-world uses:</h2>

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -20,6 +20,7 @@
   for (var i = 1; i < 10; ++i) map[i] = pushCountDigit(i);
   // Add bindings that are influenced by number keys
   iterObj({"H": "goCharLeft", "L": "goCharRight", "J": "goLineDown", "K": "goLineUp",
+		       "Left": "goCharLeft", "Right": "goCharRight", "Down": "goLineDown", "Up": "goLineUp",
            "U": "undo", "Ctrl-R": "redo"},
           function(key, cmd) { map[key] = countTimes(cmd); });
 


### PR DESCRIPTION
Vim also makes use of arrow keys to move the cursor around (note: typing `3` + `Left` goes three characters to the left just like `3` + `h`).

Also, `index.html` was missing a link to the Vim keybinding demo.
