### PR TITLE
Triple-click should include newline char

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1184,7 +1184,7 @@ var CodeMirror = (function() {
       setSelectionUser({line: pos.line, ch: start}, {line: pos.line, ch: end});
     }
     function selectLine(line) {
-      setSelectionUser({line: line, ch: 0}, {line: line, ch: getLine(line).text.length});
+      setSelectionUser({line: line, ch: 0}, clipPos({line: line + 1, ch: 0}));
     }
     function indentSelected(mode) {
       if (posEq(sel.from, sel.to)) return indentLine(sel.from.line, mode);


### PR DESCRIPTION
With this patch, triple-clicking on a line (or calling the `selectLine()` function) includes the newline character in the selection. 

After triple-clicking, pressing backspace (or doing "Cut") should remove the entire line.
