### PR TITLE
Check if +/- is immediately followed by digit before marking as a leading sign (closes #782).

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -70,7 +70,7 @@ CodeMirror.defineMode("clojure", function (config, mode) {
         }
 
         // leading sign
-        if ( ch == '+' || ch == '-' ) {
+        if ( ( ch == '+' || ch == '-' ) && ( tests.digit.test(stream.peek()) ) ) {
           stream.eat(tests.sign);
           ch = stream.next();
         }


### PR DESCRIPTION
The current code makes the assumption that `+`/`-` is _always_ a sign, but usually it is not (typically an operator). This does an additional check to make sure the next number is actually a digit, before eating it.

To test, the correct highlighting for the following code snippet should highlight the + as an operator, and each 2 as a number (taken from http://clojuredocs.org/clojure_core/1.2.0/clojure.test/deftest):

```
(is (= 4 (+ 2 2)))
```
