### PR TITLE
Sequences like "};" not line-broken anymore

### DIFF
--- a/lib/util/formatting.js
+++ b/lib/util/formatting.js
@@ -131,7 +131,7 @@ CodeMirror.modeExtensions["javascript"] = {
   autoFormatLineBreaks: function (text, startPos, endPos) {
     text = text.substring(startPos, endPos);
     var curPos = 0;
-    var reLinesSplitter = new RegExp("(;|\\{|\\})([^\r\n])", "g");
+    var reLinesSplitter = new RegExp("(;|\\{|\\})([^\r\n;])", "g");
     var nonBreakableBlocks = this.getNonBreakableBlocks(text);
     if (nonBreakableBlocks != null) {
       var res = "";


### PR DESCRIPTION
Was "};" => "}\n;" before, "};" => "};\n" now.
