### PR TITLE
Ignore hidden lines when determining maximum line length

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -78,7 +78,7 @@ var CodeMirror = (function() {
     // Variables used by startOperation/endOperation to track what
     // happened during the operation.
     var updateInput, userSelChange, changes, textChanged, selectionChanged, leaveInputAlone,
-        gutterDirty, callbacks;
+        gutterDirty, callbacks, maxLengthChanged;
     // Current visible range (may be bigger than the view window).
     var displayOffset = 0, showingFrom = 0, showingTo = 0, lastSizeC = 0;
     // bracketHighlighted is used to remember that a bracket has been
@@ -669,7 +669,7 @@ var CodeMirror = (function() {
       var recomputeMaxLength = false, maxLineLength = maxLine.length;
       if (!options.lineWrapping)
         doc.iter(from.line, to.line + 1, function(line) {
-          if (line.text.length == maxLineLength) {recomputeMaxLength = true; return true;}
+          if (!line.hidden && line.text.length == maxLineLength) {recomputeMaxLength = true; return true;}
         });
       if (from.line != to.line || newText.length > 1) gutterDirty = true;
 
@@ -725,20 +725,12 @@ var CodeMirror = (function() {
       } else {
         doc.iter(from.line, from.line + newText.length, function(line) {
           var l = line.text;
-          if (l.length > maxLineLength) {
+          if (!line.hidden && l.length > maxLineLength) {
             maxLine = l; maxLineLength = l.length; maxWidth = null;
             recomputeMaxLength = false;
           }
         });
-        if (recomputeMaxLength) {
-          maxLineLength = 0; maxLine = ""; maxWidth = null;
-          doc.iter(0, doc.size, function(line) {
-            var l = line.text;
-            if (l.length > maxLineLength) {
-              maxLineLength = l.length; maxLine = l;
-            }
-          });
-        }
+        if (recomputeMaxLength) computeMaxLength();
       }
 
       // Add these lines to the work array, so that they will be
@@ -769,6 +761,18 @@ var CodeMirror = (function() {
       // Make sure the scroll-size div has the correct height.
       if (scroller.clientHeight)
         code.style.height = (doc.height * textHeight() + 2 * paddingTop()) + "px";
+    }
+    
+    function computeMaxLength() {
+      var maxLineLength = 0; 
+      maxLine = ""; maxWidth = null;
+      doc.iter(0, doc.size, function(line) {
+        var l = line.text;
+        if (!line.hidden && l.length > maxLineLength) {
+          maxLineLength = l.length; maxLine = l;
+        }
+      });
+      maxLengthChanged = false;
     }
 
     function replaceRange(code, from, to) {
@@ -1494,6 +1498,16 @@ var CodeMirror = (function() {
       return changeLine(handle, function(line, no) {
         if (line.hidden != hidden) {
           line.hidden = hidden;
+          if (!options.lineWrapping) {
+            var l = line.text;
+            if (hidden && l.length == maxLine.length) {
+              maxLengthChanged = true;
+            }
+            else if (!hidden && l.length > maxLine.length) {
+              maxLine = l; maxWidth = null;
+              maxLengthChanged = false;
+            }
+          }
           updateLineHeight(line, hidden ? 0 : 1);
           var fline = sel.from.line, tline = sel.to.line;
           if (hidden && (fline == no || tline == no)) {
@@ -1846,6 +1860,7 @@ var CodeMirror = (function() {
     }
     function endOperation() {
       var reScroll = false, updated;
+      if (maxLengthChanged) computeMaxLength();
       if (selectionChanged) reScroll = !scrollCursorIntoView();
       if (changes.length) updated = updateDisplay(changes, true);
       else {


### PR DESCRIPTION
Per our discussion on the mailing list, this patch makes it so that the maximum line length only takes visible lines into account.

Besides ignoring hidden lines in various places where we check the max length, the main logical change is in `setLineHidden()`:
1. If we're showing a line that's longer than the current longest line, then the shown line is the new longest line.
2. If we're hiding the current longest line, recompute the max line by scanning the whole document. 
*\* This sounds wasteful, but it's the same thing `updateLinesNoUndo()` does if the longest line is dirtied and no new line in the replacement is of greater length.

To do this, I refactored out the code in `updateLinesNoUndo()` that scans the whole doc to determine the longest line (into `computeMaxLength()`). There's a new global flag, `maxLengthChanged`, which `setLineHidden()` sets in the second case above, and which causes `computeMaxLength()` to be called in `endOperation()`. That way, we only rescan the document at most once during an operation.
