### PR TITLE
Fixes for KHTML: key repeat, `delete` and `tab` key handling

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -46,6 +46,8 @@ var CodeMirror = (function() {
     lineSpace.style.outline = "none";
     if (options.tabindex != null) input.tabIndex = options.tabindex;
     if (!options.gutter && !options.lineNumbers) gutter.style.display = "none";
+    // Needed to handle Tab key in KHTML
+    if (khtml) inputDiv.style.height = "1px", inputDiv.style.position = "absolute";
 
     // Check for problem with IE innerHTML not working when we have a
     // P (or similar) parent node.
@@ -121,6 +123,12 @@ var CodeMirror = (function() {
     connect(input, "cut", operation(function(){
       if (!options.readOnly) replaceSelection("");
     }));
+
+    // Needed to handle Tab key in KHTML
+    if (khtml) connect(code, "mouseup", function() {
+        if (document.activeElement == input) input.blur();
+        focusInput();
+    });
 
     // IE throws unspecified error in certain cases, when
     // trying to access activeElement before onload


### PR DESCRIPTION
Here are three changes making CodeMirror2 usable in **Konqueror** with KHTML engine.
1. KHTML repeats `onKeyPress` events instead of `onKeyDown`. There was a similar code for Opera in `onKeyPress` so I just added `|| khtml` to the `if`.
2. Konqueror uses key code `127` for `Delete`.
3. Intercepting `tab` key press is a bit tricky: it works reliably only when `input` has focus, but KHTML seems to ignore the textarea if it's invisible (`inputDiv` has `height: 0px`), so I changed `inputDiv.style.height` to `1px` (only in KHTML of course). In order to hide `inputDiv` I set `inputDiv.style.position` to `absolute`. However, this worked only 50% of the time, so I added bluring & focusing `input` on `mouseup` event. It works perfectly now and as a side effect it fixed `Ctrl-F` as well.
