### PR TITLE
Prevent selection from covering text (closes #760)

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -169,6 +169,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   word-wrap: normal;
   line-height: inherit;
   color: inherit;
+  position: relative;
 }
 .CodeMirror-wrap pre {
   word-wrap: break-word;


### PR DESCRIPTION
Alternatively, you can change the `z-index` of the selection's `<div>` to `-1` to fix the issue (which may be better, so `position:relative;` isn't added to every line's `<pre>`).
