### PR TITLE
Fix Backspace In Autocompletion Navigating Back

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -254,6 +254,7 @@ var CodeMirror = (function() {
       replaceRange: operation(replaceRange),
       getRange: function(from, to) {return getRange(clipPos(from), clipPos(to));},
 
+      triggerOnKeyDown: operation(onKeyDown),
       execCommand: function(cmd) {return commands[cmd](instance);},
       // Stuff used by commands, probably not much use to outside code.
       moveH: operation(moveH),

--- a/lib/util/simple-hint.js
+++ b/lib/util/simple-hint.js
@@ -53,6 +53,8 @@
       else if (code == 27) {CodeMirror.e_stop(event); close(); editor.focus();}
       else if (code != 38 && code != 40) {
         close(); editor.focus();
+        // Pass the event to the CodeMirror instance so that it can handle things like backspace properly.
+        editor.triggerOnKeyDown(event);
         setTimeout(function(){CodeMirror.simpleHint(editor, getHints);}, 50);
       }
     });


### PR DESCRIPTION
When you hit ctrl+space in an autocomplete dialog using simple-hint.js it navigates backwards, this pull request fixes that.
