### PR TITLE
Update list of self-closers.

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -1,8 +1,10 @@
 CodeMirror.defineMode("xml", function(config, parserConfig) {
   var indentUnit = config.indentUnit;
   var Kludges = parserConfig.htmlMode ? {
-    autoSelfClosers: {"br": true, "img": true, "hr": true, "link": true, "input": true,
-                      "meta": true, "col": true, "frame": true, "base": true, "area": true},
+    autoSelfClosers: {'area': true, 'base': true, 'br': true, 'col': true, 'command': true,
+                      'embed': true, 'frame': true, 'hr': true, 'img': true, 'input': true,
+                      'keygen': true, 'link': true, 'meta': true, 'param': true, 'source': true,
+                      'track': true, 'wbr': true},
     doNotIndent: {"pre": true},
     allowUnquoted: true,
     allowMissing: false


### PR DESCRIPTION
New list is taken from http://www.w3.org/TR/html-markup/syntax.html#void-element
Plus obsolete "frame" tag.
