### PR TITLE
Round off fractional pixel in virtual scroll height calculation

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -823,7 +823,7 @@ var CodeMirror = (function() {
     }
 
     function updateVerticalScroll(scrollTop) {
-      var th = textHeight(), virtualHeight = doc.height * th + 2 * paddingTop(), scrollbarHeight = scroller.clientHeight;
+      var th = textHeight(), virtualHeight = Math.floor(doc.height * th + 2 * paddingTop()), scrollbarHeight = scroller.clientHeight;
       scrollbar.style.height = scrollbarHeight + "px";
       if (scroller.clientHeight)
         scrollbarInner.style.height = virtualHeight + "px";
@@ -1093,7 +1093,7 @@ var CodeMirror = (function() {
         // after the scrollbar appears (during updateVerticalScroll()). Only do this if the scrollbar is
         // appearing (if it's disappearing, we don't have to worry about the scroll position, and there are
         // issues on IE7 if we turn it off too early).
-        var virtualHeight = doc.height * th + 2 * paddingTop(), scrollbarHeight = scroller.clientHeight;
+        var virtualHeight = Math.floor(doc.height * th + 2 * paddingTop()), scrollbarHeight = scroller.clientHeight;
         if (virtualHeight > scrollbarHeight) scrollbar.style.display = "block";
         checkHeights();
       } else {


### PR DESCRIPTION
This fixes an off-by-one error that causes a scrollbar to sometimes show up when CodeMirror is in autoresize mode: https://groups.google.com/forum/?fromgroups#!topic/CodeMirror/cN_494YVlCw

If the scroller is set to `height: auto`, when calculating its height, some browsers (notably Firefox) seem to round off fractional pixels. This change makes it so we also round off our calculated document height to match.

I tested this with various large percentage heights to see if the error was ever more than one pixel (in the original code), but never found a case where that happened. This fix appears to fix the problem in all the cases I found, and seems safe generally.
