### PR TITLE
Simple hint options

### DIFF
--- a/lib/util/simple-hint.js
+++ b/lib/util/simple-hint.js
@@ -89,7 +89,7 @@
       return true;
     };
     return collectHints();
-  }
+  };
   CodeMirror.simpleHint.defaults = {
     closeOnBackspace: true,
     closeOnTokenChange: false


### PR DESCRIPTION
Added options to simple hint for closing on backspace and closing on the token being autocompleted changing, this comes from #601.
