### PR TITLE
Fixed bug with duplicating formatted text

### DIFF
--- a/lib/util/formatting.js
+++ b/lib/util/formatting.js
@@ -84,7 +84,8 @@ CodeMirror.modeExtensions["css"] = {
   commentStart: "/*",
   commentEnd: "*/",
   wordWrapChars: [";", "\\{", "\\}"],
-  autoFormatLineBreaks: function (text) {
+  autoFormatLineBreaks: function (text, startPos, endPos) {
+    text = text.substring(startPos, endPos);
     return text.replace(new RegExp("(;|\\{|\\})([^\r\n])", "g"), "$1\n$2");
   }
 };
@@ -125,7 +126,8 @@ CodeMirror.modeExtensions["javascript"] = {
     return nonBreakableBlocks;
   },
 
-  autoFormatLineBreaks: function (text) {
+  autoFormatLineBreaks: function (text, startPos, endPos) {
+    text = text.substring(startPos, endPos);
     var curPos = 0;
     var reLinesSplitter = new RegExp("(;|\\{|\\})([^\r\n])", "g");
     var nonBreakableBlocks = this.getNonBreakableBlocks(text);
@@ -158,7 +160,8 @@ CodeMirror.modeExtensions["xml"] = {
   commentEnd: "-->",
   wordWrapChars: [">"],
 
-  autoFormatLineBreaks: function (text) {
+  autoFormatLineBreaks: function (text, startPos, endPos) {
+    text = text.substring(startPos, endPos);
     var lines = text.split("\n");
     var reProcessedPortion = new RegExp("(^\\s*?<|^[^<]*?)(.+)(>\\s*?$|[^>]*?$)");
     var reOpenBrackets = new RegExp("<", "g");


### PR DESCRIPTION
In CSS/XML/JavaScript when only a part of the code, not the entire code, is formatted, formatting.js replaces the selection with the entire code in reformatted form, not with the expected reformatted text snippet. The change fixes the problem.
