### PR TITLE
Tag closer

### DIFF
--- a/demo/closetag.html
+++ b/demo/closetag.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CodeMirror: Close-Tag Demo</title>
+		<link rel="stylesheet" href="../lib/codemirror.css">
+		<script src="../lib/codemirror.js"></script>
+		<script src="../lib/util/closetag.js"></script>
+		
+<!--
+		<script src="../mode/xml/xml.js"></script>
+-->
+		<script src="../mode/xml/xml.js"></script>
+		<script src="../mode/javascript/javascript.js"></script>
+		<script src="../mode/css/css.js"></script>
+		<script src="../mode/htmlmixed/htmlmixed.js"></script>
+<!--
+		<script src="../mode/xmlpure/xmlpure.js"></script>
+-->
+
+		<link rel="stylesheet" href="../doc/docs.css">
+		<style type="text/css">
+			.CodeMirror {border-top: 1px solid #eee; border-bottom: 1px solid #eee;}
+		</style>
+	</head>
+	<body>
+	
+		<h1>Close-Tag Demo</h1>
+		<ul>
+			<li>Type an html tag.  When you type '>' or '/', the tag will auto-close/complete.  Block-level tags will indent.</li>
+			<li>There are options for disabling tag closing or customizing the list of tags to indent.</li>
+			<li>Works with "text/html" (based on htmlmixed.js or xml.js) and "xmlpure" modes.</li>
+			<li>View source for key binding details.</li>
+		</p>
+
+		<form><textarea id="code" name="code"></textarea></form>
+
+		<script type="text/javascript">
+		var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+			mode: 'text/html',
+			//mode: 'xmlpure',
+			
+			//closeTagEnabled: false, // Set this option to disable tag closing behavior without having to remove the key bindings.
+			//closeTagIndent: false, // Pass false or an array of tag names to override the default indentation behavior.
+			
+			extraKeys: {
+				"'>'": function(cm) { cm.closeTag(cm, '>'); },
+				"'/'": function(cm) { cm.closeTag(cm, '/'); }
+			},
+			
+			/*
+			// extraKeys is the easier way to go, but if you need native key event processing, this should work too.
+			onKeyEvent: function(cm, e) {
+				if (e.type == 'keydown') {
+					var c = e.keyCode || e.which;
+					if (c == 190 || c == 191) {
+						try {
+							cm.closeTag(cm, c == 190 ? '>' : '/');
+							e.stop();
+							return true;
+						} catch (e) {
+							if (e != CodeMirror.Pass) throw e;
+						}
+					}
+				}
+				return false;
+			},
+			*/
+			
+			wordWrap: true
+		});
+		</script>
+
+	</body>
+</html>

--- a/doc/compress.html
+++ b/doc/compress.html
@@ -105,6 +105,7 @@
           <option value="http://codemirror.net/lib/util/searchcursor.js">searchcursor.js</option>
           <option value="http://codemirror.net/lib/util/formatting.js">formatting.js</option>
           <option value="http://codemirror.net/lib/util/match-highlighter.js">match-highlighter.js</option>
+		  <option value="http://codemirror.net/lib/util/closetag.js">closetag.js</option>
         </optgroup>
         <optgroup label="Keymaps">
           <option value="http://codemirror.net/keymap/emacs.js">emacs.js</option>

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
       <li><a href="demo/formatting.html">Autoformatting of code</a></li>
       <li><a href="demo/emacs.html">Emacs keybindings</a></li>
       <li><a href="demo/vim.html">Vim keybindings</a></li>
+      <li><a href="demo/closetag.html">Tag closing</a></li>
     </ul>
 
     <h2>Real-world uses:</h2>

--- a/lib/util/closetag.js
+++ b/lib/util/closetag.js
@@ -1,0 +1,176 @@
+/**
+ * Tag-closer extension for CodeMirror.
+ *
+ * This extension adds a "closeTag" utility function that can be used with key bindings to 
+ * insert a matching end tag after the ">" character of a start tag has been typed.  It can
+ * also complete "</" if a matching start tag is found.  It will correctly ignore signal
+ * characters for empty tags, comments, CDATA, etc.
+ *
+ * The function depends on internal parser state to identify tags.  It is compatible with the
+ * following CodeMirror modes and will ignore all others:
+ * - htmlmixed
+ * - xml
+ * - xmlpure
+ *
+ * See demos/closetag.html for a usage example.
+ * 
+ * @author Nathan Williams <nathan@nlwillia.net>
+ * Contributed under the same license terms as CodeMirror.
+ */
+(function() {
+
+	/** Option that allows tag closing behavior to be toggled.  Default is true. */
+	CodeMirror.defaults['closeTagEnabled'] = true;
+	
+	/** Array of tag names to add indentation after the start tag for.  Default is the list of block-level html tags. */
+	CodeMirror.defaults['closeTagIndent'] = ['applet', 'blockquote', 'body', 'button', 'div', 'dl', 'fieldset', 'form', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'html', 'iframe', 'layer', 'legend', 'object', 'ol', 'p', 'select', 'table', 'ul'];
+
+	/**
+	 * Call during key processing to close tags.  Handles the key event if the tag is closed, otherwise throws CodeMirror.Pass.
+	 * - cm: The editor instance.
+	 * - ch: The character being processed.
+	 * - indent: Optional.  Omit or pass true to use the default indentation tag list defined in the 'closeTagIndent' option.
+	 *   Pass false to disable indentation.  Pass an array to override the default list of tag names.
+	 */
+	CodeMirror.defineExtension("closeTag", function(cm, ch, indent) {
+		
+		if (!cm.getOption('closeTagEnabled')) {
+			throw CodeMirror.Pass;
+		}
+		
+		var mode = cm.getOption('mode');
+		
+		if (mode == 'text/html') {
+		
+			/*
+			 * Relevant structure of token:
+			 *
+			 * htmlmixed
+			 * 		className
+			 * 		state
+			 * 			htmlState
+			 * 				type
+			 * 				context
+			 * 					tagName
+			 * 			mode
+			 * 
+			 * xml
+			 * 		className
+			 * 		state
+			 * 			tagName
+			 * 			type
+			 */
+		
+			var pos = cm.getCursor();
+			var tok = cm.getTokenAt(pos);
+			var state = tok.state;
+			
+			if (state.mode && state.mode != 'html') {
+				throw CodeMirror.Pass; // With htmlmixed, we only care about the html sub-mode.
+			}
+			
+			if (ch == '>') {
+				var type = state.htmlState ? state.htmlState.type : state.type; // htmlmixed : xml
+				
+				if (tok.className == 'tag' && type == 'closeTag') {
+					throw CodeMirror.Pass; // Don't process the '>' at the end of an end-tag.
+				}
+			
+				cm.replaceSelection('>'); // Mode state won't update until we finish the tag.
+				pos = {line: pos.line, ch: pos.ch + 1};
+				cm.setCursor(pos);
+		
+				tok = cm.getTokenAt(cm.getCursor());
+				state = tok.state;
+				type = state.htmlState ? state.htmlState.type : state.type; // htmlmixed : xml
+
+				if (tok.className == 'tag' && type != 'selfcloseTag') {
+					var tagName = state.htmlState ? state.htmlState.context.tagName : state.tagName; // htmlmixed : xml
+					if (tagName.length > 0) {
+						insertEndTag(cm, indent, pos, tagName);
+					}
+					return;
+				}
+				
+				// Undo the '>' insert and allow cm to handle the key instead.
+				cm.setSelection({line: pos.line, ch: pos.ch - 1}, pos);
+				cm.replaceSelection("");
+			
+			} else if (ch == '/') {
+				if (tok.className == 'tag') {
+					var tagName = state.htmlState ? (state.htmlState.context ? state.htmlState.context.tagName : '') : state.context.tagName; // htmlmixed : xml # extra htmlmized check is for '</' edge case
+					if (tagName.length > 0) {
+						completeEndTag(cm, pos, tagName);
+						return;
+					}
+				}
+			}
+		
+		} else if (mode == 'xmlpure') {
+
+			var pos = cm.getCursor();
+			var tok = cm.getTokenAt(pos);
+			var tagName = tok.state.context.tagName;
+
+			if (ch == '>') {
+				// <foo>			tagName=foo, string=foo
+				// <foo />			tagName=foo, string=/		# ignore
+				// <foo></foo>		tagName=foo, string=/foo	# ignore
+				if (tok.string == tagName) {
+					cm.replaceSelection('>'); // parity w/html modes
+					pos = {line: pos.line, ch: pos.ch + 1};
+					cm.setCursor(pos);
+					
+					insertEndTag(cm, indent, pos, tagName);
+					return;
+				}
+				
+			} else if (ch == '/') {
+				// <foo /			tagName=foo, string= 		# ignore
+				// <foo></			tagName=foo, string=<
+				if (tok.string == '<') {
+					completeEndTag(cm, pos, tagName);
+					return;
+				}
+			}
+		}
+		
+		throw CodeMirror.Pass; // Bubble if not handled
+	});
+
+	function insertEndTag(cm, indent, pos, tagName) {
+		if (shouldIndent(cm, indent, tagName)) {
+			cm.replaceSelection('\n\n</' + tagName + '>', 'end');
+			cm.indentLine(pos.line + 1);
+			cm.indentLine(pos.line + 2);
+			cm.setCursor({line: pos.line + 1, ch: cm.getLine(pos.line + 1).length});
+		} else {
+			cm.replaceSelection('</' + tagName + '>');
+			cm.setCursor(pos);
+		}
+	}
+	
+	function shouldIndent(cm, indent, tagName) {
+		if (typeof indent == 'undefined' || indent == null || indent == true) {
+			indent = cm.getOption('closeTagIndent');
+		}
+		if (!indent) {
+			indent = [];
+		}
+		return indexOf(indent, tagName.toLowerCase()) != -1;
+	}
+	
+	// C&P from codemirror.js...would be nice if this were visible to utilities.
+	function indexOf(collection, elt) {
+		if (collection.indexOf) return collection.indexOf(elt);
+		for (var i = 0, e = collection.length; i < e; ++i)
+			if (collection[i] == elt) return i;
+		return -1;
+	}
+
+	function completeEndTag(cm, pos, tagName) {
+		cm.replaceSelection('/' + tagName + '>');
+		cm.setCursor({line: pos.line, ch: pos.ch + tagName.length + 2 });
+	}
+	
+})();


### PR DESCRIPTION
Here's a pull request for the tag closer utility recently discussed in the group.

http://groups.google.com/group/codemirror/browse_thread/thread/544ccbe404af37f0

I revised my original demo to handle multiple modes and do some basic indenting.  Code is documented and hopefully ready for distribution.

If you have any questions or concerns, please let me know.
