### PR TITLE
Make autofocus documentation more specific in regards to how it inherits its value.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -279,7 +279,8 @@
       initialization. Defaults to off.
       When <a href="#fromTextArea"><code>fromTextArea</code></a> is
       used, and no explicit value is given for this option, it will
-      inherit the setting from the textarea.</dd>
+      inherit the setting from the textarea's <code>autofocus</code>
+      attribute.</dd>
 
       <dt id="option_onKeyEvent"><code>onKeyEvent (function)</code></dt>
       <dd>This provides a rather low-level hook into CodeMirror's key


### PR DESCRIPTION
Simply turning my comment (quoted below) on ac8579152574a0d25223aca6fb67cd0d2e979f5f into a pull request for simplicity.

> Actually, might want to specify exactly where the setting in inherited from. It doesn't inherit from whether the textarea is focused, just from whether the `autofocus` attribute is set on it or not. So, perhaps better wording would be:
> 
> > ...it will inherit the setting from the textarea**_'s `autofocus` attribute**_.
