### PR TITLE
Fix spelling of 'bracket' in comment

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -78,7 +78,7 @@ var CodeMirror = (function() {
         gutterDirty, callbacks;
     // Current visible range (may be bigger than the view window).
     var displayOffset = 0, showingFrom = 0, showingTo = 0, lastSizeC = 0;
-    // bracketHighlighted is used to remember that a backet has been
+    // bracketHighlighted is used to remember that a bracket has been
     // marked.
     var bracketHighlighted;
     // Tracks the maximum line length so that the horizontal scrollbar


### PR DESCRIPTION
Just fixing a spelling error I found when hacking on the code.
