### PR TITLE
A few improvements to the Vim keymap to start with

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -94,8 +94,8 @@
     "Shift-A": function(cm) {popCount(); CodeMirror.commands.goLineEnd(cm); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
     "I": function(cm) {popCount(); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
     "Shift-I": function(cm) {popCount(); goLineStartText(cm); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
-    "O": function(cm) {popCount(); CodeMirror.commands.goLineEnd(cm); cm.replaceSelection("\n", "end"); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
-    "Shift-O": function(cm) {popCount(); CodeMirror.commands.goLineStart(cm); cm.replaceSelection("\n", "start"); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
+    "O": function(cm) {popCount(); CodeMirror.commands.goLineEnd(cm); CodeMirror.commands.newlineAndIndent(cm); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
+    "Shift-O": function(cm) {popCount(); CodeMirror.commands.goLineStart(cm); cm.replaceSelection("\n", "start"); cm.indentLine(cm.getCursor().line); cm.setOption("keyMap", "vim-insert"); editCursor("vim-insert");},
     "G": function(cm) {cm.setOption("keyMap", "vim-prefix-g");},
     "D": function(cm) {cm.setOption("keyMap", "vim-prefix-d"); emptyBuffer();},
     "Shift-D": function(cm) {
@@ -218,6 +218,7 @@
   };
 
   CodeMirror.keyMap["vim-insert"] = {
+    // TODO: override navigation keys so that Esc will cancel automatic indentation from o, O, i_<CR>
     "Esc": function(cm) {
       cm.setCursor(cm.getCursor().line, cm.getCursor().ch-1, true); 
       cm.setOption("keyMap", "vim");


### PR DESCRIPTION
I intend to make many more improvements, but these were a few that I did just now from my initial testing of basic editing, to get started with.

My only concerns with these is that `^` must be done as `Shift-6` and `|` as `Shift-\` (and also <code>Shift-`</code> which is already there to get `~`). I have tested it briefly on a Telugu keyboard layout I had handy which doesn't use the numbers but does have the carat on what would normally be the 6 key and it works, but I'm not certain whether it will with a genuine international keyboard? At the very least, it ends up a rather unpleasant way to write it (as it requires knowledge of the US International keyboard to recognise the code). Anyway, that's getting outside the scope of this pull request.
