### PR TITLE
Handle escaped quotes for the JavaScript mode

### DIFF
--- a/lib/util/formatting.js
+++ b/lib/util/formatting.js
@@ -98,6 +98,8 @@ CodeMirror.modeExtensions["javascript"] = {
   getNonBreakableBlocks: function (text) {
     var nonBreakableRegexes = [
         new RegExp("for\\s*?\\(([\\s\\S]*?)\\)"),
+        new RegExp("\\\\\"([\\s\\S]*?)(\\\\\"|$)"),
+        new RegExp("\\\\\'([\\s\\S]*?)(\\\\\'|$)"),
         new RegExp("'([\\s\\S]*?)('|$)"),
         new RegExp("\"([\\s\\S]*?)(\"|$)"),
         new RegExp("//.*([\r\n]|$)")


### PR DESCRIPTION
The extension now handles escaped quotes. So, the following code is formatted correctly:
test="&lt;a href=# onclick=\"alert(); return false;\"&gt;test&lt;/a&gt;";

Previous (incorrect) behavior was:
test="&lt;a href=# onclick=\"alert();
   return false;
\"&gt;test&lt;/a&gt;"
