### PR TITLE
Renamed getTextarea() to getTextArea()

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1904,7 +1904,7 @@ var CodeMirror = (function() {
       textarea.parentNode.insertBefore(node, textarea.nextSibling);
     }, options);
     instance.save = save;
-    instance.getTextarea = function() { return textarea; };
+    instance.getTextArea = function() { return textarea; };
     instance.toTextArea = function() {
       save();
       textarea.parentNode.removeChild(instance.getWrapperElement());


### PR DESCRIPTION
Renamed the method to follow naming conventions and the documentation.
