### PR TITLE
Hide the cursor when printing

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -165,3 +165,12 @@ span.cm-invalidchar {color: #f00;}
 
 div.CodeMirror span.CodeMirror-matchingbracket {color: #0f0;}
 div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
+
+@media print {
+
+  /* Hide the cursor when printing */
+  .CodeMirror pre.CodeMirror-cursor {
+    visibility: hidden;
+  }
+
+}


### PR DESCRIPTION
When keyboard shortcuts are used to print (e.g. `Ctrl` + `P`), focus is not removed from the editor (at least in Firefox 14-), and if the cursor is visible at that precise moment, it is also printed, which can be misleading (could be the cursor or `|`?). This simple fix makes sure it's always hidden when printing.

Note: I wasn't sure where you wanted to place the media query, but I figured throwing it at the end would be the safest, especially if more print-specific styles are added later.
