### PR TITLE
Update lib/codemirror.js

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -570,7 +570,7 @@ var CodeMirror = (function() {
       e.dataTransfer.setData("Text", txt);
 
       // Use dummy image instead of default browsers image.
-      if (gecko || chrome) {
+      if (e.dataTransfer.setDragImage) {
         var img = elt('img');
         img.scr = 'data:image/gif;base64,R0lGODdhAgACAIAAAAAAAP///ywAAAAAAgACAAACAoRRADs='; //1x1 image
         e.dataTransfer.setDragImage(img, 0, 0);


### PR DESCRIPTION
Opera doesn't support `setDragImage` for now.
Maybe some day...
Dragging is really ugly in Opera. It ghosts an image of the `scroller`.
