### PR TITLE
Fix: properties named like built-ins are marked as errors.

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -250,7 +250,7 @@ CodeMirror.defineMode("python", function(conf, parserConf) {
         if (current === '.') {
             style = state.tokenize(stream, state);
             current = stream.current();
-            if (style === 'variable') {
+            if (style === 'variable' || style === 'builtin') {
                 return 'variable';
             } else {
                 return ERRORCLASS;


### PR DESCRIPTION
Example: foo.set("bar")
