### PR TITLE
Markdown mode links issue

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -121,7 +121,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     if (ch === '`') {
       return switchInline(stream, state, inlineElement(code, '`'));
     }
-    if (ch === '[') {
+    if (ch === '[' && stream.match(/.*\](?:\(|\[)/, false)) {
       return switchInline(stream, state, linkText);
     }
     if (ch === '<' && stream.match(/^\w/, false)) {


### PR DESCRIPTION
Hi.

Thanks for CodeMirror2, it's a beast!

The issue: in the Markdown mode, the lexer/parser/tokenizer is incorrectly highlighting words that are enclosed in square brackets as hyperlinks even when they're not followed by `()`.

To reproduce simply type a word between `[square brackets]` and it will be highlighted as a link, and the lexer expects a continuation of the token (the `(href)` part).

Thanks!
