### PR TITLE
Expose a History API

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2896,9 +2896,11 @@ var CodeMirror = (function() {
     this.done = []; this.undone = [];
     this.compound = 0;
     this.closed = false;
+    this.frozen = false;
   }
   History.prototype = {
     addChange: function(start, added, old) {
+      if (this.frozen) return;
       this.undone.length = 0;
       var time = +new Date, cur = this.done[this.done.length - 1], last = cur && cur[cur.length - 1];
       var dtime = time - this.time;
@@ -2924,7 +2926,9 @@ var CodeMirror = (function() {
     },
     endCompound: function() {
       if (!--this.compound) this.closed = true;
-    }
+    },
+    freeze: function() { this.frozen = true; },
+    unfreeze: function() { this.frozen = false; }
   };
 
   function stopMethod() {e_stop(this);}


### PR DESCRIPTION
In the process of implementing a tabbed editor, I needed to bind undo stacks to a given file edit session. The only way I could accomplish this is by exposing the local `history` variable through an API in order to swap out the editor's history for different files.

The second change is to allow a given history object to be frozen. This is useful when swapping the editor's value with that of another file (ie by switching tabs), without the change being added to either file's undo stack.

Hopefully the change isn't particularly intrusive :)
