### PR TITLE
Inline formatting in quotes & headers fix (closes #345)

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -214,7 +214,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         text: handleText,
         em: false,
         strong: false,
-        header: false
+        header: false,
+        quote: false
       };
     },
 
@@ -230,7 +231,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         text: s.text,
         em: s.em,
         strong: s.strong,
-        header: s.header
+        header: s.header,
+        quote: s.quote
       };
     },
 


### PR DESCRIPTION
Changed `blockNormal()` to do an `else if` instead of a bunch of `if` statements (result is the same, due to `return`s, but if `return` is ever removed, it will still skip other logic now). This was to avoid duplicate calls to `switchInline()`.

I also changed `header` and `quote` to be states, and stopped moving pointer ahead to end of line. This enables us to parse other inline formatting (e.g. _em_ and **strong**) while still formatting for the `header` or `quote`. To make this possible, it was also necessary to rewrite `getType()` to allow for multiple return values (which is already handled by CodeMirror2, just not by the Markdown mode). On this note, it may be a good idea to also remove `emstrong` mode and replace it with `em` & `strong` separately (and also change in CSS), but I'll leave that up to you, since it isn't breaking anything the way it is now.
