### PR TITLE
Fix resize demo (and sample code) to work with new scrolling approach

### DIFF
--- a/demo/resize.html
+++ b/demo/resize.html
@@ -15,7 +15,6 @@
         height: auto;
         overflow-y: hidden;
         overflow-x: auto;
-        width: 100%;
       }
     </style>
   </head>
@@ -27,7 +26,6 @@
   height: auto;
   overflow-y: hidden;
   overflow-x: auto;
-  width: 100%
 }</textarea></form>
 
 <p>By setting a few CSS properties, CodeMirror can be made to


### PR DESCRIPTION
Fixes one of the problems mentioned in this thread: https://groups.google.com/forum/?fromgroups#!topic/codemirror/cN_494YVlCw

The original resize.html demo had width: 100% set on the scroller, which doesn't work with the new scrolling code. Removing this doesn't seem to break the demo. Tested on Chrome/FF/Safari, IE 7/8/9.
