### PR TITLE
those byte order marks again

### DIFF
--- a/lib/util/xml-hint.js
+++ b/lib/util/xml-hint.js
@@ -1,4 +1,4 @@
-﻿
+
 (function() {
 
     CodeMirror.xmlHints = [];


### PR DESCRIPTION
Maybe there can be a test making sure that http://codemirror.net/doc/compress.html works, reducing to the smallest failing file group when there is a problem?
