### PR TITLE
Fixed some JavaScript issues that cause parse errors with IE

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -103,7 +103,7 @@ CodeMirror.defineMode("clojure", function (config, mode) {
             return {
                 indentStack: null,
                 indentation: 0,
-                mode: false,
+                mode: false
             };
         },
 

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -8,7 +8,7 @@ CodeMirror.defineMode("gfm", function(config, parserConfig) {
     "c++": "text/x-c++src",
     java: "text/x-java",
     csharp: "text/x-csharp",
-    "c#": "text/x-csharp",
+    "c#": "text/x-csharp"
   };
 
   // make this lazy so that we don't need to load GFM last

--- a/mode/go/go.js
+++ b/mode/go/go.js
@@ -123,7 +123,7 @@ CodeMirror.defineMode("go", function(config, parserConfig) {
         tokenize: null,
         context: new Context((basecolumn || 0) - indentUnit, 0, "top", false),
         indented: 0,
-        startOfLine: true,
+        startOfLine: true
       };
     },
 

--- a/mode/perl/perl.js
+++ b/mode/perl/perl.js
@@ -324,7 +324,7 @@ CodeMirror.defineMode("perl",function(config,parserConfig){
 		hex				:1,	// - convert a string to a hexadecimal number
 		'import'			:1,	// - patch a module's namespace into your own
 		index				:1,	// - find a substring within a string
-		int				:1,	// - get the integer portion of a number
+		'int'				:1,	// - get the integer portion of a number
 		ioctl				:1,	// - system-dependent device control system call
 		'join'				:1,	// - join a list into a string using a separator
 		keys				:1,	// - retrieve list of indices from a hash

--- a/mode/properties/properties.js
+++ b/mode/properties/properties.js
@@ -49,7 +49,7 @@ CodeMirror.defineMode("properties", function() {
         nextMultiline : false,  // Is the next line multiline value
         inMultiline : false     // Is the current line a multiline value
       };
-    },
+    }
 
   };
 });

--- a/mode/rpm/spec/spec.js
+++ b/mode/rpm/spec/spec.js
@@ -14,7 +14,7 @@ CodeMirror.defineMode("spec", function(config, modeConfig) {
         return {
           controlFlow: false,
           macroParameters: false,
-          section: false,
+          section: false
         };
     },
     token: function (stream, state) {

--- a/mode/smalltalk/smalltalk.js
+++ b/mode/smalltalk/smalltalk.js
@@ -27,45 +27,45 @@ CodeMirror.defineMode('smalltalk', function(config, modeConfig) {
 
 	var next = function(stream, context, state) {
 		var token = new Token(null, context, false);
-		var char = stream.next();
+		var aChar = stream.next();
 
-		if (char === '"') {
+		if (aChar === '"') {
 			token = nextComment(stream, new Context(nextComment, context));
 
-		} else if (char === '\'') {
+		} else if (aChar === '\'') {
 			token = nextString(stream, new Context(nextString, context));
 
-		} else if (char === '#') {
+		} else if (aChar === '#') {
 			stream.eatWhile(/[^ .]/);
 			token.name = 'string-2';
 
-		} else if (char === '$') {
+		} else if (aChar === '$') {
 			stream.eatWhile(/[^ ]/);
 			token.name = 'string-2';
 
-		} else if (char === '|' && state.expectVariable) {
+		} else if (aChar === '|' && state.expectVariable) {
 			token.context = new Context(nextTemporaries, context);
 
-		} else if (/[\[\]{}()]/.test(char)) {
+		} else if (/[\[\]{}()]/.test(aChar)) {
 			token.name = 'bracket';
-			token.eos = /[\[{(]/.test(char);
+			token.eos = /[\[{(]/.test(aChar);
 
-			if (char === '[') {
+			if (aChar === '[') {
 				state.indentation++;
-			} else if (char === ']') {
+			} else if (aChar === ']') {
 				state.indentation = Math.max(0, state.indentation - 1);
 			}
 
-		} else if (specialChars.test(char)) {
+		} else if (specialChars.test(aChar)) {
 			stream.eatWhile(specialChars);
 			token.name = 'operator';
-			token.eos = char !== ';'; // ; cascaded message expression
+			token.eos = aChar !== ';'; // ; cascaded message expression
 
-		} else if (/\d/.test(char)) {
+		} else if (/\d/.test(aChar)) {
 			stream.eatWhile(/[\w\d]/);
 			token.name = 'number'
 
-		} else if (/[\w_]/.test(char)) {
+		} else if (/[\w_]/.test(aChar)) {
 			stream.eatWhile(/[\w\d_]/);
 			token.name = state.expectVariable ? (keywords.test(stream.current()) ? 'keyword' : 'variable') : null;
 
@@ -88,9 +88,9 @@ CodeMirror.defineMode('smalltalk', function(config, modeConfig) {
 
 	var nextTemporaries = function(stream, context, state) {
 		var token = new Token(null, context, false);
-		var char = stream.next();
+		var aChar = stream.next();
 
-		if (char === '|') {
+		if (aChar === '|') {
 			token.context = context.parent;
 			token.eos = true;
 


### PR DESCRIPTION
I ran CodeMirror2 through Google Closure and picked off errors that it reported.  Mostly, {k1:v, ... kn: vn,} with the trailing comma after vn causes a parse error with IE.  The use of 'int' and 'char' as names and identifiers also fixed.
