### PR TITLE
Enable styles for cursor when Overwrite (insert) is enabled

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -59,6 +59,11 @@
   position: absolute;
   visibility: hidden;
   border-left: 1px solid black;
+  border-right:none;
+  width:0;
+}
+.CodeMirror pre.CodeMirror-cursor.CodeMirror-overwrite {
+  border-right:.5em solid rgba(255, 0, 0, .1);
 }
 .CodeMirror-focused pre.CodeMirror-cursor {
   visibility: visible;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -259,7 +259,15 @@ var CodeMirror = (function() {
       moveH: operation(moveH),
       deleteH: operation(deleteH),
       moveV: operation(moveV),
-      toggleOverwrite: function() {overwrite = !overwrite;},
+      toggleOverwrite: function() {
+        if(overwrite){
+          overwrite = false;
+          cursor.className = cursor.className.replace(" CodeMirror-overwrite", "");
+        } else {
+          overwrite = true;
+          cursor.className += " CodeMirror-overwrite";
+        }
+      },
 
       posFromIndex: function(off) {
         var lineNo = 0, ch;


### PR DESCRIPTION
Currently, it is impossible for the end user to tell if _overwrite_ is enabled (by pressing `Insert` key). With this patch, the class `CodeMirror-overwrite` is applied to the cursor when _overwrite_ is enabled, and removed when _overwrite_ is disabled. The style applied is a semi-transparent red box over the following letter (that will be overwritten if a character is entered) with the cursor (1px black line) still visible in the correct spot (to avoid confusion of what character will be removed when pressing `Backspace`.

The color of the overwrite cursor can be easily changed either in the original `codemirror.css` or any individual mode with the following CSS:

`.CodeMirror pre.CodeMirror-cursor.CodeMirror-overwrite {}`

Even if you prefer not to have the styles applied, I'd recommend at least applying the changes in `codemirror.js` so the class is assigned for anyone that does want to apply the styles in a mode.
