### PR TITLE
Reset `verbose` flag when running tests.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -84,6 +84,7 @@
         count = 0;
         failed = 0;
         bad = "";
+        verbose = false;
         debugUsed = Array();
         totalTests = tests.length;
         progressTotal.nodeValue = " of " + totalTests;


### PR DESCRIPTION
Previously, the `verbose` flag would remain on indefinitely once `verbose,` was included in the hash. Could only be removed by refreshing the page.
