### PR TITLE
Moving suggestion menu so appears to left of cursor if at browser edge

### DIFF
--- a/lib/util/simple-hint.js
+++ b/lib/util/simple-hint.js
@@ -29,6 +29,10 @@
     complete.style.left = pos.x + "px";
     complete.style.top = pos.yBot + "px";
     document.body.appendChild(complete);
+    // If we're at the edge of the screen, then we want the menu to appear on the left of the cursor.
+    var winW = window.innerWidth || Math.max(document.body.offsetWidth, document.documentElement.offsetWidth)
+    if(winW - pos.x < sel.clientWidth)
+      complete.style.left = (pos.x - sel.clientWidth) + "px"    
     // Hack to hide the scrollbar.
     if (completions.length <= 10)
       complete.style.width = (sel.clientWidth - 1) + "px";


### PR DESCRIPTION
Hi Marjin,

I have written a small patch which moves the suggestion context menu to the left of the cursor when the cursor is in a position where there isn't enough room to the right to display the menu without scrolling the browser (e.g. chrome) or simply truncating the menu (e.g. safari). Please let me know if you need me to make any further changes.

Thanks,
Lorenzo
