### PR TITLE
Fix vertical scrolling bug (#665)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1038,7 +1038,7 @@ var CodeMirror = (function() {
       var pl = paddingLeft(), pt = paddingTop();
       y1 += pt; y2 += pt; x1 += pl; x2 += pl;
       var screen = scroller.clientHeight, screentop = scrollbar.scrollTop, result = {};
-      var docBottom = scroller.scrollHeight;
+      var docBottom = scrollbar.scrollHeight;
       var atTop = y1 < pt + 10, atBottom = y2 + pt > docBottom - 10;;
       if (y1 < screentop) result.scrollTop = atTop ? 0 : Math.max(0, y1);
       else if (y2 > screentop + screen) result.scrollTop = (atBottom ? docBottom : y2) - screen;


### PR DESCRIPTION
calculateScrollPos() was reading scrollHeight from the wrong element, so atBottom became true almost any the time the cursor moved past the bottom edge of the viewport.  So scrolling tries to jump to bottom of document on almost any downward cursor movement.

I'm not sure how this led all the other jumping around (moving back upward, then down again, but never settling on the actual cursor position), but it fixes all cases I was able to repro before (both #665 and #664).
