### PR TITLE
Fullscreen demo. Make var editor accessible via console. Fallback on css height and width.

### DIFF
--- a/demo/fullscreen.html
+++ b/demo/fullscreen.html
@@ -137,7 +137,7 @@
                 scroller.style.width = '';
                 editor.refresh();
               }
-            },
+            }
         }
     });
 


### PR DESCRIPTION
When exiting fullscreen: fallback on width and height set by css instead of recalculating, which was wrong anyway. When pressing F11 a couple of times the editor would decrease in width.

Fullscreen link: http://codemirror.net/demo/fullscreen.html
