### PR TITLE
Fix bug with duplicate test names starting out at the wrong number.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -14,8 +14,8 @@ function test(name, run, expectedFail) {
   var originalName = name;
   var i = 2; // Second function would be NAME_2
   while (indexOf(allNames, name) !== -1){
-    i++;
     name = originalName + "_" + i;
+    i++;
   }
   allNames.push(name);
   // Add test


### PR DESCRIPTION
If two tests have the name "foo", the second should appear as "foo_2", but instead it appeared as "foo_3".

It was working correctly at one point in time while I was writing it... must've just switched things around.
