### PR TITLE
Make lineNumbers+gutter work again.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -150,6 +150,7 @@ var CodeMirror = (function() {
         else if (option == "lineWrapping" && oldVal != value) operation(wrappingChanged)();
         else if (option == "tabSize") operation(tabsChanged)();
         if (option == "lineNumbers" || option == "gutter" || option == "firstLineNumber" || option == "theme")
+          if(!options.gutter || !options.lineNumbers)gutterChanged();
           updateDisplay(true);
       },
       getOption: function(option) {return options[option];},


### PR DESCRIPTION
When default set to true, one was unable to remove the lineNumbers/gutter when set to false via script/console.
