### PR TITLE
[ecl] fixed mime type

### DIFF
--- a/mode/ecl/ecl.js
+++ b/mode/ecl/ecl.js
@@ -200,4 +200,4 @@ CodeMirror.defineMode("ecl", function(config) {
   };
 });
 
-CodeMirror.defineMIME("text/x-ecl");
+CodeMirror.defineMIME("text/x-ecl", "ecl");


### PR DESCRIPTION
mime type declaration was broken in `ecl.js`, so I fixed it :)
