### PR TITLE
Fix coffeescript comments with 4 #

### DIFF
--- a/mode/coffeescript/coffeescript.js
+++ b/mode/coffeescript/coffeescript.js
@@ -60,6 +60,12 @@ CodeMirror.defineMode('coffeescript', function(conf) {
 
         var ch = stream.peek();
 
+        // Handle docco title comment (single line)
+        if (stream.match("####")) {
+            stream.skipToEnd();
+            return 'comment';
+        }
+
         // Handle multi line comments
         if (stream.match("###")) {
             state.tokenize = longComment;

--- a/mode/coffeescript/index.html
+++ b/mode/coffeescript/index.html
@@ -46,10 +46,16 @@ root = this
 # Save the previous value of the `_` variable.
 previousUnderscore = root._
 
+### Multiline
+    comment
+###
 
 # Establish the object that gets thrown to break out of a loop iteration.
 # `StopIteration` is SOP on Mozilla.
 breaker = if typeof(StopIteration) is 'undefined' then '__break__' else StopIteration
+
+
+#### Docco style single line comment (title)
 
 
 # Helper function to escape **RegExp** contents, because JS doesn't have one.


### PR DESCRIPTION
I've found that when a comment line has 4 # it makes everything bellow appear as comment. This special formatting is used by docco to create title (http://jashkenas.github.com/docco/)

The issue appear because it first check if the stream match "###" which it does (but it's a single line comment).
