### PR TITLE
Make the JavaScript mode parser somewhat better....

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -163,7 +163,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function register(varname) {
     var state = cx.state;
-    if (state.context) {
+    if (state.context && cx.stream.match(/\(/,false) != '(') {
       cx.marked = "def";
       for (var v = state.localVars; v; v = v.next)
         if (v.name == varname) return;


### PR DESCRIPTION
Best noticeable at: http://codemirror.net/demo/theme.html
You'll see that "find" on line 2: "function find" -> has no color in default mode which is correct.
However when pressing enter after "find", "find" gets colored which is incorrect.
So this is a to do :-)
