### PR TITLE
Bug fix for Markdown styling

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -213,6 +213,10 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     token: function(stream, state) {
       if (stream.sol()) {
+        // Reset EM state
+        state.em = false;
+        // Reset STRONG state
+        state.strong = false;
         state.f = state.block;
         var previousIndentation = state.indentation
         ,   currentIndentation = 0;


### PR DESCRIPTION
EM/STRONG should not continue into sibling blocks. It could be argued that state.em/strong should only be set to TRUE when the matching \* or _ is found (which could be inserted automatically, and walked over upon inserting the same character... and if empty EM [e.g. `**|`], make it STRONG [e.g. `**|**`].. and repeat), but this will do for now.
