### PR TITLE
Migrate from innerHTML to DOM bindings / fragments

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1515,7 +1515,7 @@ var CodeMirror = (function() {
       var e = document.createElement(tag);
       if (className) e.className = className;
       if (style) e.setAttribute("style", style);
-      if (text) e.textContent = text;
+      if (text) setTextContent(e, text);
       return e;
     }
     function createChild(parent, tag, text, className, style) {
@@ -1722,7 +1722,7 @@ var CodeMirror = (function() {
       // Older IEs report zero offsets for spans directly after a wrap
       if (ie && top == 0 && left == 0) {
         var backup = document.createElement("span");
-        backup.textContent = "x";
+        setTextContent(backup, "x");
         elt.parentNode.insertBefore(backup, elt.nextSibling);
         top = backup.offsetTop;
       }
@@ -2692,7 +2692,7 @@ var CodeMirror = (function() {
             // to zero-width spaces. So we do hideous browser sniffing
             // to determine which to use.)
             if (outPos == wrapAt && outPos == len) {
-              open.textContent = gecko || (ie && !ie_lt8)  ? "\u200b" : " ";
+              setTextContent(open, gecko || (ie && !ie_lt8)  ? "\u200b" : " ");
               html.appendChild(open);
             }
             // Stop outputting HTML when gone sufficiently far beyond measure
@@ -3196,11 +3196,20 @@ var CodeMirror = (function() {
   // Some IEs don't preserve tabs through innerHTML
   } else if (htmlEscape("\t") != "\t") {
     htmlEscape = function(str) {
-      removeChildrenAndAdd(escapeElement, document.createTextNode(str));
+      escapeElement.innerHTML = "";
+      escapeElement.appendChild(document.createTextNode(str));
       return escapeElement.innerHTML;
     };
   }
   CodeMirror.htmlEscape = htmlEscape;
+
+  function setTextContent(e, str) {
+    if (ie_lt9) {
+      e.innerHTML = "";
+      e.appendChild(document.createTextNode(str));
+    } else e.textContent = str;
+  }
+  CodeMirror.setTextContent = setTextContent;
 
   // Used to position the cursor after an undo/redo by finding the
   // last edited character.


### PR DESCRIPTION
This change migrates entire codemirror.js from markup emitting / parsing to using pure DOM bindings and fragments.

Following are the benefits as I see them:
- x2 execution speed up (tested on Chrome in getHTML call sites; I would expect it to be not less on modern FF, Opera and IE)
- innerHTML is only used in 'removeChildren()'. I.e. better XSS resistance.
- Absence of getElementById (better code isolation)

Todos:
codemirror.js no longer uses escaping, but the code is needed for modules / tests. Should probably be moved out.

Tests:
measureEndOfLine and moveV fail on Opera (as in the original version though)
