### PR TITLE
Scheme mode bracket matching

### DIFF
--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -132,8 +132,6 @@ CodeMirror.defineMode("scheme", function (config, mode) {
                         }else{
                             returnType = null;
                         }
-                    } else if (isNumber(ch,stream)){
-                        returnType = NUMBER;
                     } else if (ch == "(" || ch == "[") {
                         var keyWord = ''; var indentTemp = stream.column();
                         /**
@@ -178,6 +176,8 @@ CodeMirror.defineMode("scheme", function (config, mode) {
                                 }
                             }
                         }
+                    } else if (isNumber(ch,stream)){
+                        returnType = NUMBER;
                     } else {
                         stream.eatWhile(/[\w\$_\-!$%&*+\.\/:<=>?@\^~]/);
 


### PR DESCRIPTION
Number parsing was in many cases eating brackets and tagging them as numbers.  This completely broke bracket matching since some brackets were numbers while other were really brackets.

For example, "( foo)" would result in a correct match whereas "(foo)" would not.

I prioritized the bracket tests ahead of the number matching to resolve this.  Shouldn't break anything.
