### PR TITLE
use default cursor on line numbers

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -62,6 +62,7 @@
   text-align: right;
   padding: .4em .2em .4em .4em;
   white-space: pre !important;
+  cursor: default;
 }
 .CodeMirror-lines {
   padding: .4em;


### PR DESCRIPTION
Having a text cursor when hovering over line numbers is confusing, since you can't select the line numbers as text. It's even more confusing when you use the gutter for breakpoints or codefolding. I fixed it by setting `cursor: default` on the CSS rule `.CodeMirror-gutter-text`.
