### PR TITLE
Changes to keywords in PHP mode.

### DIFF
--- a/mode/php/php.js
+++ b/mode/php/php.js
@@ -13,11 +13,12 @@
   }
   var phpConfig = {
     name: "clike",
-    keywords: keywords("abstract and array as break case catch cfunction class clone const continue declare " +
-                       "default do else elseif enddeclare endfor endforeach endif endswitch endwhile extends " +
-                       "final for foreach function global goto if implements interface instanceof namespace " +
-                       "new or private protected public static switch throw try use var while xor return" +
-                       "die echo empty exit eval include include_once isset list require require_once print unset"),
+    keywords: keywords("abstract and array as break case catch class clone const continue declare default " +
+                       "do else elseif enddeclare endfor endforeach endif endswitch endwhile extends final " +
+                       "for foreach function global goto if implements interface instanceof namespace " +
+                       "new or private protected public static switch throw trait try use var while xor " +
+                       "die echo empty exit eval include include_once isset list require require_once return " +
+                       "print unset __halt_compiler self static parent"),
     blockKeywords: keywords("catch do else elseif for foreach if switch try while"),
     atoms: keywords("true false null TRUE FALSE NULL"),
     multiLineStrings: true,


### PR DESCRIPTION
A missing space between "return" and "die" was causing both to not get
highlighted. While in there I removed "cfunction" as it was PHP4 only,
added "trait" (coming in 5.4), and added "__halt_compiler", "self",
"static", and "parent".
