### PR TITLE
Added getTextarea() method

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1904,6 +1904,7 @@ var CodeMirror = (function() {
       textarea.parentNode.insertBefore(node, textarea.nextSibling);
     }, options);
     instance.save = save;
+    instance.getTextarea = function() { return textarea; };
     instance.toTextArea = function() {
       save();
       textarea.parentNode.removeChild(instance.getWrapperElement());


### PR DESCRIPTION
Added getTextarea() method which returns the original textarea element when CodeMirror is instantiated using fromTextarea() method.
