### PR TITLE
HTML: reduce error distribution for incorrect / unfinished entities

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -47,9 +47,17 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
       }
     }
     else if (ch == "&") {
-      stream.eatWhile(/[^;]/);
-      stream.eat(";");
-      return "atom";
+      var ok;
+      if (stream.eat("#")) {
+        if (stream.eat("x")) {
+          ok = stream.eatWhile(/[a-fA-F\d]/) && stream.eat(";");          
+        } else {
+          ok = stream.eatWhile(/[\d]/) && stream.eat(";");
+        }
+      } else {
+        ok = stream.eatWhile(/[\w]/) && stream.eat(";");
+      }
+      return ok ? "atom" : "error";
     }
     else {
       stream.eatWhile(/[^&<]/);


### PR DESCRIPTION
Example:

<pre>&lt;html>
 &lt;body>War & Peace&lt;/body>
&lt;/html></pre>


In this example "& Peace&lt;/body>" is marked as error. As a consequence "&lt;/html>" is marked as error too.

After applying patch, error area becomes as small as possible - to the first inappropriate symbol. That way user will see: where is error.
