### PR TITLE
Add support for `autofocus` attribute on textareas, and also for manual overriding

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -45,6 +45,7 @@ var CodeMirror = (function() {
     if (!webkit) lineSpace.draggable = true;
     lineSpace.style.outline = "none";
     if (options.tabindex != null) input.tabIndex = options.tabindex;
+    if (options.autofocus === true) input.focus();
     if (!options.gutter && !options.lineNumbers) gutter.style.display = "none";
 
     // Check for problem with IE innerHTML not working when we have a
@@ -1848,7 +1849,8 @@ var CodeMirror = (function() {
     workDelay: 200,
     pollInterval: 100,
     undoDepth: 40,
-    tabindex: null
+    tabindex: null,
+    autofocus: null
   };
 
   var ios = /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent);
@@ -2014,6 +2016,9 @@ var CodeMirror = (function() {
     options.value = textarea.value;
     if (!options.tabindex && textarea.tabindex)
       options.tabindex = textarea.tabindex;
+    if (typeof options.autofocus === "undefined")
+      if (textarea.getAttribute("autofocus") !== null)
+        options.autofocus = true;
 
     function save() {textarea.value = instance.getValue();}
     if (textarea.form) {


### PR DESCRIPTION
This makes it possible for options.autofocus to be set to **on** (`true`), **off** (`false`), or **inherit** (`null` / not set) which will use the value from the HTML `autofocus` attribute (if present, `true`, else `false`).
