### PR TITLE
Table row wasn't closed in mode test script.

### DIFF
--- a/test/mode_test.js
+++ b/test/mode_test.js
@@ -159,6 +159,7 @@ ModeTest.prettyPrintOutputTable = function(output) {
     s +=
       '<td class="mt-style"><span>' + token[0] + '</span></td>';
   }
+  s += '</tr>';
   s += '</table>';
   return s;
 }


### PR DESCRIPTION
Just closing the table row in the mode test script.

Side note: I'll probably go through and get rid of the `document.write` calls at some point, but this'll work for now.
