### PR TITLE
Harmonized Tiddlywiki styling

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -112,7 +112,7 @@ div.CodeMirror-selected { background: #d9d9d9; }
 .cm-s-default span.cm-bracket {color: #cc7;}
 .cm-s-default span.cm-tag {color: #170;}
 .cm-s-default span.cm-attribute {color: #00c;}
-.cm-s-default span.cm-header {color: #a0a;}
+.cm-s-default span.cm-header {color: blue;}
 .cm-s-default span.cm-quote {color: #090;}
 .cm-s-default span.cm-hr {color: #999;}
 .cm-s-default span.cm-link {color: #00c;}

--- a/mode/tiddlywiki/tiddlywiki.css
+++ b/mode/tiddlywiki/tiddlywiki.css
@@ -1,21 +1,14 @@
-.cm-s-default span.cm-header {color: blue; font-weight:bold;}
-.cm-s-default span.cm-code {color: #a50;}
-.cm-s-default span.cm-code-inline {color: #660;}
-
-.cm-s-default span.cm-quote {color: #555;}
-.cm-s-default span.cm-list {color: #c60;}
-.cm-s-default span.cm-hr {color: #999;}
-.cm-s-default span.cm-em {font-style: italic;}
-.cm-s-default span.cm-strong {font-weight: bold;}
-
-.cm-s-default span.cm-link-external {color: blue;}
-.cm-s-default span.cm-brace {color: #170; font-weight: bold;}
-.cm-s-default span.cm-macro {color: #9E3825;}
-.cm-s-default span.cm-table {color: blue; font-weight: bold;}
-.cm-s-default span.cm-warning {color: red; font-weight: bold;}
-
-.cm-s-default span.cm-underlined {text-decoration: underline;}
-.cm-s-default span.cm-line-through {text-decoration: line-through;}
-
-.cm-s-default span.cm-comment {color: #666;}
-
+span.cm-underlined {
+  text-decoration: underline;
+}
+span.cm-strikethrough {
+  text-decoration: line-through;
+}
+span.cm-brace {
+  color: #170;
+  font-weight: bold;
+}
+span.cm-table {
+  color: blue;
+  font-weight: bold;
+}

--- a/mode/tiddlywiki/tiddlywiki.js
+++ b/mode/tiddlywiki/tiddlywiki.js
@@ -107,10 +107,10 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 				return ret('quote', 'quote');
 			}
 			if (stream.match(reWikiCommentStart) || stream.match(reWikiCommentStop)) {
-				return ret('code', 'code');
+				return ret('code', 'comment');
 			}
 			if (stream.match(reJsCodeStart) || stream.match(reJsCodeStop) || stream.match(reXmlCodeStart) || stream.match(reXmlCodeStop)) {
-				return ret('code', 'code');
+				return ret('code', 'comment');
 			}
 			if (stream.match(reHR)) {
 				return ret('hr', 'hr');
@@ -125,26 +125,26 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 			}
 			if (ch == "*") { // tw list
 				stream.eatWhile('*');
-				return ret("list", "list");
+				return ret("list", "comment");
 			}
 			if (ch == "#") { // tw numbered list
 				stream.eatWhile('#');
-				return ret("list", "list");
+				return ret("list", "comment");
 			}
 			if (ch == ";") { // definition list, term
 				stream.eatWhile(';');
-				return ret("list", "list");
+				return ret("list", "comment");
 			}
 			if (ch == ":") { // definition list, description
 				stream.eatWhile(':');
-				return ret("list", "list");
+				return ret("list", "comment");
 			}
 			if (ch == ">") { // single line quote
 				stream.eatWhile(">");
 				return ret("quote", "quote");
 			}
 			if (ch == '|') {
-				return ret('table', 'table');
+				return ret('table', 'header');
 			}
 		}
 
@@ -155,7 +155,7 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 		// rudimentary html:// file:// link matching. TW knows much more ...
 		if (/[hf]/i.test(ch)) {
 			if (/[ti]/i.test(stream.peek()) && stream.match(/\b(ttps?|tp|ile):\/\/[\-A-Z0-9+&@#\/%?=~_|$!:,.;]*[A-Z0-9+&@#\/%=~_|$]/i)) {
-				return ret("link-external", "link-external");
+				return ret("link", "link");
 			}
 		}
 		// just a little string indicator, don't want to have the whole string covered
@@ -173,7 +173,7 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 		}
 		if (ch == "@") {	// check for space link. TODO fix @@...@@ highlighting
 			stream.eatWhile(isSpaceName);
-			return ret("link-external", "link-external");
+			return ret("link", "link");
 		}
 		if (/\d/.test(ch)) {	// numbers
 			stream.eatWhile(/\d/);
@@ -266,21 +266,21 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 		var ch, sb = state.block;
 		
 		if (sb && stream.current()) {
-			return ret("code", "code");
+			return ret("code", "comment");
 		}
 
 		if (!sb && stream.match(reUntilCodeStop)) {
 			state.tokenize = jsTokenBase;
-			return ret("code", "code-inline");
+			return ret("code", "comment");
 		}
 
 		if (sb && stream.sol() && stream.match(reCodeBlockStop)) {
 			state.tokenize = jsTokenBase;
-			return ret("code", "code");
+			return ret("code", "comment");
 		}
 
 		ch = stream.next();
-		return (sb) ? ret("code", "code") : ret("code", "code-inline");
+		return (sb) ? ret("code", "comment") : ret("code", "comment");
 	}
 
 	// tw em / italic
@@ -324,7 +324,7 @@ CodeMirror.defineMode("tiddlywiki", function (config, parserConfig) {
 			}
 			maybeEnd = (ch == "-");
 		}
-		return ret("text", "line-through");
+		return ret("text", "strikethrough");
 	}
 
 	// macro


### PR DESCRIPTION
We concatenate every CSS file into a single bundle, and Tiddlywiki's CSS file was breaking a lot of standard styles. I reset styling to standard where possible, and the custom styles left don't break anything.

Also, I changed the default theme's header color from `#a0a` to `blue`. This is what Tiddlywiki had and I find that color much nicer than the default purple, but this is debatable.
