### PR TITLE
Update lib/codemirror.js Fix default image when DND

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -469,10 +469,10 @@ var CodeMirror = (function() {
       //e.dataTransfer.setData("Text", txt);
       
       //use dummy image instead of default browsers image. default is mighty ugly the way CodeMirror is now.
-      var a = document.createElement('img');
-	  a.scr = 'data:image/gif;base64,R0lGODdhAgACAIAAAAAAAP///ywAAAAAAgACAAACAoRRADs=';//1x1 image
+      var img = document.createElement('img');
+	  img.scr = 'data:image/gif;base64,R0lGODdhAgACAIAAAAAAAP///ywAAAAAAgACAAACAoRRADs=';//1x1 image
 	  e.dataTransfer.setData("text/plain", txt);
-      if(/chrome|firefox/ig.test(navigator.userAgent))e.dataTransfer.setDragImage(a, 0, 0);
+      if(/chrome|firefox/ig.test(navigator.userAgent))e.dataTransfer.setDragImage(img, 0, 0);
     }
 
     function doHandleBinding(bound, dropShift) {


### PR DESCRIPTION
Use dummy image instead of default browsers image. Default is mighty ugly the way CodeMirror is now.
