### PR TITLE
loadmode plugin does not work over non string modes

### DIFF
--- a/lib/util/loadmode.js
+++ b/lib/util/loadmode.js
@@ -21,10 +21,13 @@
   }
 
   CodeMirror.requireMode = function(mode, cont) {
+    mode = typeof mode == 'object' ? mode.name : mode;
+    
     if (CodeMirror.modes.hasOwnProperty(mode)) return ensureDeps(mode, cont());
     if (loading.hasOwnProperty(mode)) return loading[mode].push(cont);
 
     var script = document.createElement("script");
+    
     script.src = CodeMirror.modeURL.replace(/%N/g, mode);
     var others = document.getElementsByTagName("script")[0];
     others.parentNode.insertBefore(script, others);


### PR DESCRIPTION
The json mode works with the mode being `{name:'javascript',json:true}`. 

Running 

```
CodeMirror.autoLoadMode(editor,{name:'javascript',json:true});
```

results in mode being converted to string and not being loaded. A simple type check for mode being an object fixes this (in loadmode.js)

```
mode = typeof mode == 'object' ? mode.name : mode;
```
