### PR TITLE
Change selection drawing.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -30,7 +30,8 @@ var CodeMirror = (function() {
             '<div class="CodeMirror-lines"><div style="position: relative">' +
               '<div style="position: absolute; width: 100%; height: 0; overflow: hidden; visibility: hidden"></div>' +
               '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor
-              '<div></div>' + // This DIV contains the actual code
+              '<div style="position: relative"></div>' + // This DIV contains the selection
+              '<div style="position: relative"></div>' + // This DIV contains the actual code
             '</div></div></div></div></div>';
     if (place.appendChild) place.appendChild(wrapper); else place(wrapper);
     // I've never seen more elegant code in my life.
@@ -38,7 +39,7 @@ var CodeMirror = (function() {
         scroller = wrapper.lastChild, code = scroller.firstChild,
         mover = code.firstChild, gutter = mover.firstChild, gutterText = gutter.firstChild,
         lineSpace = gutter.nextSibling.firstChild, measure = lineSpace.firstChild,
-        cursor = measure.nextSibling, lineDiv = cursor.nextSibling;
+        cursor = measure.nextSibling, selectionDiv = cursor.nextSibling, lineDiv = selectionDiv.nextSibling;
     themeChanged();
     // Needed to hide big blue blinking cursor on Mobile Safari
     if (ios) input.style.width = "0px";
@@ -1013,8 +1014,41 @@ var CodeMirror = (function() {
         cursor.style.display = "";
       }
       else cursor.style.display = "none";
+      updateSelection();
     }
-
+    function updateSelection() {
+      selectionDiv.innerHTML = ""; // Clear old selection
+      if (!posEq(sel.from, sel.to)) {
+        var fromPos = localCoords(sel.from, true), toPos = localCoords(sel.to, true);            
+        
+        if (fromPos.yBot == toPos.yBot) { // Single line selection
+          selectionDiv.innerHTML = getSelectionHTML(fromPos.x, fromPos.y, toPos.x - fromPos.x, toPos.yBot - toPos.y);
+        } else { // Multi line selection
+          var viewWidth = scroller.clientWidth - (eltOffset(lineSpace, false).left - eltOffset(scroller, false).left),
+              maxWidth = Math.max(viewWidth, lineDiv.clientWidth),
+              html = [];
+          // First line
+          html.push(getSelectionHTML(fromPos.x, fromPos.y, maxWidth - fromPos.x, fromPos.yBot - fromPos.y));
+          // Middle block
+          if (toPos.y > fromPos.yBot)
+            html.push(getSelectionHTML(0, fromPos.yBot, maxWidth, toPos.y - fromPos.yBot));
+          // Last line
+          html.push(getSelectionHTML(0, toPos.y, toPos.x, toPos.yBot - toPos.y));
+          selectionDiv.innerHTML = html.join("");
+        }   
+      }
+    }
+    function getSelectionHTML(left, top, width, height) {
+      var html = [];
+      html.push("<span class='CodeMirror-selected' style='position: absolute;");
+        html.push("left:" + left + "px;");
+        html.push("top:" + top + "px;");
+        html.push("width:" + width + "px;");
+        html.push("height:" + height + "px;");
+      html.push("'></span>");
+      return html.join("");
+    }
+    
     function setShift(val) {
       if (val) shiftSelecting = shiftSelecting || (sel.inverted ? sel.to : sel.from);
       else shiftSelecting = null;
@@ -2274,7 +2308,7 @@ var CodeMirror = (function() {
       if (endAt != null) len = Math.min(endAt, len);
 
       if (!allText && endAt == null)
-        span(" ", sfrom != null && sto == null ? "CodeMirror-selected" : null);
+        span(" ", null);
       else if (!marked && sfrom == null)
         for (var i = 0, ch = 0; ch < len; i+=2) {
           var str = st[i], style = st[i+1], l = str.length;
@@ -2284,7 +2318,7 @@ var CodeMirror = (function() {
         }
       else {
         var pos = 0, i = 0, text = "", style, sg = 0;
-        var markpos = -1, mark = null;
+        var markpos = -1, mark = null;  
         function nextMark() {
           if (marked) {
             markpos += 1;
@@ -2295,13 +2329,6 @@ var CodeMirror = (function() {
         while (pos < len) {
           var upto = len;
           var extraStyle = "";
-          if (sfrom != null) {
-            if (sfrom > pos) upto = sfrom;
-            else if (sto == null || sto > pos) {
-              extraStyle = " CodeMirror-selected";
-              if (sto != null) upto = Math.min(upto, sto);
-            }
-          }
           while (mark && mark.to != null && mark.to <= pos) nextMark();
           if (mark) {
             if (mark.from > pos) upto = Math.min(upto, mark.from);
@@ -2320,7 +2347,6 @@ var CodeMirror = (function() {
             text = st[i++]; style = "cm-" + st[i++];
           }
         }
-        if (sfrom != null && sto == null) span(" ", "CodeMirror-selected");
       }
       if (includePre) html.push("</pre>");
       return html.join("");


### PR DESCRIPTION
Selection is drawn as highlight rectangles behind the text. There are at most three rectangles drawn - one for the first partial line, one for the last partial line, and one for the block of lines in between. Selection is now true block selection, where the highlight extends to the right edge of the window.

The attached code is covered by the MIT license as follows.

---

Copyright ©2012  Adobe Systems Incorporated. All Rights Reserved.

Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
