### PR TITLE
Moved ECL specific colouring into demo web page.

### DIFF
--- a/mode/ecl/index.html
+++ b/mode/ecl/index.html
@@ -5,8 +5,9 @@
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>
     <script src="ecl.js"></script>
+    <link rel="stylesheet" href="../../theme/declarative.css">
+    <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
     <link rel="stylesheet" href="../../doc/docs.css">
-    <style>.CodeMirror {border: 1px solid black;}</style>
   </head>
   <body>
     <h1>CodeMirror: ECL mode</h1>
@@ -31,7 +32,9 @@ output(d);
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
         tabMode: "indent",
+        lineNumbers: true,
         matchBrackets: true,
+        theme: "declarative"
       });
     </script>
 

--- a/theme/declarative.css
+++ b/theme/declarative.css
@@ -1,0 +1,10 @@
+.cm-s-declarative span.cm-comment {color: #008000;}
+.cm-s-declarative span.cm-meta {color: #004080}
+.cm-s-declarative span.cm-variable {font-weight: bold; color: #000080;}
+.cm-s-declarative span.cm-variable-2 {color: #800000;}
+.cm-s-declarative span.cm-variable-3 {color: #800000;}
+.cm-s-declarative span.cm-keyword {color: #0000ff;}
+.cm-s-declarative span.cm-builtin {color: #800080;}
+.cm-s-declarative span.cm-string {color: #808080;}
+.cm-s-declarative span.cm-number, .cm-s-default span.cm-atom {color: #000000;}
+


### PR DESCRIPTION
Defaulting demo colours to match default ECL colours in Eclipse/IDE + ECL Notepad

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
