### PR TITLE
fixes for the stex mode

### DIFF
--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -82,7 +82,7 @@ CodeMirror.defineMode("stex", function(cmCfg, modeCfg)
     }
 
     function normal(source, state) {
-	if (source.match(/^\\[a-z]+/)) {
+	if (source.match(/^\\[a-zA-Z@]+/)) {
 	    var cmdName = source.current();
 	    cmdName = cmdName.substr(1, cmdName.length-1);
 	    var plug = plugins[cmdName];
@@ -96,18 +96,21 @@ CodeMirror.defineMode("stex", function(cmCfg, modeCfg)
 	}
 
         // escape characters 
-        if (source.match(/^\\[$&%#{}_SP]/)) {
+        if (source.match(/^\\[$&%#{}_]/)) {
           return "tag";
         }
 
         // white space control characters
-        if (source.match(/^\\[,;!@\/]/)) {
+        if (source.match(/^\\[,;!\/]/)) {
           return "tag";
         }
 
 	var ch = source.next();
 	if (ch == "%") {
-	    setState(state, inCComment);
+            // special case: % at end of its own line; stay in same state
+            if (!source.eol()) {
+              setState(state, inCComment);
+            }
 	    return "comment";
 	} 
 	else if (ch=='}' || ch==']') {


### PR DESCRIPTION
- escaped % (\%) was being interpreted as start of comment
- a % at the end of a line caused the next line to look like a comment
- now recognizes upper- and mixed-case commands (e.g. \LaTeX) as tags
- now recognizes some other special and escaped characters

A follow-up pull request will include some test cases...
