### PR TITLE
Highlight multi-digit ordered lists in markdown

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -15,7 +15,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
   var hrRE = /^[*-=_]/
   ,   ulRE = /^[*-+]\s+/
-  ,   olRE = /^[0-9]\.\s+/
+  ,   olRE = /^[0-9]+\.\s+/
   ,   headerRE = /^(?:\={3,}|-{3,})$/
   ,   codeRE = /^(k:\t|\s{4,})/
   ,   textRE = /^[^\[*_\\<>`]+/;


### PR DESCRIPTION
The current markdown.js file only highlights ordered lists that have a single digit. This small change highlights multiple digit numbers correctly.
