### PR TITLE
Update lib/codemirror.js prevent scroller from highlighting onfocus(DND)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -44,7 +44,7 @@ var CodeMirror = (function() {
     // Needed to hide big blue blinking cursor on Mobile Safari
     if (ios) input.style.width = "0px";
     if (!webkit) lineSpace.draggable = true;
-    scroller.style.outline = "none";//dirty hack to prevent scroller from highlighting when gettting focus(only occurs when dragging selection)
+    scroller.style.outline = "none";//dirty hack to prevent scroller from highlighting when gettting focus(only occurs when dragging selection). WebKit only.
     if (options.tabindex != null) input.tabIndex = options.tabindex;
     if (!options.gutter && !options.lineNumbers) gutter.style.display = "none";
 


### PR DESCRIPTION
Dirty hack to prevent scroller from highlighting when gettting focus(only occurs when dragging selection)
This solution should not be final. Why? Well if you want the outline to be visible when the scroller gets focus using tabbing(tabindex) , there is no color present as it is set to none, so it it not visible.

Edit: WebKit only
