### PR TITLE
[gfm mode] Fix: autolinks. New: double bracket links, latex formulas.

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -69,7 +69,7 @@ CodeMirror.defineMode("gfm", function(config, parserConfig) {
   function handleText(stream, mdState) {
     var match;
     if (stream.match(/^\w+:\/\/\S+/)) {
-      return 'linkhref';
+      return 'link';
     }
     if (stream.match(/^[^\[*\\<>` _][^\[*\\<>` ]*[^\[*\\<>` _]/)) {
       return mdMode.getType(mdState);
@@ -102,7 +102,43 @@ CodeMirror.defineMode("gfm", function(config, parserConfig) {
     },
 
     token: function(stream, state) {
-      return state.token(stream, state);
+        /* Parse GFM double bracket links */
+        if ((ch = stream.peek()) != undefined && ch == '[') {
+            stream.next(); // Advance the stream
+
+            /* Only handle double bracket links */
+            if ((ch = stream.peek()) == undefined || ch != '[') {
+                stream.backUp(1);
+                return state.token(stream, state);
+            } 
+
+            while ((ch = stream.next()) != undefined && ch != ']') {}
+
+            if (ch == ']' && (ch = stream.next()) != undefined && ch == ']') 
+                return 'link';
+
+            /* If we did not find the second ']' */
+            stream.backUp(1);
+        }
+
+        /* Match GFM latex formulas, as well as latex formulas within '$' */
+        if (stream.match(/^\$[^\$]+\$/)) {
+            return "string";
+        }
+
+        if (stream.match(/^\\\((.*?)\\\)/)) {
+            return "string";
+        }
+
+        if (stream.match(/^\$\$[^\$]+\$\$/)) {
+            return "string";
+        }
+        
+        if (stream.match(/^\\\[(.*?)\\\]/)) {
+            return "string";
+        }
+
+        return state.token(stream, state);
     }
   }
 }, "markdown");


### PR DESCRIPTION
Autolinks were not being displayed as such in the editor, I suppose it's a bug, changed
`linkhref` to `link` in line 72 to fix it.

Added support for GFM double bracket links. `[[link]]` is now displayed
correctly as a link by the editor.

Added coloring support for latex formulas, usage of
- `$formula$`,
- `$$formula$$`,
- `\( formula \)`, and
- `\[ formula \]`
  will now be highlighted with the same coloring used for strings.

Even though the latex `$` and `$$` syntax is not supported by GFM, I would like it to be, so that is why I preferred to add it :)
