### PR TITLE
Copy state not copying state in PHP mode

### DIFF
--- a/mode/php/php.js
+++ b/mode/php/php.js
@@ -95,18 +95,18 @@
 
 	// the old copyState was not actually copying the state, instead it just created new ones. This caused the state.mode information to be lost and made it impossible to carry state infomation.
 	copyState: function(state) {
-                var htmlNew = CodeMirror.copyState(htmlMode, state.html), phpNew = CodeMirror.copyState(phpMode, state.php), cur;
-                if (state.curState == state.html) cur = htmlNew;
-                else if (state.curState == state.php) cur = phpNew;
-                else cur = CodeMirror.copyState(state.curMode, state.curState);
-                var nstate=CodeMirror.copyState(state.curMode, state);
-                nstate.html=htmlNew;
-                nstate.php=phpNew;
-                nstate.curMode= state.curMode; 
-                nstate.curState= cur;
-                nstate.curClose= state.curClose;
-                return nstate;
-            }
+	        var htmlNew = CodeMirror.copyState(htmlMode, state.html), phpNew = CodeMirror.copyState(phpMode, state.php), cur;
+	        if (state.curState == state.html) cur = htmlNew;
+	        else if (state.curState == state.php) cur = phpNew;
+	        else cur = CodeMirror.copyState(state.curMode, state.curState);
+	        var nstate=CodeMirror.copyState(state.curMode, state);
+	        nstate.html=htmlNew;
+	        nstate.php=phpNew;
+	        nstate.curMode= state.curMode; 
+	        nstate.curState= cur;
+	        nstate.curClose= state.curClose;
+	        return nstate;
+	    },
       token: dispatch,
 
       indent: function(state, textAfter) {


### PR DESCRIPTION
The PHP mode has a custom copyState that did not actually carry state and lost information like state.mode. State is now carried properly and across different modes. 
