### PR TITLE
Add catchTab option to allow for navigating via Tab.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -138,6 +138,12 @@
       the <code>cm-s-foo</code> and the <code>cm-s-bar</code> classes
       to the editor.</dd>
 
+      <dt id="option_catchTab"><code>catchTab (boolean)</code></dt>
+      <dd>Indicates whether <kbd>Tab</kbd> should be caught and handled by CodeMirror
+      (<code>true</code>, useful for indentation) or the browser (<code>false</code>,
+      useful for tabbing through form controls). By default, CodeMirror catches and
+      handles <kbd>Tab</kbd>.</dd>
+
       <dt id="option_indentUnit"><code>indentUnit (integer)</code></dt>
       <dd>How many spaces a block (whatever that means in the edited
       language) should be indented. The default is 2.</dd>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -613,6 +613,7 @@ var CodeMirror = (function() {
 
       var name = keyNames[e_prop(e, "keyCode")], handled = false;
       if (name == null || e.altGraphKey) return false;
+      if (name == "Tab" && !options.catchTab) return false;
       if (e_prop(e, "altKey")) name = "Alt-" + name;
       if (e_prop(e, "ctrlKey")) name = "Ctrl-" + name;
       if (e_prop(e, "metaKey")) name = "Cmd-" + name;
@@ -2073,6 +2074,7 @@ var CodeMirror = (function() {
     workDelay: 200,
     pollInterval: 100,
     undoDepth: 40,
+    catchTab: true,
     tabindex: null,
     autofocus: null,
     lineNumberFormatter: function(integer) { return integer; }


### PR DESCRIPTION
Currently, it is only possible for `Tab` to add `\t` or change the indentation of code. The `catchTab` option allows the developer to override this (by setting `catchTab` to `false`) to make it possible for the browser to handle `Tab` instead (e.g. navigating between form elements).
