### PR TITLE
Make the full-screen demo less buggy. Gain user experience.

### DIFF
--- a/demo/fullscreen.html
+++ b/demo/fullscreen.html
@@ -147,7 +147,7 @@
 
     <p><strong>Note:</strong> Does not currently work correctly in IE
     6 and 7, where setting the height of something
-    to <code>100%</code> doesn't make it full-screen.</p>
+    to <code>100%</code> doesn't make it full screen.</p>
 
   </body>
 </html>


### PR DESCRIPTION
Setting the keybinding to Ctrl-F11 for full-screen on the CodeMirror instance.
This way the instance will not interfere with the standard/default F11 full-screen for the browser tab and vice versa.
