### PR TITLE
Fix scrolling flicker in WebKit and IE9+

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -3,6 +3,11 @@
   font-family: monospace;
 }
 
+.CodeMirror.cm-flicker-fix {
+  /* This prevents a scrollbar from showing up on the body in IE. */
+  overflow-y: hidden;
+}
+
 .CodeMirror-scroll {
   overflow: auto;
   height: 300px;
@@ -10,6 +15,39 @@
      is visible outside of the scrolling box. */
   position: relative;
   outline: none;
+}
+
+.CodeMirror.cm-flicker-fix .CodeMirror-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* The .CodeMirror-scrollbar classes are only used if the flickerFix option is set. */
+.CodeMirror-scrollbar {
+  float: right;
+  overflow-x: hidden;
+  overflow-y: scroll;
+
+  /* This corrects for the 1px gap introduced to the left of the scrollbar
+     by the rule for .CodeMirror-scrollbar-inner. */
+  margin-left: -1px;
+}
+.CodeMirror-scrollbar-inner {
+  /* This needs to have a nonzero width in order for the scrollbar to appear 
+     in Firefox and IE9. */
+  width: 1px;
+}
+.CodeMirror-scrollbar.cm-sb-overlap {   
+  /* Ensure that the scrollbar appears in Lion, and that it overlaps the content
+     rather than sitting to the right of it. */
+  position: absolute;
+  z-index: 1;
+  float: none;
+  right: 0;
+  min-width: 12px;
+}
+.CodeMirror-scrollbar.cm-sb-nonoverlap {
+  min-width: 12px;
 }
 
 .CodeMirror-gutter {
@@ -29,6 +67,11 @@
 .CodeMirror-lines {
   padding: .4em;
   white-space: pre;
+  cursor: text;
+}
+.CodeMirror.cm-flicker-fix .CodeMirror-lines * {
+  /* Necessary for throw-scrolling to decelerate properly on Safari. */
+  pointer-events: none;
 }
 
 .CodeMirror pre {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -17,10 +17,17 @@ var CodeMirror = (function() {
     var wrapper = document.createElement("div");
     wrapper.className = "CodeMirror" + (options.lineWrapping ? " CodeMirror-wrap" : "");
     // This mess creates the base DOM structure for the editor.
-    wrapper.innerHTML =
+    var domStructure =
       '<div style="overflow: hidden; position: relative; width: 3px; height: 0px;">' + // Wraps and hides input textarea
         '<textarea style="position: absolute; padding: 0; width: 1px; height: 1em" wrap="off" ' +
-          'autocorrect="off" autocapitalize="off"></textarea></div>' +
+          'autocorrect="off" autocapitalize="off"></textarea></div>';
+    if (options.flickerFix) {
+      domStructure +=
+        '<div class="CodeMirror-scrollbar">' + // The vertical scrollbar. Horizontal scrolling is handled by the scroller itself.
+          '<div class="CodeMirror-scrollbar-inner">' + // The empty scrollbar content, used solely for managing the scrollbar thumb.
+        '</div></div>'; // This must be before the scroll area because it's float-right.
+    }
+    domStructure +=
       '<div class="CodeMirror-scroll" tabindex="-1">' +
         '<div style="position: relative">' + // Set to the height of the text, causes scrolling
           '<div style="position: relative">' + // Moved around its parent to cover visible view
@@ -31,6 +38,7 @@ var CodeMirror = (function() {
               '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor
               '<div style="position: relative; z-index: -1"></div><div></div>' + // DIVs containing the selection and the actual code
             '</div></div></div></div></div>';
+    wrapper.innerHTML = domStructure;
     if (place.appendChild) place.appendChild(wrapper); else place(wrapper);
     // I've never seen more elegant code in my life.
     var inputDiv = wrapper.firstChild, input = inputDiv.firstChild,
@@ -38,7 +46,10 @@ var CodeMirror = (function() {
         mover = code.firstChild, gutter = mover.firstChild, gutterText = gutter.firstChild,
         lineSpace = gutter.nextSibling.firstChild, measure = lineSpace.firstChild,
         cursor = measure.nextSibling, selectionDiv = cursor.nextSibling,
-        lineDiv = selectionDiv.nextSibling;
+        lineDiv = selectionDiv.nextSibling,
+        scrollbar = (options.flickerFix ? inputDiv.nextSibling : null), 
+        scrollbarInner = (options.flickerFix ? scrollbar.firstChild : null),
+        vScrollElt = (options.flickerFix ? scrollbar : scroller);
     themeChanged();
     // Needed to hide big blue blinking cursor on Mobile Safari
     if (ios) input.style.width = "0px";
@@ -50,6 +61,20 @@ var CodeMirror = (function() {
     // Needed to handle Tab key in KHTML
     if (khtml) inputDiv.style.height = "1px", inputDiv.style.position = "absolute";
 
+    if (options.flickerFix) {
+      wrapper.className += " cm-flicker-fix";
+
+      // Check for OS X >= 10.7. If so, we need to force a width on the scrollbar, and 
+      // make it overlap the content. (But we only do this if the scrollbar doesn't already
+      // have a natural width. If the mouse is plugged in or the user sets the system pref
+      // to always show scrollbars, the scrollbar shouldn't overlap.)
+      var osxMatch = /Mac OS X 10\D([\d+])\D/.exec(navigator.userAgent);
+      if (osxMatch && osxMatch[1] && Number(osxMatch[1]) >= 7) {
+        if (scrollbar.offsetWidth <= 1) scrollbar.className += " cm-sb-overlap";
+        else scrollbar.className += " cm-sb-nonoverlap";
+      }
+    }
+    
     // Check for problem with IE innerHTML not working when we have a
     // P (or similar) parent node.
     try { stringWidth("x"); }
@@ -73,7 +98,7 @@ var CodeMirror = (function() {
     var sel = {from: {line: 0, ch: 0}, to: {line: 0, ch: 0}, inverted: false};
     // Selection-related flags. shiftSelecting obviously tracks
     // whether the user is holding shift.
-    var shiftSelecting, lastClick, lastDoubleClick, lastScrollPos = 0, draggingText,
+    var shiftSelecting, lastClick, lastDoubleClick, lastScrollTop = 0, lastScrollLeft = 0, draggingText,
         overwrite = false, suppressEdits = false;
     // Variables used by startOperation/endOperation to track what
     // happened during the operation.
@@ -102,12 +127,13 @@ var CodeMirror = (function() {
     // which point we can't mess with it anymore. Context menu is
     // handled in onMouseDown for Gecko.
     if (!gecko) connect(scroller, "contextmenu", onContextMenu);
-    connect(scroller, "scroll", function() {
-      lastScrollPos = scroller.scrollTop;
-      updateDisplay([]);
-      if (options.fixedGutter) gutter.style.left = scroller.scrollLeft + "px";
-      if (options.onScroll) options.onScroll(instance);
-    });
+    connect(scroller, "scroll", onScroll);
+    if (options.flickerFix) {
+      connect(scrollbar, "scroll", onScroll);
+      connect(scrollbar, "mousedown", function() {setTimeout(focusInput, 0);});
+      connect(scroller, "mousewheel", onMouseWheel);
+      connect(scroller, "DOMMouseScroll", onMouseWheel);
+    }
     connect(window, "resize", function() {updateDisplay(true);});
     connect(input, "keyup", operation(onKeyUp));
     connect(input, "input", fastPoll);
@@ -305,15 +331,15 @@ var CodeMirror = (function() {
       },
       scrollTo: function(x, y) {
         if (x != null) scroller.scrollLeft = x;
-        if (y != null) scroller.scrollTop = y;
+        if (y != null) vScrollElt.scrollTop = y;
         updateDisplay([]);
       },
 
       operation: function(f){return operation(f)();},
       refresh: function(){
         updateDisplay(true);
-        if (scroller.scrollHeight > lastScrollPos)
-          scroller.scrollTop = lastScrollPos;
+        if (vScrollElt.scrollHeight > lastScrollTop)
+          vScrollElt.scrollTop = lastScrollTop;
       },
       getInputField: function(){return input;},
       getWrapperElement: function(){return wrapper;},
@@ -340,6 +366,16 @@ var CodeMirror = (function() {
       return text.join("\n");
     }
 
+    function onScroll(e) {
+      if (lastScrollTop != vScrollElt.scrollTop || lastScrollLeft != scroller.scrollLeft) {
+        lastScrollTop = vScrollElt.scrollTop;
+        lastScrollLeft = scroller.scrollLeft;
+        updateDisplay([]);
+        if (options.fixedGutter) gutter.style.left = scroller.scrollLeft + "px";
+        if (options.onScroll) options.onScroll(instance);
+      }
+    }
+      
     function onMouseDown(e) {
       setShift(e_prop(e, "shiftKey"));
       // Check whether this is a click in a widget
@@ -362,6 +398,7 @@ var CodeMirror = (function() {
         return;
       case 2:
         if (start) setCursor(start.line, start.ch, true);
+        e_preventDefault(e);
         return;
       }
       // For button 1, if it was clicked inside the editor
@@ -612,6 +649,44 @@ var CodeMirror = (function() {
       setTimeout(function() {if (!focused) shiftSelecting = null;}, 150);
     }
 
+    function chopDelta(delta) {
+      // Make sure we always scroll a little bit for any nonzero delta.
+      if (delta > 0.0 && delta < 1.0) return 1;
+      else if (delta > -1.0 && delta < 0.0) return -1;
+      else return Math.round(delta);
+    }
+    
+    function onMouseWheel(e) {
+      var deltaX = 0, deltaY = 0;
+      if (e.type == "DOMMouseScroll") { // Firefox
+        var delta = -e.detail * 8.0;
+        if (e.axis == e.HORIZONTAL_AXIS) deltaX = delta;
+        else if (e.axis == e.VERTICAL_AXIS) deltaY = delta;
+      }
+      else if (e.wheelDeltaX !== undefined && e.wheelDeltaY !== undefined) { // WebKit
+        deltaX = e.wheelDeltaX / 3.0;
+        deltaY = e.wheelDeltaY / 3.0;
+      }
+      else if (e.wheelDelta !== undefined) { // IE or Opera
+        deltaY = e.wheelDelta / 3.0;
+      }
+      
+      var scrolled = false;
+      deltaX = chopDelta(deltaX);
+      deltaY = chopDelta(deltaY);
+      if ((deltaX > 0 && scroller.scrollLeft > 0) ||
+          (deltaX < 0 && scroller.scrollLeft + scroller.clientWidth < scroller.scrollWidth)) {
+        scroller.scrollLeft -= deltaX;
+        scrolled = true;
+      }
+      if ((deltaY > 0 && vScrollElt.scrollTop > 0) ||
+          (deltaY < 0 && vScrollElt.scrollTop + vScrollElt.clientHeight < vScrollElt.scrollHeight)) {
+        vScrollElt.scrollTop -= deltaY;      
+        scrolled = true;
+      }
+      if (scrolled) e_stop(e);
+    }
+
     // Replace the range from from to to by the strings in newText.
     // Afterwards, set the selection to selFrom, selTo.
     function updateLines(from, to, newText, selFrom, selTo) {
@@ -745,8 +820,21 @@ var CodeMirror = (function() {
       setSelection(selFrom, selTo, updateLine(sel.from.line), updateLine(sel.to.line));
 
       // Make sure the scroll-size div has the correct height.
+      updateVerticalScroll();
+    }
+
+    function updateVerticalScroll() {
+      var th = textHeight(), virtualHeight = doc.height * th + 2 * paddingTop();
+      var heightElt = (options.flickerFix ? scrollbarInner : code);
+      if (options.flickerFix) {
+        var scrollbarHeight = scroller.clientHeight;
+        scrollbar.style.display = (virtualHeight > scrollbarHeight) ? "block" : "none";
+        scrollbar.style.height = scrollbarHeight + "px";
+      }
       if (scroller.clientHeight)
-        code.style.height = (doc.height * textHeight() + 2 * paddingTop()) + "px";
+        heightElt.style.height = virtualHeight + "px";
+      // Position the mover div to align with the current virtual scroll position
+      mover.style.top = (displayOffset * th - (options.flickerFix ? scrollbar.scrollTop : 0)) + "px";
     }
 
     function replaceRange(code, from, to) {
@@ -856,7 +944,7 @@ var CodeMirror = (function() {
       // IE returns bogus coordinates when the instance sits inside of an iframe and the cursor is hidden
       if (ie && rect.top == rect.bottom) return;
       var winH = window.innerHeight || Math.max(document.body.offsetHeight, document.documentElement.offsetHeight);
-      if (rect.top < 0 || rect.bottom > winH) cursor.scrollIntoView();
+      if (rect.top < 0 || rect.bottom > winH) scrollCursorIntoView();
     }
     function scrollCursorIntoView() {
       var cursor = localCoords(sel.inverted ? sel.from : sel.to);
@@ -866,9 +954,9 @@ var CodeMirror = (function() {
     function scrollIntoView(x1, y1, x2, y2) {
       var pl = paddingLeft(), pt = paddingTop();
       y1 += pt; y2 += pt; x1 += pl; x2 += pl;
-      var screen = scroller.clientHeight, screentop = scroller.scrollTop, scrolled = false, result = true;
-      if (y1 < screentop) {scroller.scrollTop = Math.max(0, y1); scrolled = true;}
-      else if (y2 > screentop + screen) {scroller.scrollTop = y2 - screen; scrolled = true;}
+      var screen = scroller.clientHeight, screentop = vScrollElt.scrollTop, scrolled = false, result = true;
+      if (y1 < screentop) {vScrollElt.scrollTop = Math.max(0, y1); scrolled = true;}
+      else if (y2 > screentop + screen) {vScrollElt.scrollTop = y2 - screen; scrolled = true;}
 
       var screenw = scroller.clientWidth, screenleft = scroller.scrollLeft;
       var gutterw = options.fixedGutter ? gutter.clientWidth : 0;
@@ -887,7 +975,7 @@ var CodeMirror = (function() {
     }
 
     function visibleLines() {
-      var lh = textHeight(), top = scroller.scrollTop - paddingTop();
+      var lh = textHeight(), top = vScrollElt.scrollTop - paddingTop();
       var from_height = Math.max(0, Math.floor(top / lh));
       var to_height = Math.ceil((top + scroller.clientHeight) / lh);
       return {from: lineAtHeight(doc, from_height),
@@ -904,7 +992,10 @@ var CodeMirror = (function() {
       // Compute the new visible window
       var visible = visibleLines();
       // Bail out if the visible area is already rendered and nothing changed.
-      if (changes !== true && changes.length == 0 && visible.from > showingFrom && visible.to < showingTo) return;
+      if (changes !== true && changes.length == 0 && visible.from > showingFrom && visible.to < showingTo) {
+        if (options.flickerFix) updateVerticalScroll();
+        return;
+      }
       var from = Math.max(visible.from - 100, 0), to = Math.min(doc.size, visible.to + 100);
       if (showingFrom < from && from - showingFrom < 20) from = showingFrom;
       if (showingTo > to && showingTo - to < 20) to = Math.min(doc.size, showingTo);
@@ -922,7 +1013,10 @@ var CodeMirror = (function() {
         if (range.from >= range.to) intact.splice(i--, 1);
         else intactLines += range.to - range.from;
       }
-      if (intactLines == to - from) return;
+      if (intactLines == to - from) {
+        if (options.flickerFix) updateVerticalScroll();
+        return;
+      }
       intact.sort(function(a, b) {return a.domStart - b.domStart;});
 
       var th = textHeight(), gutterDisplay = gutter.style.display;
@@ -930,17 +1024,13 @@ var CodeMirror = (function() {
       patchDisplay(from, to, intact);
       lineDiv.style.display = gutter.style.display = "";
 
-      // Position the mover div to align with the lines it's supposed
-      // to be showing (which will cover the visible display)
       var different = from != showingFrom || to != showingTo || lastSizeC != scroller.clientHeight + th;
       // This is just a bogus formula that detects when the editor is
       // resized or the font size changes.
       if (different) lastSizeC = scroller.clientHeight + th;
       showingFrom = from; showingTo = to;
       displayOffset = heightAtLine(doc, from);
-      mover.style.top = (displayOffset * th) + "px";
-      if (scroller.clientHeight)
-        code.style.height = (doc.height * th + 2 * paddingTop()) + "px";
+      updateVerticalScroll();
 
       // Since this is all rather error prone, it is honoured with the
       // only assertion in the whole file.
@@ -1260,7 +1350,7 @@ var CodeMirror = (function() {
       if (unit == "page") dist = Math.min(scroller.clientHeight, window.innerHeight || document.documentElement.clientHeight);
       else if (unit == "line") dist = textHeight();
       var target = coordsChar(pos.x, pos.y + dist * dir + 2);
-      if (unit == "page") scroller.scrollTop += localCoords(target, true).y - pos.y;
+      if (unit == "page") vScrollElt.scrollTop += localCoords(target, true).y - pos.y;
       setCursor(target.line, target.ch, true);
       goalColumn = pos.x;
     }
@@ -1640,7 +1730,7 @@ var CodeMirror = (function() {
       return coordsChar(x - offL.left, y - offL.top);
     }
     function onContextMenu(e) {
-      var pos = posFromMouse(e), scrollPos = scroller.scrollTop;
+      var pos = posFromMouse(e), scrollPos = vScrollElt.scrollTop;
       if (!pos || window.opera) return; // Opera is difficult.
       if (posEq(sel.from, sel.to) || posLess(pos, sel.from) || !posLess(pos, sel.to))
         operation(setCursor)(pos.line, pos.ch);
@@ -1659,7 +1749,7 @@ var CodeMirror = (function() {
         if (newVal != val) operation(replaceSelection)(newVal, "end");
         inputDiv.style.position = "relative";
         input.style.cssText = oldCSS;
-        if (ie_lt9) scroller.scrollTop = scrollPos;
+        if (ie_lt9) vScrollElt.scrollTop = scrollPos;
         leaveInputAlone = false;
         resetInput(true);
         slowPoll();
@@ -1893,7 +1983,8 @@ var CodeMirror = (function() {
     pollInterval: 100,
     undoDepth: 40,
     tabindex: null,
-    autofocus: null
+    autofocus: null,
+    flickerFix: !/Firefox/.test(navigator.userAgent) && !/MSIE [1-8]\b/.test(navigator.userAgent)
   };
 
   var ios = /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent);


### PR DESCRIPTION
The current CodeMirror virtual scrolling approach relies on sliding the "mover" div around within a large scroll region as the user scrolls. In Firefox, this looks fine, but in Chrome, Safari, and IE, scrolling in large documents is flickery--portions of the code flash in and out during scrolling. This is because the browser actually moves the mover div offscreen during the scroll before CodeMirror gets a chance to reposition the div, causing some or all of the scroller to draw a blank square briefly before the mover div is repositioned.

This pull request introduces a new "flickerFix" option which is true by default in all browsers except Firefox and IE <9 (see below for explanation why). With flickerFix set to true, we suppress the standard vertical scrollbar within the scroller itself, and create a separate div that's exactly the width of its scrollbar. Within that div, we create a tall inner div that's set to the virtual height of the document--this inner div is invisible (and always blank), but lets us set the scroll thumb position and size of the scrollbar. In the main scroll region, the mover div only slides around a (relatively) small amount in order to match its top visible pixel with the virtual scroll position--it never slides all the way off the screen. This eliminates the flicker.

From the point of view of other code within CodeMirror, the only difference is that any code which needs to access the scrollTop or scrollHeight of the scroller div now needs to look at "vScrollElt" instead. With flickerFix off, this is just set to the scroller as in the original code, but with flickerFix on it's set to the vertical scrollbar. Horizontal scrolling is still handled by the scroller itself.

In addition to listening to onScroll events from the separate scrollbar, we also listen to mousewheel/touch scroll events on the scroller itself and handle them manually for vertical scrolls.

There is a little messiness in the CSS for dealing with OS X Lion. In that case, we need to make the scrollbar overlap the content (the OS takes care of auto-hiding it when it's not in use). We also have to prop open the scrollbar div to a minimum width in some browsers.

As noted above, we disable the new flicker-fix code on Firefox and IE <9 by default. In the case of Firefox, the original approach doesn't flicker anyway, and we found that touch scrolling felt less smooth with the flicker-fix code because of the limited resolution of the mousewheel events that Firefox generates during a touch-throw scroll. (Aside from that, though, the flicker-fix code does work fine in Firefox.)

In the case of IE <9, we ran into some browser bugs, and rather than trying to build nasty workarounds into the flicker-fix code, we felt that it was better to just explicitly not support those older versions of IE.

We've tested the new flicker-fix approach in the most recent versions of Chrome, Safari and IE9. We also tested Firefox and IE 7/8 to make sure that the old scrolling code is still working properly in those cases (i.e., we didn't break the old behavior). We tested all browsers on Windows XP, Windows 7, Mac OS X Snow Leopard (10.6), and Mac OS X Lion (10.7).

I'll add some line notes to the diffs to explain some of the less obvious bits of code.
# 

Legalese: The attached code is covered by the MIT license as follows.

Copyright ©2012 Adobe Systems Incorporated. All Rights Reserved.

Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
