### PR TITLE
Save memory on null pointers in Line object

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -57,7 +57,7 @@ var CodeMirror = (function() {
     // Needed to handle Tab key in KHTML
     if (khtml) inputDiv.style.height = "1px", inputDiv.style.position = "absolute";
 
-    // Check for OS X >= 10.7. If so, we need to force a width on the scrollbar, and 
+    // Check for OS X >= 10.7. If so, we need to force a width on the scrollbar, and
     // make it overlap the content. (But we only do this if the scrollbar doesn't already
     // have a natural width. If the mouse is plugged in or the user sets the system pref
     // to always show scrollbars, the scrollbar shouldn't overlap.)
@@ -572,7 +572,7 @@ var CodeMirror = (function() {
     function onDragStart(e) {
       var txt = getSelection();
       e.dataTransfer.setData("Text", txt);
-      
+
       // Use dummy image instead of default browsers image.
       if (gecko || chrome || opera) {
         var img = document.createElement('img');
@@ -869,8 +869,8 @@ var CodeMirror = (function() {
       // Position the mover div to align with the current virtual scroll position
       mover.style.top = displayOffset * textHeight() + "px";
     }
-  
-    // On Mac OS X Lion and up, detect whether the mouse is plugged in by measuring 
+
+    // On Mac OS X Lion and up, detect whether the mouse is plugged in by measuring
     // the width of a div with a scrollbar in it. If the width is <= 1, then
     // the mouse isn't plugged in and scrollbars should overlap the content.
     function overlapScrollbars() {
@@ -890,7 +890,7 @@ var CodeMirror = (function() {
 
     function computeMaxLength() {
       maxLine = getLine(0); maxLineChanged = true;
-      var maxLineLength = maxLine.text.length; 
+      var maxLineLength = maxLine.text.length;
       doc.iter(1, doc.size, function(line) {
         var l = line.text;
         if (!line.hidden && l.length > maxLineLength) {


### PR DESCRIPTION
Regarding issue #688:

I removed the explicit null pointers from the `Line` object constructor, and I benchmarked this change loading a 178K-lines file into a single CodeMirror instance. I ran `Chrome 21 Linux 64 bits`, and took heap snapshots in both cases with the chrome heap profiler, looking at the shallow sizes of the three biggest footprint items.
## Before

178 K `Line` objects in memory, taking up 20 MB of heap.
279 K `(array)` objects in memory, taking up 58 MB of heap.
374 K `(string)` objects in memory, taking up 14 MB of heap.
## After

178 K `Line` objects in memory, taking up 11 MB of heap.
281 K `(array)` objects in memory, taking up 60 MB of heap.
378 K `(string)` objects in memory, taking up 14 MB of heap.

This change seems to cut the `Line` objects memory footprint by 45%.

I didn't precisely measure loading time and highlighting / scrolling performance in both cases, but I there is no noticeable difference.
