### PR TITLE
Specify character encoding on all pages.

### DIFF
--- a/demo/activeline.html
+++ b/demo/activeline.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Active Line Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/changemode.html
+++ b/demo/changemode.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Mode-Changing Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/closetag.html
+++ b/demo/closetag.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 	<head>
+    <meta charset="utf-8">
 		<title>CodeMirror: Close-Tag Demo</title>
 		<link rel="stylesheet" href="../lib/codemirror.css">
 		<script src="../lib/codemirror.js"></script>

--- a/demo/complete.html
+++ b/demo/complete.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Autocomplete Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/emacs.html
+++ b/demo/emacs.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Emacs bindings demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Code Folding Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/formatting.html
+++ b/demo/formatting.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Formatting Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/fullscreen.html
+++ b/demo/fullscreen.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Full Screen Editing</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/loadmode.html
+++ b/demo/loadmode.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Lazy Mode Loading Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/marker.html
+++ b/demo/marker.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Breakpoint Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/matchhighlighter.html
+++ b/demo/matchhighlighter.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Match Highlighter Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/multiplex.html
+++ b/demo/multiplex.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Multiplexing Parser Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/mustache.html
+++ b/demo/mustache.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Overlay Parser Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/preview.html
+++ b/demo/preview.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: HTML5 preview</title>
-    <meta charset=utf-8>
     <script src=../lib/codemirror.js></script>
     <script src=../mode/xml/xml.js></script>
     <script src=../mode/javascript/javascript.js></script>

--- a/demo/resize.html
+++ b/demo/resize.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Autoresize Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/runmode.html
+++ b/demo/runmode.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Mode Runner Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/search.html
+++ b/demo/search.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Search/Replace Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/theme.html
+++ b/demo/theme.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Theme Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/vim.html
+++ b/demo/vim.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Vim bindings demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/visibletabs.html
+++ b/demo/visibletabs.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Visible tabs demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/demo/xmlcomplete.html
+++ b/demo/xmlcomplete.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: XML Autocomplete Demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>

--- a/doc/compress.html
+++ b/doc/compress.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror: Compression Helper</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   </head>
   <body>
 

--- a/doc/internals.html
+++ b/doc/internals.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror: Internals</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <style>dl dl {margin: 0;} .update {color: #d40 !important}</style>
   </head>
   <body>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror: User Manual</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <style>dl dl {margin: 0;}</style>
   </head>
   <body>

--- a/doc/oldrelease.html
+++ b/doc/oldrelease.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <link rel="alternate" href="http://twitter.com/statuses/user_timeline/242283288.rss" type="application/rss+xml"/>
   </head>
   <body>

--- a/doc/reporting.html
+++ b/doc/reporting.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror: Reporting Bugs</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <style>li { margin-top: 1em; }</style>
   </head>
   <body>

--- a/doc/upgrade_v2.2.html
+++ b/doc/upgrade_v2.2.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror: Upgrading to v2.2</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   </head>
   <body>
 

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"/>
     <title>CodeMirror</title>
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="doc/docs.css"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <link rel="alternate" href="http://twitter.com/statuses/user_timeline/242283288.rss" type="application/rss+xml"/>
   </head>
   <body>

--- a/mode/clike/index.html
+++ b/mode/clike/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: C-like mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/clike/scala.html
+++ b/mode/clike/scala.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: C-like mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <link rel="stylesheet" href="../../theme/ambiance.css">

--- a/mode/clojure/index.html
+++ b/mode/clojure/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Clojure mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/coffeescript/index.html
+++ b/mode/coffeescript/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: CoffeeScript mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/css/index.html
+++ b/mode/css/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: CSS mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/diff/index.html
+++ b/mode/diff/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Diff mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/erlang/index.html
+++ b/mode/erlang/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Erlang mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: GFM mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/go/index.html
+++ b/mode/go/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Go mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <link rel="stylesheet" href="../../theme/elegant.css">

--- a/mode/groovy/index.html
+++ b/mode/groovy/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Groovy mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/haskell/index.html
+++ b/mode/haskell/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Haskell mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/haxe/index.html
+++ b/mode/haxe/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Haxe mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/htmlembedded/index.html
+++ b/mode/htmlembedded/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Html Embedded Scripts mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/htmlmixed/index.html
+++ b/mode/htmlmixed/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: HTML mixed mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/javascript/index.html
+++ b/mode/javascript/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: JavaScript mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/jinja2/index.html
+++ b/mode/jinja2/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Jinja2 mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/less/index.html
+++ b/mode/less/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: LESS mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>
@@ -8,7 +9,6 @@
     <style>.CodeMirror {background: #f8f8f8; border: 1px solid #ddd; font-size:12px} .CodeMirror-scroll {height: 400px}</style>
     <link rel="stylesheet" href="../../doc/docs.css">
     <link rel="stylesheet" href="../../theme/lesser-dark.css">
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   </head>
   <body>
     <h1>CodeMirror: LESS mode</h1>

--- a/mode/lua/index.html
+++ b/mode/lua/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Lua mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Markdown mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/mysql/index.html
+++ b/mode/mysql/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: MySQL mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/ntriples/index.html
+++ b/mode/ntriples/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: NTriples mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/pascal/index.html
+++ b/mode/pascal/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Pascal mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/perl/index.html
+++ b/mode/perl/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Perl mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/php/index.html
+++ b/mode/php/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: PHP mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/pig/index.html
+++ b/mode/pig/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Pig Latin mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/plsql/index.html
+++ b/mode/plsql/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Oracle PL/SQL mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/properties/index.html
+++ b/mode/properties/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Properties files mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Python mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/r/index.html
+++ b/mode/r/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: R mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/rpm/changes/index.html
+++ b/mode/rpm/changes/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: RPM changes mode</title>
     <link rel="stylesheet" href="../../../lib/codemirror.css">
     <script src="../../../lib/codemirror.js"></script>

--- a/mode/rpm/spec/index.html
+++ b/mode/rpm/spec/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: RPM spec mode</title>
     <link rel="stylesheet" href="../../../lib/codemirror.css">
     <script src="../../../lib/codemirror.js"></script>

--- a/mode/rst/index.html
+++ b/mode/rst/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: reStructuredText mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/ruby/index.html
+++ b/mode/ruby/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Ruby mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/rust/index.html
+++ b/mode/rust/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Rust mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/scheme/index.html
+++ b/mode/scheme/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Scheme mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/smalltalk/index.html
+++ b/mode/smalltalk/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Smalltalk mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/smarty/index.html
+++ b/mode/smarty/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Smarty mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/sparql/index.html
+++ b/mode/sparql/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: SPARQL mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/stex/index.html
+++ b/mode/stex/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: sTeX mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/stex/test.html
+++ b/mode/stex/test.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: sTeX mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/tiddlywiki/index.html
+++ b/mode/tiddlywiki/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: TiddlyWiki mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/tiki/index.html
+++ b/mode/tiki/index.html
@@ -1,5 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Tiki wiki mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/vb/index.html
+++ b/mode/vb/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: VB.NET mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/vbscript/index.html
+++ b/mode/vbscript/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: VBScript mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/velocity/index.html
+++ b/mode/velocity/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Velocity mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/verilog/index.html
+++ b/mode/verilog/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: Verilog mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/xml/index.html
+++ b/mode/xml/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: XML mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>

--- a/mode/xquery/index.html
+++ b/mode/xquery/index.html
@@ -25,6 +25,7 @@ THE SOFTWARE.
 */
 -->
   <head> 
+    <meta charset="utf-8">
     <title>CodeMirror 2: JavaScript mode</title> 
     <link rel="stylesheet" href="../../lib/codemirror.css"> 
     <script src="http://codemirror.net/lib/codemirror.js"></script> 

--- a/mode/yaml/index.html
+++ b/mode/yaml/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>CodeMirror: YAML mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>


### PR DESCRIPTION
Special characters are broken on pages that don't specify character encoding. They work on codemirror.net because the character encoding is sent by the server, but are broken locally, and on servers that don't specify the encoding.

To test, open `/demo/marker.html` locally (before this patch) and click on the gutter next to a line to set a breakpoint. A `●` should be displayed, but instead `â—` is displayed.

I used `<meta charset="utf-8">` instead of the longer, outdated version as it is backward compatible with all known browsers, as far as I know. For more information, see http://blog.whatwg.org/the-road-to-html-5-character-encoding
