### PR TITLE
add space deletion to previous tabstop behavior

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2194,6 +2194,20 @@ var CodeMirror = (function() {
       cm.indentLine(cm.getCursor().line);
     },
     toggleOverwrite: function(cm) {cm.toggleOverwrite();}
+    ,delSpaceToPrevTabStop : function(cm){
+        var from = cm.getCursor(true), to = cm.getCursor(false), sel = !posEq(from, to);
+        if (!posEq(from, to)) {cm.replaceRange("", from, to); return}
+        var cur = cm.getCursor(), line = cm.getLine(cur.line);
+        var tabsize = cm.getOption('tabSize');
+        var chToPrevTabStop = cur.ch-(Math.ceil(cur.ch/tabsize)-1)*tabsize;
+        var from = {ch:cur.ch-chToPrevTabStop,line:cur.line}
+        var select = cm.getRange(from,cur)
+        if( select.match(/^\ +$/) != null){
+            cm.replaceRange("",from,cur)
+        } else {
+            cm.deleteH(-1,"char")
+        }
+    }
   };
 
   var keyMap = CodeMirror.keyMap = {};


### PR DESCRIPTION
this allows to bind backspace to delete space until previous tabstop.
is deleting cm.tabSize space is not possible, it falls back to deleting
1 character, or delete selection if smth is selected.

---

hi, 

I was not able to achieve the behavior I wanted only by configuring codemirror with availlable options, so I patched it and propose the change upstream.
Basically I want to indent with (4) space, and delete to the previous n*tabSize when possible, otherwise fall back to del 1 character.

Thanks.
-\- 
Matthias
