### PR TITLE
Move drag handling to scroller to fix drag-and-drop on WebKit/Firefox

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -47,7 +47,7 @@ var CodeMirror = (function() {
     themeChanged(); keyMapChanged();
     // Needed to hide big blue blinking cursor on Mobile Safari
     if (ios) input.style.width = "0px";
-    if (!webkit) lineSpace.draggable = true;
+    if (!webkit) scroller.draggable = true;
     lineSpace.style.outline = "none";
     if (options.tabindex != null) input.tabIndex = options.tabindex;
     if (options.autofocus) focusInput();
@@ -131,7 +131,7 @@ var CodeMirror = (function() {
     connect(input, "blur", onBlur);
 
     if (options.dragDrop) {
-      connect(lineSpace, "dragstart", onDragStart);
+      connect(scroller, "dragstart", onDragStart);
       function drag_(e) {
         if (options.onDragEvent && options.onDragEvent(instance, addStop(e))) return;
         e_stop(e);
@@ -421,9 +421,9 @@ var CodeMirror = (function() {
       if (options.dragDrop && dragAndDrop && !options.readOnly && !posEq(sel.from, sel.to) &&
           !posLess(start, sel.from) && !posLess(sel.to, start)) {
         // Let the drag handler handle this.
-        if (webkit) lineSpace.draggable = true;
+        if (webkit) scroller.draggable = true;
         function dragEnd(e2) {
-          if (webkit) lineSpace.draggable = false;
+          if (webkit) scroller.draggable = false;
           draggingText = false;
           up(); drop();
           if (Math.abs(e.clientX - e2.clientX) + Math.abs(e.clientY - e2.clientY) < 10) {
@@ -436,7 +436,7 @@ var CodeMirror = (function() {
         var drop = connect(scroller, "drop", operation(dragEnd), true);
         draggingText = true;
         // IE's approach to draggable
-        if (lineSpace.dragDrop) lineSpace.dragDrop();
+        if (scroller.dragDrop) scroller.dragDrop();
         return;
       }
       e_preventDefault(e);


### PR DESCRIPTION
Fixes the issue reported in this forum thread: https://groups.google.com/forum/?fromgroups#!topic/codemirror/XA2N040PzuQ (see last few messages)

My scrolling changes broke drag-and-drop in WebKit and Firefox due to the setting of "pointer-events: none" on the lineSpace (which was necessary to make throw scrolling work properly in Safari). To fix this, we now handle drag-and-drop on the scroller instead of the lineSpace.

The behavior after this fix appears to be the same as it was in v2.25:
- Chrome: works
- Firefox: works, but mouse cursor does not change to drag cursor
- Safari: works, but drag proxy looks very weird, like a partial copy of the lineSpace with a blank area at the bottom (is this a known issue? confirmed it happens in 2.25)
- IE9: works
- IE7/8: no drag/drop

Let me know if that doesn't match your expectation for where and how drag/drop should be working.
