### PR TITLE
Allow for hard wrapping within a blockquote

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -38,6 +38,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     state.em = false;
     // Reset STRONG state
     state.strong = false;
+    // Reset state.quote
+    state.quote = false;
     if (!htmlFound && state.f == htmlBlock) {
       state.f = inlineNormal;
       state.block = blockNormal;
@@ -246,8 +248,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
         // Reset state.header
         state.header = false;
-        // Reset state.quote
-        state.quote = false;
 
         state.f = state.block;
         var indentation = stream.match(/^\s*/, true)[0].replace(/\t/g, '    ').length;


### PR DESCRIPTION
The first three lines should receive the `quote` state, while the last line (after the blank line) should not:

> &gt; This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
> consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
> 
> Not part of blockquote.

Taken from http://daringfireball.net/projects/markdown/syntax/#blockquote

Currently, only the first line receives the `quote` state.
