### PR TITLE
Folding by tag & brace now both show matching end by default, plus option to hide

### DIFF
--- a/lib/util/foldcode.js
+++ b/lib/util/foldcode.js
@@ -1,7 +1,7 @@
 // the tagRangeFinder function is
 //   Copyright (C) 2011 by Daniel Glazman <daniel@glazman.org>
 // released under the MIT license (../../LICENSE) like the rest of CodeMirror
-CodeMirror.tagRangeFinder = function(cm, line, hideEnd) {
+CodeMirror.tagRangeFinder = function(cm, line) {
   var nameStartChar = "A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
   var nameChar = nameStartChar + "\-\.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
   var xmlNAMERegExp = new RegExp("^[" + nameStartChar + "][" + nameChar + "]*");
@@ -36,10 +36,8 @@ CodeMirror.tagRangeFinder = function(cm, line, hideEnd) {
           var slash = lt.lastIndexOf("/", gt);
           if (-1 != slash && slash < gt) {
             var str = lineText.substr(slash, gt - slash + 1);
-            if (!str.match( /\/\s*\>/ )) { // yep, that's the end of empty tag
-              if (hideEnd === true) l++;
+            if (!str.match( /\/\s*\>/ )) // yep, that's the end of empty tag
               return l;
-            }
           }
         }
         l++;
@@ -97,10 +95,8 @@ CodeMirror.tagRangeFinder = function(cm, line, hideEnd) {
             depth--;
           else
             depth++;
-          if (!depth) {
-            if (hideEnd === true) l++;
+          if (!depth)
             return l;
-          }
         }
       }
       l++;
@@ -109,7 +105,7 @@ CodeMirror.tagRangeFinder = function(cm, line, hideEnd) {
   }
 };
 
-CodeMirror.braceRangeFinder = function(cm, line, hideEnd) {
+CodeMirror.braceRangeFinder = function(cm, line) {
   var lineText = cm.getLine(line);
   var startChar = lineText.lastIndexOf("{");
   if (startChar < 0 || lineText.lastIndexOf("}") > startChar) return;
@@ -131,7 +127,6 @@ CodeMirror.braceRangeFinder = function(cm, line, hideEnd) {
     }
   }
   if (end == null || end == line + 1) return;
-  if (hideEnd === true) end++;
   return end;
 };
 
@@ -174,7 +169,8 @@ CodeMirror.newFoldFunction = function(rangeFinder, markText, hideEnd) {
         folded.splice(known.pos, 1);
         expand(cm, known.region);
       } else {
-        var end = rangeFinder(cm, line, hideEnd);
+        var end = rangeFinder(cm, line);
+        if (rangeFinder !== CodeMirror.indentRangeFinder && hideEnd === true) end++;
         if (end == null) return;
         var hidden = [];
         for (var i = line + 1; i < end; ++i) {


### PR DESCRIPTION
Matching end tag not folded away by default (now the same as folding by brace or indent)
hideEnd param added to brace & tag finder funcs to optionally fold end away or not (via true value)
No changes to indentRangeFinder func
