### PR TITLE
Fix vim mode when array prototype has been modified.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -70,7 +70,7 @@
     for (var prop in o) if (o.hasOwnProperty(prop)) f(prop, o[prop]);
   }
   function iterList(l, f) {
-    for (var i in l) f(l[i]);
+    for (var i = 0; i < l.length; ++i) f(l[i]);
   }
   function toLetter(ch) {
     // T -> t, Shift-T -> T, '*' -> *, "Space" -> " "


### PR DESCRIPTION
Switched to using a standard for loop rather than a for each in iterList.
