### PR TITLE
Only autofocus editor if another element isn't already focused.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -279,7 +279,10 @@
 
       <dt id="option_autofocus"><code>autofocus (boolean)</code></dt>
       <dd>Can be used to make CodeMirror focus itself on
-      initialization. Defaults to off.
+      initialization. If another element already has focus because of
+      a script, another element's <code>autofocus</code> attribute,
+      or user interaction, CodeMirror will leave that element focused,
+      rather than focusing itself. Defaults to off.
       When <a href="#fromTextArea"><code>fromTextArea</code></a> is
       used, and no explicit value is given for this option, it will
       inherit the setting from the textarea's <code>autofocus</code>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -47,7 +47,18 @@ var CodeMirror = (function() {
     if (!webkit) scroller.draggable = true;
     lineSpace.style.outline = "none";
     if (options.tabindex != null) input.tabIndex = options.tabindex;
-    if (options.autofocus) focusInput();
+    if (options.autofocus){
+      // IE throws unspecified error in certain cases, when
+      // trying to access activeElement before onload
+      // Always focus the editor for IE users
+      // For all other browsers:
+      // Either remove autofocus if another element is already selected
+      // Or blur() the element to work around check in CodeMirror()
+      if (!ie && document.activeElement !== document.body)
+        options.autofocus = false;
+      else
+        focusInput(true);
+    }
     if (!options.gutter && !options.lineNumbers) gutter.style.display = "none";
     // Needed to handle Tab key in KHTML
     if (khtml) inputDiv.style.height = "1px", inputDiv.style.position = "absolute";
@@ -2248,6 +2259,16 @@ var CodeMirror = (function() {
       options.tabindex = textarea.tabindex;
     if (options.autofocus == null && textarea.getAttribute("autofocus") != null)
       options.autofocus = true;
+    // IE throws unspecified error in certain cases, when
+    // trying to access activeElement before onload
+    // Always focus the editor for IE users
+    // For all other browsers:
+    // Either remove autofocus if another element is already selected
+    // Or blur() the element to work around check in CodeMirror()
+    if (!ie && document.activeElement !== document.body && document.activeElement !== textarea)
+      options.autofocus = false;
+    else
+      textarea.blur();
 
     function save() {textarea.value = instance.getValue();}
     if (textarea.form) {


### PR DESCRIPTION
Checks to see if another element already has focus, similar to how the `autofocus` attribute works for plain HTML. You'll notice the two code blocks are nearly identical, but regrettably (at least as far as I can tell), it's impossible to only do this check once, since you don't have access to `textarea` in the main `CodeMirror()` function (so you can't check if it is focused).

As for the IE check/note, I originally found it on line 163 of codemirror.js (in this patch, [line 152 in the current master](https://github.com/marijnh/CodeMirror2/blob/e828092146b5940a7b6a8e5f6ae0399fe6bed6ce/lib/codemirror.js#L152)) and it didn't mention which versions were affected. Also, I don't have access to IE, so I couldn't test. So, you may want to change this to `ie_lt*` accordingly.
