### PR TITLE
vim go end of line binding

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -22,7 +22,7 @@
   iterObj({"H": "goColumnLeft", "L": "goColumnRight", "J": "goLineDown", "K": "goLineUp",
 		       "Left": "goColumnLeft", "Right": "goColumnRight", "Down": "goLineDown", "Up": "goLineUp",
            "Backspace": "goCharLeft", "Space": "goCharRight",
-           "U": "undo", "Ctrl-R": "redo"},
+           "U": "undo", "Ctrl-R": "redo", "Shift-4": "goLineEnd"},
           function(key, cmd) { map[key] = countTimes(cmd); });
 
   CodeMirror.keyMap["vim-insert"] = {


### PR DESCRIPTION
Marijn, I tried to add a naive implementation of the vim "$" go to end of line binding, but in the current form it doesn't quite work as it instead causes a text selection to the end of line to occur. 

I think this is due to the presence of Shift modifier which combined with movement keys in default keybinding for a text area does the same thing?
