### PR TITLE
Added boolean option: collapseEmptyLines

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1763,6 +1763,7 @@ var CodeMirror = (function() {
     indentWithTabs: false,
     smartIndent: true,
     tabSize: 4,
+    collapseEmptyLines: false,
     keyMap: "default",
     extraKeys: null,
     electricChars: true,
@@ -1877,8 +1878,13 @@ var CodeMirror = (function() {
                         {line: cur.line, ch: cur.ch - 1}, {line: cur.line, ch: cur.ch + 1});
     },
     newlineAndIndent: function(cm) {
+      var n = cm.getCursor().line;
+      var collapse = cm.getOption('collapseEmptyLines') // Not enabled by default
+        && !cm.somethingSelected() // Ignore when replacing a selection
+        && /^[\s\u00a0]*$/.test(cm.getLine(n)); // Test that the entire only contains indents
       cm.replaceSelection("\n", "end");
       cm.indentLine(cm.getCursor().line);
+      if (collapse) cm.setLine(n, ''); // Collapse previous line (after indent is calculated)
     },
     toggleOverwrite: function(cm) {cm.toggleOverwrite();}
   };


### PR DESCRIPTION
With the option `collapseEmptyLines` set to true, the editor will discard the auto-inserted indentation spaces when `<Enter>` is hit. For example, type this (without the line numbers):

```
1 function foo() {
2   var r;
3
4   r = 13; 
5
6   return r;
7 } 
```

Starting at the end of line 2, I type `<Enter><Enter>` to get to line 4.

Without `collapseEmptyLines`, lines 3 and 5 will contain space characters which were inserted to indent the line.
- Applies both with and without `smartIndent`.
- Does not apply when replacing a text selection.
