### PR TITLE
Fix issues introduced by fix for #714

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -290,7 +290,10 @@
       When <a href="#fromTextArea"><code>fromTextArea</code></a> is
       used, and no explicit value is given for this option, it will
       inherit the setting from the textarea's <code>autofocus</code>
-      attribute.</dd>
+      attribute, but if another element already has focus because of
+      a script, an <code>autofocus</code> attribute, or user
+      interaction, CodeMirror will leave that element focused, rather
+      than focusing itself.</dd>
 
       <dt id="option_dragDrop"><code>dragDrop (boolean)</code></dt>
       <dd>Controls whether drag-and-drop is enabled. On by default.</dd>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2259,8 +2259,20 @@ var CodeMirror = (function() {
     options.value = textarea.value;
     if (!options.tabindex && textarea.tabindex)
       options.tabindex = textarea.tabindex;
+    // Focus editor if the textarea is focused
     if (options.autofocus == null)
       try { if (document.activeElement == textarea) options.autofocus = true; } catch(e) {}
+    // Focus editor if autofocus attribute is found
+    if (options.autofocus == null && textarea.getAttribute("autofocus") != null) {
+      options.autofocus = true;
+      // IE throws unspecified error in certain cases, when
+      // trying to access activeElement before onload
+      try {
+        // Remove autofocus if another element is already focused
+        if (document.activeElement != document.body && document.activeElement != textarea)
+          options.autofocus = false;
+      } catch(e) {}
+    }
 
     function save() {textarea.value = instance.getValue();}
     if (textarea.form) {


### PR DESCRIPTION
The patch (76dd7c6475e71fce142ce75c6acce61ce2ad1ea0) to close #714 introduced a few issues:
- `autofocus` attribute no longer works for IE in the situations where it chokes on `document.activeElement`
- In some cases, `autofocus` attribute support is broken in _every_ browser, as the editor loads before _any_ element is actually focused

To fix the IE issue, I've fallen back to always applying focus to the editor, as that's typically better than no focus at all.

To fix the loading issues, the `autofocus` option is set to `true` whenever the `autofocus` attribute is found. Then, if a _different_ element has already been focused, the `autofocus` option is set to `false`. Per [your request](https://github.com/marijnh/CodeMirror2/pull/714#issuecomment-7691630), if the `autofocus` option set manually, the editor will _always_ receive focus.
