### PR TITLE
Remove src attribute from dummy image

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -563,7 +563,6 @@ window.CodeMirror = (function() {
       // Use dummy image instead of default browsers image.
       if (gecko || chrome || opera) {
         var img = elt('img');
-        img.src = 'data:image/gif;base64,R0lGODdhAgACAIAAAAAAAP///ywAAAAAAgACAAACAoRRADs='; //1x1 image
         e.dataTransfer.setDragImage(img, 0, 0);
       }
     }


### PR DESCRIPTION
When dragging there is no src attribute needed on the dummy image.
