### PR TITLE
Handle CoffeeScript properties as true properties.

### DIFF
--- a/mode/coffeescript/coffeescript.js
+++ b/mode/coffeescript/coffeescript.js
@@ -10,11 +10,12 @@ CodeMirror.defineMode('coffeescript', function(conf) {
     }
 
     var singleOperators = new RegExp("^[\\+\\-\\*/%&|\\^~<>!\?]");
-    var singleDelimiters = new RegExp('^[\\(\\)\\[\\]\\{\\}@,:`=;\\.]');
+    var singleDelimiters = new RegExp('^[\\(\\)\\[\\]\\{\\},:`=;\\.]');
     var doubleOperators = new RegExp("^((\->)|(\=>)|(\\+\\+)|(\\+\\=)|(\\-\\-)|(\\-\\=)|(\\*\\*)|(\\*\\=)|(\\/\\/)|(\\/\\=)|(==)|(!=)|(<=)|(>=)|(<>)|(<<)|(>>)|(//))");
     var doubleDelimiters = new RegExp("^((\\.\\.)|(\\+=)|(\\-=)|(\\*=)|(%=)|(/=)|(&=)|(\\|=)|(\\^=))");
     var tripleDelimiters = new RegExp("^((\\.\\.\\.)|(//=)|(>>=)|(<<=)|(\\*\\*=))");
     var identifiers = new RegExp("^[_A-Za-z$][_A-Za-z$0-9]*");
+    var properties = new RegExp("^(@|this\.)[_A-Za-z$][_A-Za-z$0-9]*");
 
     var wordOperators = wordRegexp(['and', 'or', 'not',
                                     'is', 'isnt', 'in',
@@ -157,6 +158,10 @@ CodeMirror.defineMode('coffeescript', function(conf) {
         if (stream.match(identifiers)) {
             return 'variable';
         }
+        
+        if (stream.match(properties)) {
+            return 'property';
+        }
 
         // Handle non-detected items
         stream.next();
@@ -259,12 +264,6 @@ CodeMirror.defineMode('coffeescript', function(conf) {
             } else {
                 return ERRORCLASS;
             }
-        }
-
-        // Handle properties
-        if (current === '@') {
-            stream.eat('@');
-            return 'keyword';
         }
 
         // Handle scope changes.


### PR DESCRIPTION
This makes coloration of CoffeeScript properties work the way they do on coffeescript.org, with the '@' and the variable name all one color.
