### PR TITLE
[vibrant-ink] remove byte order mark

### DIFF
--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -1,4 +1,4 @@
-﻿/* Taken from the popular Visual Studio Vibrant Ink Schema */
+/* Taken from the popular Visual Studio Vibrant Ink Schema */
 
 .cm-s-vibrant-ink { background: black; color: white; }
 .cm-s-vibrant-ink .CodeMirror-selected { background: #35493c !important; }


### PR DESCRIPTION
Just ran into a CSS build issue with `vibrant-ink` theme because it had a BOM, so I removed it.
