### PR TITLE
fix scheme number parsing

### DIFF
--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -110,8 +110,8 @@ CodeMirror.defineMode("scheme", function (config, mode) {
                     } else if (ch == ";") { // comment
                         stream.skipToEnd(); // rest of the line is a comment
                         returnType = COMMENT;
-                    } else if (/\d/.test(ch) && stream.match(/$|\d+(?:\/\d+|(?:\.\d+)?(?:[eE][+\-]?\d+)?)\b/) ||
-                               ch == "-" && stream.match(/\d+(?:\/\d+|(?:\.\d+)?(?:[eE][+\-]?\d+)?)\b/)) {
+                    } else if (/\d/.test(ch) && stream.match(/$|^\d*(?:\/\d+|(?:\.\d+)?(?:[eE][+\-]?\d+)?)\b/) ||
+                               ch == "-" && stream.match(/^\d+(?:\/\d+|(?:\.\d+)?(?:[eE][+\-]?\d+)?)\b/)) {
                         returnType = NUMBER;
                     } else if (ch == "(" || ch == "[") {
                         var keyWord = ''; var indentTemp = stream.column();


### PR DESCRIPTION
The latest fix introduced a new bug that was causing number regexes to match too far ahead of the current position.

For example, when parsing `((foo 3) 4)`, the `stream.match` following `/\d/.test("3")` would match ahead to the following `4`, causing the stream to skip a single character over `)` and yielding a number token `3)`.

Likewise, parsing `((foo -) 4)` would behave similarly and yield `-)` as a number token.

This change includes two slightly stricter patterns that solve the problem.
