### PR TITLE
Avoid TypeError with digits and empty editor.

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -85,7 +85,7 @@ CodeMirror.defineMode("clojure", function (config, mode) {
                 stream.eatWhile(tests.digit);
             }
 
-            if ( 'e' == stream.peek().toLowerCase() ) {
+            if ( 'e' == String(stream.peek()).toLowerCase() ) {
                 stream.eat(tests.exponent);
                 stream.eat(tests.sign);
                 stream.eatWhile(tests.digit);


### PR DESCRIPTION
Closes #776.

Alternatively, you could use:

```
            if ( stream.peek() !== undefined && 'e' == stream.peek().toLowerCase() ) {
```

And just noticed you used `.test()` in LESS mode (see 472d099befcca4381b3a449db9010fe3fbaafa0f). I really don't know which way is best; just figured I'd submit a patch to help out.
