### PR TITLE
New mode: Smarty Templating language

### DIFF
--- a/mode/smarty/index.html
+++ b/mode/smarty/index.html
@@ -11,7 +11,7 @@
   <body>
     <h1>CodeMirror: Smarty mode</h1>
 
-<form><textarea id="code" name="code">
+    <form><textarea id="code" name="code">
 {extends file="parent.tpl"}
 {include file="template.tpl"}
 
@@ -36,16 +36,46 @@
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
         lineNumbers: true,
-        matchBrackets: true,
-        mode: "smarty",
-        indentUnit: 4,
-        indentWithTabs: true,
-        enterMode: "keep",
-        tabMode: "shift"
+        mode: "smarty"
       });
     </script>
 
-    <p>A plain text/Smarty mode which allows for custom delimiter tags (defaults to { and }).</p>
+    <br />
+
+    <form><textarea id="code2" name="code2">
+{--extends file="parent.tpl"--}
+{--include file="template.tpl"--}
+
+{--* some example Smarty content *--}
+{--if isset($name) && $name == 'Blog'--}
+  This is a {--$var--}.
+  {--$integer = 451--}, {--$array[] = "a"--}, {--$stringvar = "string"--}
+  {--assign var='bob' value=$var.prop--}
+{--elseif $name == $foo--}
+  {--function name=menu level=0--}
+    {--foreach $data as $entry--}
+      {--if is_array($entry)--}
+        - {--$entry@key--}
+        {--menu data=$entry level=$level+1--}
+      {--else--}
+        {--$entry--}
+      {--/if--}
+    {--/foreach--}
+  {--/function--}
+{--/if--}</textarea></form>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code2"), {
+        lineNumbers: true,
+        mode: {
+          name: "smarty",
+          leftDelimiter: "{--",
+          rightDelimiter: "--}"
+        }
+      });
+    </script>
+
+    <p>A plain text/Smarty mode which allows for custom delimiter tags (defaults to <b>{</b> and <b>}</b>).</p>
 
     <p><strong>MIME types defined:</strong> <code>text/x-smarty</code></p>
   </body>

--- a/mode/smarty/smarty.js
+++ b/mode/smarty/smarty.js
@@ -1,5 +1,5 @@
 CodeMirror.defineMode("smarty", function(config, parserConfig) {
-  var keyFuncs = ["debug", "extends", "function", "include", "include_php", "literal"];
+  var keyFuncs = ["debug", "extends", "function", "include", "literal"];
   var last;
   var regs = {
     operatorChars: /[+\-*&%=<>!?]/,
@@ -9,6 +9,7 @@ CodeMirror.defineMode("smarty", function(config, parserConfig) {
   var leftDelim = (typeof config.mode.leftDelimiter != 'undefined') ? config.mode.leftDelimiter : "{";
   var rightDelim = (typeof config.mode.rightDelimiter != 'undefined') ? config.mode.rightDelimiter : "}";
   function ret(style, lst) { last = lst; return style; }
+
 
   function tokenizer(stream, state) {
     function chain(parser) {
@@ -26,7 +27,7 @@ CodeMirror.defineMode("smarty", function(config, parserConfig) {
       }
     }
     else {
-      // I'd like to do an eatWhile() here, but I can't get it going with searching for UP to the leftDelim string...
+      // I'd like to do an eatWhile() here, but I can't get it to eat only up to the rightDelim string/char
       stream.next();
       return null;
     }
@@ -93,8 +94,7 @@ CodeMirror.defineMode("smarty", function(config, parserConfig) {
       while ((c = stream.eat(regs.validIdentifier))) {
         str += c;
       }
-
-      var i;
+      var i, j;
       for (i=0, j=keyFuncs.length; i<j; i++) {
         if (keyFuncs[i] == str) {
           return ret("keyword", "keyword");


### PR DESCRIPTION
Hi Marijn,

This is a mode for the PHP Smarty templating language (http://www.smarty.net/). Since Smarty can be used to as a pre-parser to generate any old thing (HTML, CSV, CSS, XML, you name it), I thought the best approach would be to first write a plain text/Smarty parser to focus on the Smarty syntax highlighting. This mode is for that. Once it’s looking okay, I was planning to write a second "smartyhtmlmixed" mode for HTML, CSS, JS + Smarty - which is by far the most common usage for Smarty.

Since Smarty allows custom tag delimiters, the mode allows you to customize it, but defaults to the standard { and } chars.

Thoughts? I’d very much welcome any suggestions you have for improving the code. 

Thanks!
- Ben
  @vancouverben
