### PR TITLE
Fix Scala mode demo to work with new scrolling behavior

### DIFF
--- a/mode/clike/scala.html
+++ b/mode/clike/scala.html
@@ -13,6 +13,7 @@
         margin: 0;
         padding: 0;
         max-width:inherit;
+        height: 100%;
       }
       html, form, .CodeMirror, .CodeMirror-scroll
       {


### PR DESCRIPTION
Fixes #559 by setting the height of `body` to 100% (in addition to setting all the other parent heights to 100%).

In the original scrolling scheme, this actually wasn't working correctly either, though the behavior was better; it was essentially setting the height of the CodeMirror editor to be the full height of its content, meaning that no virtual scrolling was taking place (the vertical scrollbar being shown was the browser's body scrollbar, not the CodeMirror scroller's scrollbar) and the horizontal scrollbar was actually at the bottom of the entire scroll area, not the bottom of the window.

Tested this in Chrome/Safari/FF on Mac and IE9 on Win.
