### PR TITLE
Added drag-and-drop option

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -116,9 +116,11 @@ var CodeMirror = (function() {
     connect(input, "focus", onFocus);
     connect(input, "blur", onBlur);
 
-    connect(scroller, "dragenter", e_stop);
-    connect(scroller, "dragover", e_stop);
-    connect(scroller, "drop", operation(onDrop));
+    if(options.dragDrop){
+      connect(scroller, "dragenter", e_stop);
+      connect(scroller, "dragover", e_stop);
+      connect(scroller, "drop", operation(onDrop));
+    }
     connect(scroller, "paste", function(){focusInput(); fastPoll();});
     connect(input, "paste", fastPoll);
     connect(input, "cut", operation(function(){
@@ -1881,6 +1883,7 @@ var CodeMirror = (function() {
     fixedGutter: false,
     firstLineNumber: 1,
     readOnly: false,
+    dragDrop: true,
     onChange: null,
     onCursorActivity: null,
     onGutterClick: null,


### PR DESCRIPTION
In the course of building our application, the default drag-and-drop behavior in the editor became a problem, so I added a configuration option to disable it. Drag and drop remains enabled by default.
