### PR TITLE
Prevent logo from causing a horizontal scrollbar at smaller viewport widths.

### DIFF
--- a/doc/compress.html
+++ b/doc/compress.html
@@ -10,10 +10,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* Script compression
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* Script compression
    helper */
 </pre>
+</div>
 
     <p>To optimize loading CodeMirror, especially when including a
     bunch of different modes, it is recommended that you combine and

--- a/doc/docs.css
+++ b/doc/docs.css
@@ -39,17 +39,28 @@ pre.code {
 }
 
 .grey {
-  font-size: 2.2em;
-  padding: .5em 1em;
-  line-height: 1.2em;
-  margin-top: .5em;
+  background-color: #eee;
+  border-radius: 6px;
+  margin-bottom: 1.65em;
+  margin-top: 0.825em;
+  padding: 0.825em 1.65em;
   position: relative;
 }
 
 img.logo {
   position: absolute;
-  right: -25px;
+  right: -1em;
   bottom: 4px;
+  max-width: 23.6875em; /* Scale image down with text to prevent clipping */
+}
+
+.grey > pre {
+  background:none;
+  border-radius:0;
+  padding:0;
+  margin:0;
+  font-size:2.2em;
+  line-height:1.2em;
 }
 
 a:link, a:visited, .quasilink {

--- a/doc/internals.html
+++ b/doc/internals.html
@@ -11,10 +11,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* (Re-) Implementing A Syntax-
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* (Re-) Implementing A Syntax-
    Highlighting Editor in JavaScript */
 </pre>
+</div>
 
 <div class="clear"><div class="leftbig blk">
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -11,10 +11,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* User manual and
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* User manual and
    reference guide */
 </pre>
+</div>
 
 <div class="clear"><div class="leftbig blk">
 

--- a/doc/oldrelease.html
+++ b/doc/oldrelease.html
@@ -11,10 +11,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* Old release history */
-
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* Old release
+   history */
 </pre>
+</div>
 
   <p class="rel">27-10-2011: <a href="http://codemirror.net/codemirror-2.16.zip">Version 2.16</a>:</p>
   <ul class="rel-note">

--- a/doc/reporting.html
+++ b/doc/reporting.html
@@ -11,10 +11,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* Reporting bugs
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* Reporting bugs
    effectively */
 </pre>
+</div>
 
 <div class="left">
 

--- a/doc/upgrade_v2.2.html
+++ b/doc/upgrade_v2.2.html
@@ -10,10 +10,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="baboon.png" class="logo" alt="logo"/>/* Upgrading to v2.2
- */
+<div class="grey">
+<img src="baboon.png" class="logo" alt="logo"/>
+<pre>
+/* Upgrading to
+   v2.2 */
 </pre>
+</div>
 
 <div class="left">
 

--- a/index.html
+++ b/index.html
@@ -11,10 +11,13 @@
 
 <h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
 
-<pre class="grey">
-<img src="doc/baboon.png" class="logo" alt="logo"/>/* In-browser code editing
+<div class="grey">
+<img src="doc/baboon.png" class="logo" alt="logo"/>
+<pre>
+/* In-browser code editing
    made bearable */
 </pre>
+</div>
 
 <div class="clear"><div class="left blk">
 


### PR DESCRIPTION
This was especially noticeable with non-default font-sizes. The wrapper div and additional pre are required due to using the font-size (specifically monospace font-size) provided by the browser (using em throughout).

I also changed the header text (whitespace only) for `doc/upgrade_v2.2.html` and `doc/oldrelease.html` to fit the style of the other headers (assuming it was _not_ intentional to have them different, apologies if it was).

An alternative solution to fix this, without the wrappers, is to add `body { font-size: 16px; }` and adjust padding/margins/etc of all other elements accordingly (any element using a monospace font would be affected). Regrettably, this alternative solution throws out user-specified font-sizes entirely.
