### PR TITLE
Fix off-by-one error in deciding whether to recompute max line length

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -648,7 +648,7 @@ var CodeMirror = (function() {
       if (suppressEdits) return;
       var recomputeMaxLength = false, maxLineLength = maxLine.length;
       if (!options.lineWrapping)
-        doc.iter(from.line, to.line, function(line) {
+        doc.iter(from.line, to.line + 1, function(line) {
           if (line.text.length == maxLineLength) {recomputeMaxLength = true; return true;}
         });
       if (from.line != to.line || newText.length > 1) gutterDirty = true;


### PR DESCRIPTION
While working on some other functionality I noticed that the logic for deciding whether to recompute the maximum line length didn't seem to be working properly--in particular, as you add more characters to the longest line by typing into it, it wasn't resetting the maximum length. I think it's an off-by-one error due to the fact that doc.iter() excludes the last line in the range you pass to it, hence this proposed fix.

I don't know of a user-visible error that this causes (the scroller seems to update itself properly anyway, because it takes into account the actual width of all descendants)--but some other code that I'm working on in my app depends on the width of the lineSpace being correct. (I know, it probably shouldn't :)) However, it seems worth having the logic be correct here.
