### PR TITLE
Vim word motions: B, b, E, e, W, and w

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -22,6 +22,12 @@
   iterObj({"H": "goColumnLeft", "L": "goColumnRight", "J": "goLineDown", "K": "goLineUp",
 		       "Left": "goColumnLeft", "Right": "goColumnRight", "Down": "goLineDown", "Up": "goLineUp",
            "Backspace": "goCharLeft", "Space": "goCharRight",
+           "B": function(cm) { cm.moveH(-1, "vimWord", "end"); },
+           "E": function(cm) { cm.moveH(1, "vimWord", "end"); },
+           "W": function(cm) { cm.moveH(1, "vimWord", "start"); },
+           "Shift-B": function(cm) { cm.moveH(-1, "nonSpace", "end"); },
+           "Shift-E": function(cm) { cm.moveH(1, "nonSpace", "end"); },
+           "Shift-W": function(cm) { cm.moveH(1, "nonSpace", "start"); },
            "U": "undo", "Ctrl-R": "redo"},
           function(key, cmd) { map[key] = countTimes(cmd); });
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1048,7 +1048,7 @@ var CodeMirror = (function() {
       else return pos;
     }
 
-    function findPosH(dir, unit) {
+    function findPosH(dir, unit, position) {
       var end = sel.inverted ? sel.from : sel.to, line = end.line, ch = end.ch;
       var lineObj = getLine(line);
       function findNextLine() {
@@ -1064,28 +1064,39 @@ var CodeMirror = (function() {
         } else ch += dir;
         return true;
       }
+      function charType() {
+        var c = lineObj.text.charAt(ch);
+        if (/\w/.test(c)) return "word";
+        if (unit != "word" && /\S/.test(c)) return unit == "nonSpace" ? "word" : "special";
+      }
       if (unit == "char") moveOnce();
       else if (unit == "column") moveOnce(true);
-      else if (unit == "word") {
-        var sawWord = false;
-        for (;;) {
-          if (dir < 0) if (!moveOnce()) break;
-          if (/\w/.test(lineObj.text.charAt(ch))) sawWord = true;
-          else if (sawWord) {if (dir < 0) {dir = 1; moveOnce();} break;}
-          if (dir > 0) if (!moveOnce()) break;
+      else if (position) {
+        if (position == "end") moveOnce();
+        var lastChar = charType();
+        while (moveOnce()) {
+          var thisChar = charType();
+          if (thisChar != lastChar) {
+            if (thisChar && position == "start") break;
+            else if (lastChar) {
+              if (position == "after") break;
+              else if (position == "end") { dir = -dir; moveOnce(); break; }
+            }
+          }
+          lastChar = thisChar;
         }
       }
       return {line: line, ch: ch};
     }
-    function moveH(dir, unit) {
+    function moveH(dir, unit, position) {
       var pos = dir < 0 ? sel.from : sel.to;
-      if (shiftSelecting || posEq(sel.from, sel.to)) pos = findPosH(dir, unit);
+      if (shiftSelecting || posEq(sel.from, sel.to)) pos = findPosH(dir, unit, position);
       setCursor(pos.line, pos.ch, true);
     }
-    function deleteH(dir, unit) {
+    function deleteH(dir, unit, position) {
       if (!posEq(sel.from, sel.to)) replaceRange("", sel.from, sel.to);
-      else if (dir < 0) replaceRange("", findPosH(dir, unit), sel.to);
-      else replaceRange("", sel.from, findPosH(dir, unit));
+      else if (dir < 0) replaceRange("", findPosH(dir, unit, position), sel.to);
+      else replaceRange("", sel.from, findPosH(dir, unit, position));
       userSelChange = true;
     }
     var goalColumn = null;
@@ -1770,12 +1781,12 @@ var CodeMirror = (function() {
     goCharRight: function(cm) {cm.moveH(1, "char");},
     goColumnLeft: function(cm) {cm.moveH(-1, "column");},
     goColumnRight: function(cm) {cm.moveH(1, "column");},
-    goWordLeft: function(cm) {cm.moveH(-1, "word");},
-    goWordRight: function(cm) {cm.moveH(1, "word");},
+    goWordLeft: function(cm) {cm.moveH(-1, "word", "end");},
+    goWordRight: function(cm) {cm.moveH(1, "word", "after");},
     delCharLeft: function(cm) {cm.deleteH(-1, "char");},
     delCharRight: function(cm) {cm.deleteH(1, "char");},
-    delWordLeft: function(cm) {cm.deleteH(-1, "word");},
-    delWordRight: function(cm) {cm.deleteH(1, "word");},
+    delWordLeft: function(cm) {cm.deleteH(-1, "word", "end");},
+    delWordRight: function(cm) {cm.deleteH(1, "word", "after");},
     indentAuto: function(cm) {cm.indentSelection("smart");},
     indentMore: function(cm) {cm.indentSelection("add");},
     indentLess: function(cm) {cm.indentSelection("subtract");},


### PR DESCRIPTION
Since these are the most commonly used horizontal motions in Vim (for me anyways), it's pretty important that they work exactly the same as they do in Vim (which turned out to be a pain in the ass).  This implementation, as far as I can tell, gets it right.  If you open the same text in Vim and CodeMirror and type `42w`, for instance, it will land on the exact same character.  At least in all my tests :)

Keybindings including the shift key select the text that they move over, however. Any ideas on that one? Should I open an issue?
