### PR TITLE
Add setHTMLContent function -> fix Breakpoint demo

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -20,23 +20,23 @@ var CodeMirror = (function() {
     // This mess creates the base DOM structure for the editor.
     wrapper.innerHTML =
       '<div style="overflow: hidden; position: relative; width: 3px; height: 0px;">' + // Wraps and hides input textarea
-      '<textarea style="position: absolute; padding: 0; width: 1px; height: 1em" wrap="off" ' +
-      'autocorrect="off" autocapitalize="off"></textarea></div>' +
+        '<textarea style="position: absolute; padding: 0; width: 1px; height: 1em" wrap="off" ' +
+          'autocorrect="off" autocapitalize="off"></textarea></div>' +
       '<div class="CodeMirror-scrollbar">' + // The vertical scrollbar. Horizontal scrolling is handled by the scroller itself.
-      '<div class="CodeMirror-scrollbar-inner">' + // The empty scrollbar content, used solely for managing the scrollbar thumb.
+        '<div class="CodeMirror-scrollbar-inner">' + // The empty scrollbar content, used solely for managing the scrollbar thumb.
       '</div></div>' + // This must be before the scroll area because it's float-right.
       '<div class="CodeMirror-scroll" tabindex="-1">' +
-      '<div style="position: relative">' + // Set to the height of the text, causes scrolling
-      '<div style="position: relative">' + // Moved around its parent to cover visible view
-      '<div class="CodeMirror-gutter"><div class="CodeMirror-gutter-text"></div></div>' +
-      // Provides positioning relative to (visible) text origin
-      '<div class="CodeMirror-lines"><div style="position: relative; z-index: 0">' +
-      // Used to measure text size
-      '<div style="position: absolute; width: 100%; height: 0px; overflow: hidden; visibility: hidden;"></div>' +
-      '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor
-      '<pre class="CodeMirror-cursor" style="visibility: hidden">&#160;</pre>' + // Used to force a width
-      '<div style="position: relative; z-index: -1"></div><div></div>' + // DIVs containing the selection and the actual code
-      '</div></div></div></div></div>';
+        '<div style="position: relative">' + // Set to the height of the text, causes scrolling
+          '<div style="position: relative">' + // Moved around its parent to cover visible view
+            '<div class="CodeMirror-gutter"><div class="CodeMirror-gutter-text"></div></div>' +
+            // Provides positioning relative to (visible) text origin
+            '<div class="CodeMirror-lines"><div style="position: relative; z-index: 0">' +
+              // Used to measure text size
+              '<div style="position: absolute; width: 100%; height: 0px; overflow: hidden; visibility: hidden;"></div>' +
+              '<pre class="CodeMirror-cursor">&#160;</pre>' + // Absolutely positioned blinky cursor
+              '<pre class="CodeMirror-cursor" style="visibility: hidden">&#160;</pre>' + // Used to force a width
+              '<div style="position: relative; z-index: -1"></div><div></div>' + // DIVs containing the selection and the actual code
+            '</div></div></div></div></div>';
     if (place.appendChild) place.appendChild(wrapper); else place(wrapper);
     // I've never seen more elegant code in my life.
     var inputDiv = wrapper.firstChild, input = inputDiv.firstChild,
@@ -1260,7 +1260,7 @@ var CodeMirror = (function() {
         var clientHeight = lineSpace.clientHeight || lineSpace.offsetHeight;
         var add = function(left, top, right, height) {
           var rstyle = quirksMode ? "width: " + (!right ? clientWidth : clientWidth - right - left) + "px"
-              : "right: " + right + "px";
+                                  : "right: " + right + "px";
           createChild(fragment, "div", null, null, "CodeMirror-selected", "position: absolute; left: " + left +
                       "px; top: " + top + "px; " + rstyle + "; height: " + height + "px");
         };


### PR DESCRIPTION
Add setHTMLContent function

```
function setHTMLContent(e, html) {
    e.innerHTML = "";
    if (firefox_lt8) {
        e.innerHTML = html;
    } else e.insertAdjacentHTML('AfterBegin',html);
}
```

Updated createChild( + createElement( to handle html

Fixes [#703](https://github.com/marijnh/CodeMirror2/issues/703) Breakpoint demo
