### PR TITLE
Configurable cursor blink rate, default to 530ms

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -261,6 +261,10 @@
       <dd>Determines whether brackets are matched whenever the cursor
       is moved next to a bracket.</dd>
 
+      <dt id="option_cursorBlinkRate"><code>cursorBlinkRate (number)</code></dt>
+      <dd>Half-period in milliseconds used for cursor blinking. The default blink
+      rate is 530ms.</dd>
+
       <dt id="option_workTime"><code>workTime, workDelay (number)</code></dt>
       <dd>Highlighting is done by a pseudo background-thread that will
       work for <code>workTime</code> milliseconds, and then use

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1845,7 +1845,7 @@ var CodeMirror = (function() {
       cursor.style.visibility = "";
       blinker = setInterval(function() {
         cursor.style.visibility = (on = !on) ? "" : "hidden";
-      }, 650);
+      }, options.cursorBlinkRate);
     }
 
     var matching = {"(": ")>", ")": "(<", "[": "]>", "]": "[<", "{": "}>", "}": "{<"};
@@ -2073,6 +2073,7 @@ var CodeMirror = (function() {
     onUpdate: null,
     onFocus: null, onBlur: null, onScroll: null,
     matchBrackets: false,
+    cursorBlinkRate: 530,
     workTime: 100,
     workDelay: 200,
     pollInterval: 100,


### PR DESCRIPTION
As @repenaxa indicated in issue #722, the default blink rate in Windows is 530ms. It feels similar on Mac and Ubuntu, but I couldn't find any evidence to support this claim.
