### PR TITLE
Add double and triple click support for word and line selection

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -416,19 +416,24 @@ var CodeMirror = (function() {
       if (!focused) onFocus();
 
       var now = +new Date;
+      var single = false, double = false, triple = false;
       if (lastDoubleClick && lastDoubleClick.time > now - 400 && posEq(lastDoubleClick.pos, start)) {
+        triple = true;
         e_preventDefault(e);
         setTimeout(focusInput, 20);
-        return selectLine(start.line);
+        selectLine(start.line);
       } else if (lastClick && lastClick.time > now - 400 && posEq(lastClick.pos, start)) {
+        double = true;
         lastDoubleClick = {time: now, pos: start};
         e_preventDefault(e);
-        return selectWordAt(start);
+        selectWordAt(start);
       } else { lastClick = {time: now, pos: start}; }
+
+      if (!double && !triple) single = true;
 
       var last = start, going;
       if (options.dragDrop && dragAndDrop && !options.readOnly && !posEq(sel.from, sel.to) &&
-          !posLess(start, sel.from) && !posLess(sel.to, start)) {
+          !posLess(start, sel.from) && !posLess(sel.to, start) && !double && !triple) {
         // Let the drag handler handle this.
         if (webkit) scroller.draggable = true;
         function dragEnd(e2) {
@@ -449,14 +454,30 @@ var CodeMirror = (function() {
         return;
       }
       e_preventDefault(e);
-      setCursor(start.line, start.ch, true);
+      if (single) setCursor(start.line, start.ch, true);
+
+      var startstart = instance.getCursor(true);
+      var startend = instance.getCursor(false);
+
+      function doSelect(cur) {
+        if (single) setSelectionUser(start, cur);
+        else if (double) {
+          selectWordAt(cur);
+          if(posLess(cur, startstart)) setSelectionUser(startend, instance.getCursor(true));
+          else setSelectionUser(startstart, instance.getCursor(false));
+        }
+        else if (triple) {
+          if(posLess(cur, startstart)) setSelectionUser(startend, clipPos({line: cur.line, ch: 0}));
+          else setSelectionUser(startstart, clipPos({line: cur.line + 1, ch: 0}));
+        }
+      }
 
       function extend(e) {
         var cur = posFromMouse(e, true);
         if (cur && !posEq(cur, last)) {
           if (!focused) onFocus();
           last = cur;
-          setSelectionUser(start, cur);
+          doSelect(cur);
           updateInput = false;
           var visible = visibleLines();
           if (cur.line >= visible.to || cur.line < visible.from)
@@ -467,7 +488,7 @@ var CodeMirror = (function() {
       function done(e) {
         clearTimeout(going);
         var cur = posFromMouse(e);
-        if (cur) setSelectionUser(start, cur);
+        if (cur) doSelect(cur);
         e_preventDefault(e);
         focusInput();
         updateInput = true;
@@ -484,11 +505,7 @@ var CodeMirror = (function() {
     function onDoubleClick(e) {
       for (var n = e_target(e); n != wrapper; n = n.parentNode)
         if (n.parentNode == gutterText) return e_preventDefault(e);
-      var start = posFromMouse(e);
-      if (!start) return;
-      lastDoubleClick = {time: +new Date, pos: start};
       e_preventDefault(e);
-      selectWordAt(start);
     }
     function onDrop(e) {
       if (options.onDragEvent && options.onDragEvent(instance, addStop(e))) return;


### PR DESCRIPTION
Solution to issue #300. Double and triple click in most text editors are used for selecting entire words or lines, respectively. By making some changes to the `onMouseDown` function, I created the same behavior in CodeMirror.
