### PR TITLE
Add tests for CSS mode and fixed found bugs

### DIFF
--- a/mode/css/css.css
+++ b/mode/css/css.css
@@ -1,0 +1,7 @@
+/* Change error (warning) so it's not so scary */
+.cm-s-default span.cm-property {font-weight: bold;}
+.cm-s-default span.cm-property.cm-error {color: black; font-weight: normal;}
+
+/* Differentiate color from .cm-def and change error (warning) so it's not so scary */
+.cm-s-default span.cm-attribute {color: #c0c; font-weight: bold;}
+.cm-s-default span.cm-attribute.cm-error {color: #c0c; font-weight: normal;}

--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -1,60 +1,196 @@
 CodeMirror.defineMode("css", function(config) {
   var indentUnit = config.indentUnit, type;
+  
+  var atMediaTypes = keySet([
+    "all", "aural", "braille", "handheld", "print", "projection", "screen",
+    "tty", "tv", "embossed"
+  ]);
+  
+  var atMediaFeatures = keySet([
+    "width", "min-width", "max-width", "height", "min-height", "max-height",
+    "device-width", "min-device-width", "max-device-width", "device-height",
+    "min-device-height", "max-device-height", "aspect-ratio",
+    "min-aspect-ratio", "max-aspect-ratio", "device-aspect-ratio",
+    "min-device-aspect-ratio", "max-device-aspect-ratio", "color", "min-color",
+    "max-color", "color-index", "min-color-index", "max-color-index",
+    "monochrome", "min-monochrome", "max-monochrome", "resolution",
+    "min-resolution", "max-resolution", "scan", "grid"
+  ]);
 
-  var keywords = keySet(["above", "absolute", "activeborder", "activecaption", "afar", "after-white-space", "ahead", "alias", "all", "all-scroll",
-    "alternate", "always", "amharic", "amharic-abegede", "antialiased", "appworkspace", "arabic-indic", "armenian", "asterisks",
-    "auto", "avoid", "background", "backwards", "baseline", "below", "bidi-override", "binary", "bengali", "blink",
-    "block", "block-axis", "bold", "bolder", "border", "border-box", "both", "bottom", "break-all", "break-word", "button",
-    "button-bevel", "buttonface", "buttonhighlight", "buttonshadow", "buttontext", "cambodian", "capitalize", "caps-lock-indicator",
-    "caption", "captiontext", "caret", "cell", "center", "checkbox", "circle", "cjk-earthly-branch", "cjk-heavenly-stem", "cjk-ideographic",
-    "clear", "clip", "close-quote", "col-resize", "collapse", "compact", "condensed", "contain", "content", "content-box", "context-menu",
-    "continuous", "copy", "cover", "crop", "cross", "crosshair", "currentcolor", "cursive", "dashed", "decimal", "decimal-leading-zero", "default",
-    "default-button", "destination-atop", "destination-in", "destination-out", "destination-over", "devanagari", "disc", "discard", "document",
-    "dot-dash", "dot-dot-dash", "dotted", "double", "down", "e-resize", "ease", "ease-in", "ease-in-out", "ease-out", "element",
-    "ellipsis", "embed", "end", "ethiopic", "ethiopic-abegede", "ethiopic-abegede-am-et", "ethiopic-abegede-gez",
-    "ethiopic-abegede-ti-er", "ethiopic-abegede-ti-et", "ethiopic-halehame-aa-er", "ethiopic-halehame-aa-et",
-    "ethiopic-halehame-am-et", "ethiopic-halehame-gez", "ethiopic-halehame-om-et", "ethiopic-halehame-sid-et",
-    "ethiopic-halehame-so-et", "ethiopic-halehame-ti-er", "ethiopic-halehame-ti-et", "ethiopic-halehame-tig", "ew-resize", "expanded",
-    "extra-condensed", "extra-expanded", "fantasy", "fast", "fill", "fixed", "flat", "footnotes", "forwards", "from", "geometricPrecision",
-    "georgian", "graytext", "groove", "gujarati", "gurmukhi", "hand", "hangul", "hangul-consonant", "hebrew", "help",
-    "hidden", "hide", "higher", "highlight", "highlighttext", "hiragana", "hiragana-iroha", "horizontal", "hsl", "hsla", "icon", "ignore",
-    "inactiveborder", "inactivecaption", "inactivecaptiontext", "infinite", "infobackground", "infotext", "inherit", "initial", "inline",
-    "inline-axis", "inline-block", "inline-table", "inset", "inside", "intrinsic", "invert", "italic", "justify", "kannada", "katakana",
-    "katakana-iroha", "khmer", "landscape", "lao", "large", "larger", "left", "level", "lighter", "line-through", "linear", "lines",
-    "list-item", "listbox", "listitem", "local", "logical", "loud", "lower", "lower-alpha", "lower-armenian", "lower-greek",
-    "lower-hexadecimal", "lower-latin", "lower-norwegian", "lower-roman", "lowercase", "ltr", "malayalam", "match", "media-controls-background",
-    "media-current-time-display", "media-fullscreen-button", "media-mute-button", "media-play-button", "media-return-to-realtime-button",
-    "media-rewind-button", "media-seek-back-button", "media-seek-forward-button", "media-slider", "media-sliderthumb", "media-time-remaining-display",
-    "media-volume-slider", "media-volume-slider-container", "media-volume-sliderthumb", "medium", "menu", "menulist", "menulist-button",
-    "menulist-text", "menulist-textfield", "menutext", "message-box", "middle", "min-intrinsic", "mix", "mongolian", "monospace", "move", "multiple",
-    "myanmar", "n-resize", "narrower", "navy", "ne-resize", "nesw-resize", "no-close-quote", "no-drop", "no-open-quote", "no-repeat", "none",
-    "normal", "not-allowed", "nowrap", "ns-resize", "nw-resize", "nwse-resize", "oblique", "octal", "open-quote", "optimizeLegibility",
-    "optimizeSpeed", "oriya", "oromo", "outset", "outside", "overlay", "overline", "padding", "padding-box", "painted", "paused",
-    "persian", "plus-darker", "plus-lighter", "pointer", "portrait", "pre", "pre-line", "pre-wrap", "preserve-3d", "progress",
-    "push-button", "radio", "read-only", "read-write", "read-write-plaintext-only", "relative", "repeat", "repeat-x",
-    "repeat-y", "reset", "reverse", "rgb", "rgba", "ridge", "right", "round", "row-resize", "rtl", "run-in", "running", "s-resize", "sans-serif",
-    "scroll", "scrollbar", "se-resize", "searchfield", "searchfield-cancel-button", "searchfield-decoration", "searchfield-results-button",
-    "searchfield-results-decoration", "semi-condensed", "semi-expanded", "separate", "serif", "show", "sidama", "single",
-    "skip-white-space", "slide", "slider-horizontal", "slider-vertical", "sliderthumb-horizontal", "sliderthumb-vertical", "slow",
-    "small", "small-caps", "small-caption", "smaller", "solid", "somali", "source-atop", "source-in", "source-out", "source-over",
-    "space", "square", "square-button", "start", "static", "status-bar", "stretch", "stroke", "sub", "subpixel-antialiased", "super",
-    "sw-resize", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group",
-    "table-row", "table-row-group", "telugu", "text", "text-bottom", "text-top", "textarea", "textfield", "thai", "thick", "thin",
-    "threeddarkshadow", "threedface", "threedhighlight", "threedlightshadow", "threedshadow", "tibetan", "tigre", "tigrinya-er", "tigrinya-er-abegede",
-    "tigrinya-et", "tigrinya-et-abegede", "to", "top", "transparent", "ultra-condensed", "ultra-expanded", "underline", "up", "upper-alpha", "upper-armenian",
-    "upper-greek", "upper-hexadecimal", "upper-latin", "upper-norwegian", "upper-roman", "uppercase", "urdu", "url", "vertical", "vertical-text", "visible",
-    "visibleFill", "visiblePainted", "visibleStroke", "visual", "w-resize", "wait", "wave", "white", "wider", "window", "windowframe", "windowtext",
-    "x-large", "x-small", "xor", "xx-large", "xx-small", "yellow", "-wap-marquee", "-webkit-activelink", "-webkit-auto", "-webkit-baseline-middle",
-    "-webkit-body", "-webkit-box", "-webkit-center", "-webkit-control", "-webkit-focus-ring-color", "-webkit-grab", "-webkit-grabbing",
-    "-webkit-gradient", "-webkit-inline-box", "-webkit-left", "-webkit-link", "-webkit-marquee", "-webkit-mini-control", "-webkit-nowrap", "-webkit-pictograph",
-    "-webkit-right", "-webkit-small-control", "-webkit-text", "-webkit-xxx-large", "-webkit-zoom-in", "-webkit-zoom-out"]);
+  var propertyKeywords = keySet([
+    "align-content", "align-items", "align-self", "alignment-adjust",
+    "alignment-baseline", "anchor-point", "animation", "animation-delay",
+    "animation-direction", "animation-duration", "animation-iteration-count",
+    "animation-name", "animation-play-state", "animation-timing-function",
+    "appearance", "azimuth", "backface-visibility", "background",
+    "background-attachment", "background-clip", "background-color",
+    "background-image", "background-origin", "background-position",
+    "background-repeat", "background-size", "baseline-shift", "binding",
+    "bleed", "bookmark-label", "bookmark-level", "bookmark-state",
+    "bookmark-target", "border", "border-bottom", "border-bottom-color",
+    "border-bottom-left-radius", "border-bottom-right-radius",
+    "border-bottom-style", "border-bottom-width", "border-collapse",
+    "border-color", "border-image", "border-image-outset",
+    "border-image-repeat", "border-image-slice", "border-image-source",
+    "border-image-width", "border-left", "border-left-color",
+    "border-left-style", "border-left-width", "border-radius", "border-right",
+    "border-right-color", "border-right-style", "border-right-width",
+    "border-spacing", "border-style", "border-top", "border-top-color",
+    "border-top-left-radius", "border-top-right-radius", "border-top-style",
+    "border-top-width", "border-width", "bottom", "box-decoration-break",
+    "box-shadow", "box-sizing", "break-after", "break-before", "break-inside",
+    "caption-side", "clear", "clip", "color", "color-profile", "column-count",
+    "column-fill", "column-gap", "column-rule", "column-rule-color",
+    "column-rule-style", "column-rule-width", "column-span", "column-width",
+    "columns", "content", "counter-increment", "counter-reset", "crop", "cue",
+    "cue-after", "cue-before", "cursor", "direction", "display",
+    "dominant-baseline", "drop-initial-after-adjust",
+    "drop-initial-after-align", "drop-initial-before-adjust",
+    "drop-initial-before-align", "drop-initial-size", "drop-initial-value",
+    "elevation", "empty-cells", "fit", "fit-position", "flex", "flex-basis",
+    "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap",
+    "float", "float-offset", "font", "font-feature-settings", "font-family",
+    "font-kerning", "font-language-override", "font-size", "font-size-adjust",
+    "font-stretch", "font-style", "font-synthesis", "font-variant",
+    "font-variant-alternates", "font-variant-caps", "font-variant-east-asian",
+    "font-variant-ligatures", "font-variant-numeric", "font-variant-position",
+    "font-weight", "grid-cell", "grid-column", "grid-column-align",
+    "grid-column-sizing", "grid-column-span", "grid-columns", "grid-flow",
+    "grid-row", "grid-row-align", "grid-row-sizing", "grid-row-span",
+    "grid-rows", "grid-template", "hanging-punctuation", "height", "hyphens",
+    "icon", "image-orientation", "image-rendering", "image-resolution",
+    "inline-box-align", "justify-content", "left", "letter-spacing",
+    "line-break", "line-height", "line-stacking", "line-stacking-ruby",
+    "line-stacking-shift", "line-stacking-strategy", "list-style",
+    "list-style-image", "list-style-position", "list-style-type", "margin",
+    "margin-bottom", "margin-left", "margin-right", "margin-top",
+    "marker-offset", "marks", "marquee-direction", "marquee-loop",
+    "marquee-play-count", "marquee-speed", "marquee-style", "max-height",
+    "max-width", "min-height", "min-width", "move-to", "nav-down", "nav-index",
+    "nav-left", "nav-right", "nav-up", "opacity", "order", "orphans", "outline",
+    "outline-color", "outline-offset", "outline-style", "outline-width",
+    "overflow", "overflow-style", "overflow-wrap", "overflow-x", "overflow-y",
+    "padding", "padding-bottom", "padding-left", "padding-right", "padding-top",
+    "page", "page-break-after", "page-break-before", "page-break-inside",
+    "page-policy", "pause", "pause-after", "pause-before", "perspective",
+    "perspective-origin", "pitch", "pitch-range", "play-during", "position",
+    "presentation-level", "punctuation-trim", "quotes", "rendering-intent",
+    "resize", "rest", "rest-after", "rest-before", "richness", "right",
+    "rotation", "rotation-point", "ruby-align", "ruby-overhang",
+    "ruby-position", "ruby-span", "size", "speak", "speak-as", "speak-header",
+    "speak-numeral", "speak-punctuation", "speech-rate", "stress", "string-set",
+    "tab-size", "table-layout", "target", "target-name", "target-new",
+    "target-position", "text-align", "text-align-last", "text-decoration",
+    "text-decoration-color", "text-decoration-line", "text-decoration-skip",
+    "text-decoration-style", "text-emphasis", "text-emphasis-color",
+    "text-emphasis-position", "text-emphasis-style", "text-height",
+    "text-indent", "text-justify", "text-outline", "text-shadow",
+    "text-space-collapse", "text-transform", "text-underline-position",
+    "text-wrap", "top", "transform", "transform-origin", "transform-style",
+    "transition", "transition-delay", "transition-duration",
+    "transition-property", "transition-timing-function", "unicode-bidi",
+    "vertical-align", "visibility", "voice-balance", "voice-duration",
+    "voice-family", "voice-pitch", "voice-range", "voice-rate", "voice-stress",
+    "voice-volume", "volume", "white-space", "widows", "width", "word-break",
+    "word-spacing", "word-wrap", "z-index"
+  ]);
+
+  var colorKeywords = keySet([
+    "black", "silver", "gray", "white", "maroon", "red", "purple", "fuchsia",
+    "green", "lime", "olive", "yellow", "navy", "blue", "teal", "aqua"
+  ]);
+  
+  var valueKeywords = keySet([
+    "above", "absolute", "activeborder", "activecaption", "afar",
+    "after-white-space", "ahead", "alias", "all", "all-scroll", "alternate",
+    "always", "amharic", "amharic-abegede", "antialiased", "appworkspace",
+    "arabic-indic", "armenian", "asterisks", "auto", "avoid", "background",
+    "backwards", "baseline", "below", "bidi-override", "binary", "bengali",
+    "blink", "block", "block-axis", "bold", "bolder", "border", "border-box",
+    "both", "bottom", "break-all", "break-word", "button", "button-bevel",
+    "buttonface", "buttonhighlight", "buttonshadow", "buttontext", "cambodian",
+    "capitalize", "caps-lock-indicator", "caption", "captiontext", "caret",
+    "cell", "center", "checkbox", "circle", "cjk-earthly-branch",
+    "cjk-heavenly-stem", "cjk-ideographic", "clear", "clip", "close-quote",
+    "col-resize", "collapse", "compact", "condensed", "contain", "content",
+    "content-box", "context-menu", "continuous", "copy", "cover", "crop",
+    "cross", "crosshair", "currentcolor", "cursive", "dashed", "decimal",
+    "decimal-leading-zero", "default", "default-button", "destination-atop",
+    "destination-in", "destination-out", "destination-over", "devanagari",
+    "disc", "discard", "document", "dot-dash", "dot-dot-dash", "dotted",
+    "double", "down", "e-resize", "ease", "ease-in", "ease-in-out", "ease-out",
+    "element", "ellipsis", "embed", "end", "ethiopic", "ethiopic-abegede",
+    "ethiopic-abegede-am-et", "ethiopic-abegede-gez", "ethiopic-abegede-ti-er",
+    "ethiopic-abegede-ti-et", "ethiopic-halehame-aa-er",
+    "ethiopic-halehame-aa-et", "ethiopic-halehame-am-et",
+    "ethiopic-halehame-gez", "ethiopic-halehame-om-et",
+    "ethiopic-halehame-sid-et", "ethiopic-halehame-so-et",
+    "ethiopic-halehame-ti-er", "ethiopic-halehame-ti-et",
+    "ethiopic-halehame-tig", "ew-resize", "expanded", "extra-condensed",
+    "extra-expanded", "fantasy", "fast", "fill", "fixed", "flat", "footnotes",
+    "forwards", "from", "geometricPrecision", "georgian", "graytext", "groove",
+    "gujarati", "gurmukhi", "hand", "hangul", "hangul-consonant", "hebrew",
+    "help", "hidden", "hide", "higher", "highlight", "highlighttext",
+    "hiragana", "hiragana-iroha", "horizontal", "hsl", "hsla", "icon", "ignore",
+    "inactiveborder", "inactivecaption", "inactivecaptiontext", "infinite",
+    "infobackground", "infotext", "inherit", "initial", "inline", "inline-axis",
+    "inline-block", "inline-table", "inset", "inside", "intrinsic", "invert",
+    "italic", "justify", "kannada", "katakana", "katakana-iroha", "khmer",
+    "landscape", "lao", "large", "larger", "left", "level", "lighter",
+    "line-through", "linear", "lines", "list-item", "listbox", "listitem",
+    "local", "logical", "loud", "lower", "lower-alpha", "lower-armenian",
+    "lower-greek", "lower-hexadecimal", "lower-latin", "lower-norwegian",
+    "lower-roman", "lowercase", "ltr", "malayalam", "match",
+    "media-controls-background", "media-current-time-display",
+    "media-fullscreen-button", "media-mute-button", "media-play-button",
+    "media-return-to-realtime-button", "media-rewind-button",
+    "media-seek-back-button", "media-seek-forward-button", "media-slider",
+    "media-sliderthumb", "media-time-remaining-display", "media-volume-slider",
+    "media-volume-slider-container", "media-volume-sliderthumb", "medium",
+    "menu", "menulist", "menulist-button", "menulist-text",
+    "menulist-textfield", "menutext", "message-box", "middle", "min-intrinsic",
+    "mix", "mongolian", "monospace", "move", "multiple", "myanmar", "n-resize",
+    "narrower", "navy", "ne-resize", "nesw-resize", "no-close-quote", "no-drop",
+    "no-open-quote", "no-repeat", "none", "normal", "not-allowed", "nowrap",
+    "ns-resize", "nw-resize", "nwse-resize", "oblique", "octal", "open-quote",
+    "optimizeLegibility", "optimizeSpeed", "oriya", "oromo", "outset",
+    "outside", "overlay", "overline", "padding", "padding-box", "painted",
+    "paused", "persian", "plus-darker", "plus-lighter", "pointer", "portrait",
+    "pre", "pre-line", "pre-wrap", "preserve-3d", "progress", "push-button",
+    "radio", "read-only", "read-write", "read-write-plaintext-only", "relative",
+    "repeat", "repeat-x", "repeat-y", "reset", "reverse", "rgb", "rgba",
+    "ridge", "right", "round", "row-resize", "rtl", "run-in", "running",
+    "s-resize", "sans-serif", "scroll", "scrollbar", "se-resize", "searchfield",
+    "searchfield-cancel-button", "searchfield-decoration",
+    "searchfield-results-button", "searchfield-results-decoration",
+    "semi-condensed", "semi-expanded", "separate", "serif", "show", "sidama",
+    "single", "skip-white-space", "slide", "slider-horizontal",
+    "slider-vertical", "sliderthumb-horizontal", "sliderthumb-vertical", "slow",
+    "small", "small-caps", "small-caption", "smaller", "solid", "somali",
+    "source-atop", "source-in", "source-out", "source-over", "space", "square",
+    "square-button", "start", "static", "status-bar", "stretch", "stroke",
+    "sub", "subpixel-antialiased", "super", "sw-resize", "table",
+    "table-caption", "table-cell", "table-column", "table-column-group",
+    "table-footer-group", "table-header-group", "table-row", "table-row-group",
+    "telugu", "text", "text-bottom", "text-top", "textarea", "textfield", "thai",
+    "thick", "thin", "threeddarkshadow", "threedface", "threedhighlight",
+    "threedlightshadow", "threedshadow", "tibetan", "tigre", "tigrinya-er",
+    "tigrinya-er-abegede", "tigrinya-et", "tigrinya-et-abegede", "to", "top",
+    "transparent", "ultra-condensed", "ultra-expanded", "underline", "up",
+    "upper-alpha", "upper-armenian", "upper-greek", "upper-hexadecimal",
+    "upper-latin", "upper-norwegian", "upper-roman", "uppercase", "urdu", "url",
+    "vertical", "vertical-text", "visible", "visibleFill", "visiblePainted",
+    "visibleStroke", "visual", "w-resize", "wait", "wave", "white", "wider",
+    "window", "windowframe", "windowtext", "x-large", "x-small", "xor",
+    "xx-large", "xx-small", "yellow"
+  ]);
 
   function keySet(array) { var keys = {}; for (var i = 0; i < array.length; ++i) keys[array[i]] = true; return keys; }
   function ret(style, tp) {type = tp; return style;}
 
   function tokenBase(stream, state) {
     var ch = stream.next();
-    if (ch == "@") {stream.eatWhile(/[\w\\\-]/); return ret("meta", stream.current());}
+    if (ch == "@") {stream.eatWhile(/[\w\\\-]/); return ret("def", stream.current());}
     else if (ch == "/" && stream.eat("*")) {
       state.tokenize = tokenCComment;
       return tokenCComment(stream, state);
@@ -75,21 +211,35 @@ CodeMirror.defineMode("css", function(config) {
     }
     else if (ch == "!") {
       stream.match(/^\s*\w*/);
-      return ret("keyword", "important");
+      return ret("builtin", "important");
     }
     else if (/\d/.test(ch)) {
       stream.eatWhile(/[\w.%]/);
       return ret("number", "unit");
     }
-    else if (/[,.+>*\/]/.test(ch)) {
+    else if (ch === "-") {
+      if (/\d/.test(stream.peek())) {
+        stream.eatWhile(/[\w.%]/);
+        return ret("number", "unit");
+      } else if (stream.match(/^[^-]+-/)) {
+        return ret("meta", type);
+      }
+    }
+    else if (/[,+>*\/]/.test(ch)) {
       return ret(null, "select-op");
     }
-    else if (/[;{}:\[\]\(\)]/.test(ch)) {
+    else if (ch == "." && stream.match(/^\w+/)) {
+      return ret("qualifier", type);
+    }
+    else if (ch == ":") {
+      return ret("operator", ch);
+    }
+    else if (/[;{}\[\]\(\)]/.test(ch)) {
       return ret(null, ch);
     }
     else {
       stream.eatWhile(/[\w\\\-]/);
-      return ret("variable", "variable");
+      return ret("property", "variable");
     }
   }
 
@@ -138,32 +288,156 @@ CodeMirror.defineMode("css", function(config) {
     },
 
     token: function(stream, state) {
+      
+      // Use these terms when applicable (see http://www.xanthir.com/blog/b4E50)
+      // 
+      // rule** or **ruleset:
+      // A selector + braces combo, or an at-rule.
+      // 
+      // declaration block:
+      // A sequence of declarations.
+      // 
+      // declaration:
+      // A property + colon + value combo.
+      // 
+      // property value:
+      // The entire value of a property.
+      // 
+      // component value:
+      // A single piece of a property value. Like the 5px in
+      // text-shadow: 0 0 5px blue;. Can also refer to things that are
+      // multiple terms, like the 1-4 terms that make up the background-size
+      // portion of the background shorthand.
+      // 
+      // term:
+      // The basic unit of author-facing CSS, like a single number (5),
+      // dimension (5px), string ("foo"), or function. Officially defined
+      //  by the CSS 2.1 grammar (look for the 'term' production)
+      // 
+      // 
+      // simple selector:
+      // A single atomic selector, like a type selector, an attr selector, a
+      // class selector, etc.
+      // 
+      // compound selector:
+      // One or more simple selectors without a combinator. div.example is
+      // compound, div > .example is not.
+      // 
+      // complex selector:
+      // One or more compound selectors chained with combinators.
+      // 
+      // combinator:
+      // The parts of selectors that express relationships. There are four
+      // currently - the space (descendant combinator), the greater-than
+      // bracket (child combinator), the plus sign (next sibling combinator),
+      // and the tilda (following sibling combinator).
+      // 
+      // sequence of selectors:
+      // One or more of the named type of selector chained with commas.
+
       if (stream.eatSpace()) return null;
       var style = state.tokenize(stream, state);
 
+      // Changing style returned based on context
       var context = state.stack[state.stack.length-1];
-      if (type == "hash" && context != "rule") style = "string-2";
-      else if (style == "variable") {
-        if (context == "rule") style = keywords[stream.current()] ? "keyword" : "number";
-        else if (!context || context == "@media{") style = "tag";
+      if (style == "property") {
+        if (context == "propertyValue"){
+          if (valueKeywords[stream.current()]) {
+            style = "string-2";
+          } else if (colorKeywords[stream.current()]) {
+            style = "keyword";
+          } else {
+            style = "variable-2";
+          }
+        } else if (context == "rule") {
+          if (!propertyKeywords[stream.current()]) {
+            style += " error";
+          }
+        } else if (!context || context == "@media{") {
+          style = "tag";
+        } else if (context == "@media") {
+          if (atMediaTypes[stream.current()]) {
+            style = "attribute"; // Known attribute
+          } else if (/^(only|not)$/i.test(stream.current())) {
+            style = "keyword";
+          } else if (stream.current().toLowerCase() == "and") {
+            style = "error"; // "and" is only allowed in @mediaType
+          } else if (atMediaFeatures[stream.current()]) {
+            style = "error"; // Known property, should be in @mediaType(
+          } else {
+            // Unknown, expecting keyword or attribute, assuming attribute
+            style = "attribute error";
+          }
+        } else if (context == "@mediaType") {
+          if (atMediaTypes[stream.current()]) {
+            style = "attribute";
+          } else if (stream.current().toLowerCase() == "and") {
+            style = "operator";
+          } else if (/^(only|not)$/i.test(stream.current())) {
+            style = "error"; // Only allowed in @media
+          } else if (atMediaFeatures[stream.current()]) {
+            style = "error"; // Known property, should be in parentheses
+          } else {
+            // Unknown attribute or property, but expecting property (preceded
+            // by "and"). Should be in parentheses
+            style = "error";
+          }
+        } else if (context == "@mediaType(") {
+          if (propertyKeywords[stream.current()]) {
+            // do nothing, remains "property"
+          } else if (atMediaTypes[stream.current()]) {
+            style = "error"; // Known property, should be in parentheses
+          } else if (stream.current().toLowerCase() == "and") {
+            style = "operator";
+          } else if (/^(only|not)$/i.test(stream.current())) {
+            style = "error"; // Only allowed in @media
+          } else {
+            style += " error";
+          }
+        } else {
+          style = "error";
+        }
+      } else if (style == "atom") {
+        if(!context || context == "@media{") {
+          style = "header";
+        } else if (context == "propertyValue") {
+          if (!/^#([0-9a-fA-f]{3}|[0-9a-fA-f]{6})$/.test(stream.current())) {
+            style += " error";
+          }
+        } else {
+          style = "error";
+        }
+      } else if (context == "@media" && type == "{") {
+        style = "error";
       }
 
-      if (context == "rule" && /^[\{\};]$/.test(type))
-        state.stack.pop();
+      // Push/pop context stack
       if (type == "{") {
-        if (context == "@media") state.stack[state.stack.length-1] = "@media{";
-        else state.stack.push("{");
+        if (context == "@media" || context == "@mediaType") {
+          state.stack.pop();
+          state.stack[state.stack.length-1] = "@media{";
+        }
+        else state.stack.push("rule");
       }
-      else if (type == "}") state.stack.pop();
+      else if (type == "}") {
+        state.stack.pop();
+        if (context == "propertyValue") state.stack.pop();
+      }
       else if (type == "@media") state.stack.push("@media");
-      else if (context == "{" && type != "comment") state.stack.push("rule");
+      else if (context == "@media" && /\b(keyword|attribute)\b/.test(style))
+        state.stack.push("@mediaType");
+      else if (context == "@mediaType" && stream.current() == ",") state.stack.pop();
+      else if (context == "@mediaType" && type == "(") state.stack.push("@mediaType(");
+      else if (context == "@mediaType(" && type == ")") state.stack.pop();
+      else if (context == "rule" && type == ":") state.stack.push("propertyValue");
+      else if (context == "propertyValue" && type == ";") state.stack.pop();
       return style;
     },
 
     indent: function(state, textAfter) {
       var n = state.stack.length;
       if (/^\}/.test(textAfter))
-        n -= state.stack[state.stack.length-1] == "rule" ? 2 : 1;
+        n -= state.stack[state.stack.length-1] == "propertyValue" ? 2 : 1;
       return state.baseIndent + n * indentUnit;
     },
 

--- a/mode/css/index.html
+++ b/mode/css/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>
     <script src="css.js"></script>
+    <link rel="stylesheet" href="css.css">
     <style>.CodeMirror {background: #f8f8f8;}</style>
     <link rel="stylesheet" href="../../doc/docs.css">
   </head>
@@ -51,6 +52,8 @@ code {
     </script>
 
     <p><strong>MIME types defined:</strong> <code>text/css</code>.</p>
+
+    <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#css_*">normal</a>,  <a href="../../test/index.html#verbose,css_*">verbose</a>.</p>
 
   </body>
 </html>

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -1,0 +1,501 @@
+// Initiate ModeTest and set defaults
+var MT = ModeTest;
+MT.modeName = 'css';
+MT.modeOptions = {};
+
+// Requires at least one media query
+MT.testMode(
+  'atMediaEmpty',
+  '@media { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'error', '{',
+    null, ' }'
+  ]
+);
+
+MT.testMode(
+  'atMediaMultiple',
+  '@media not screen and (color), not print and (color) { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'keyword', 'not',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'operator', 'and',
+    null, ' (',
+    'property', 'color',
+    null, '), ',
+    'keyword', 'not',
+    null, ' ',
+    'attribute', 'print',
+    null, ' ',
+    'operator', 'and',
+    null, ' (',
+    'property', 'color',
+    null, ') { }'
+  ]
+);
+
+MT.testMode(
+  'atMediaCheckStack',
+  '@media screen { } foo { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' { } ',
+    'tag', 'foo',
+    null, ' { }'
+  ]
+);
+
+MT.testMode(
+  'atMediaCheckStack',
+  '@media screen (color) { } foo { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' (',
+    'property', 'color',
+    null, ') { } ',
+    'tag', 'foo',
+    null, ' { }'
+  ]
+);
+
+MT.testMode(
+  'atMediaCheckStackInvalidAttribute',
+  '@media foobarhello { } foo { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute error', 'foobarhello',
+    null, ' { } ',
+    'tag', 'foo',
+    null, ' { }'
+  ]
+);
+
+// Error, because "and" is only allowed immediately preceding a media expression
+MT.testMode(
+  'atMediaInvalidAttribute',
+  '@media foobarhello { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute error', 'foobarhello',
+    null, ' { }'
+  ]
+);
+
+// Error, because "and" is only allowed immediately preceding a media expression
+MT.testMode(
+  'atMediaInvalidAnd',
+  '@media and screen { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'error', 'and',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' { }'
+  ]
+);
+
+// Error, because "not" is only allowed as the first item in each media query
+MT.testMode(
+  'atMediaInvalidNot',
+  '@media screen not (not) { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'error', 'not',
+    null, ' (',
+    'error', 'not',
+    null, ') { }'
+  ]
+);
+
+// Error, because "only" is only allowed as the first item in each media query
+MT.testMode(
+  'atMediaInvalidOnly',
+  '@media screen only (only) { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'error', 'only',
+    null, ' (',
+    'error', 'only',
+    null, ') { }'
+  ]
+);
+
+// Error, because "foobarhello" is neither a known type or property, but
+// property was expected (after "and"), and it should be in parenthese.
+MT.testMode(
+  'atMediaUnknownType',
+  '@media screen and foobarhello { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'operator', 'and',
+    null, ' ',
+    'error', 'foobarhello',
+    null, ' { }'
+  ]
+);
+
+// Error, because "color" is not a known type, but is a known property, and
+// should be in parentheses.
+MT.testMode(
+  'atMediaInvalidType',
+  '@media screen and color { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'operator', 'and',
+    null, ' ',
+    'error', 'color',
+    null, ' { }'
+  ]
+);
+
+// Error, because "print" is not a known property, but is a known type,
+// and should not be in parenthese.
+MT.testMode(
+  'atMediaInvalidProperty',
+  '@media screen and (print) { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'operator', 'and',
+    null, ' (',
+    'error', 'print',
+    null, ') { }'
+  ]
+);
+
+// Soft error, because "foobarhello" is not a known property or type.
+MT.testMode(
+  'atMediaUnknownProperty',
+  '@media screen and (foobarhello) { }',
+  [
+    'def', '@media',
+    null, ' ',
+    'attribute', 'screen',
+    null, ' ',
+    'operator', 'and',
+    null, ' (',
+    'property error', 'foobarhello',
+    null, ') { }'
+  ]
+);
+
+MT.testMode(
+  'tagSelector',
+  'foo { }',
+  [
+    'tag', 'foo',
+    null, ' { }'
+  ]
+);
+
+MT.testMode(
+  'classSelector',
+  '.foo { }',
+  [
+    'qualifier', '.foo',
+    null, ' { }'
+  ]
+);
+
+MT.testMode(
+  'idSelector',
+  '#foo { #foo }',
+  [
+    'header', '#foo',
+    null, ' { ',
+    'error', '#foo',
+    null, ' }'
+  ]
+);
+
+MT.testMode(
+  'tagSelectorUnclosed',
+  'foo { margin: 0 } bar { }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'margin',
+    'operator', ':',
+    null, ' ',
+    'number', '0',
+    null, ' } ',
+    'tag', 'bar',
+    null, ' { }'
+  ]
+);
+
+MT.testMode(
+  'tagStringNoQuotes',
+  'foo { font-family: hello world; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'font-family',
+    'operator', ':',
+    null, ' ',
+    'variable-2', 'hello',
+    null, ' ',
+    'variable-2', 'world',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagStringDouble',
+  'foo { font-family: "hello world"; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'font-family',
+    'operator', ':',
+    null, ' ',
+    'string', '"hello world"',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagStringSingle',
+  'foo { font-family: \'hello world\'; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'font-family',
+    'operator', ':',
+    null, ' ',
+    'string', '\'hello world\'',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagColorKeyword',
+  'foo { color: black; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'color',
+    'operator', ':',
+    null, ' ',
+    'keyword', 'black',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagColorHex3',
+  'foo { background: #fff; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'background',
+    'operator', ':',
+    null, ' ',
+    'atom', '#fff',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagColorHex6',
+  'foo { background: #ffffff; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'background',
+    'operator', ':',
+    null, ' ',
+    'atom', '#ffffff',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagColorHex4',
+  'foo { background: #ffff; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'background',
+    'operator', ':',
+    null, ' ',
+    'atom error', '#ffff',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagColorHexInvalid',
+  'foo { background: #ffg; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'background',
+    'operator', ':',
+    null, ' ',
+    'atom error', '#ffg',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagNegativeNumber',
+  'foo { margin: -5px; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'margin',
+    'operator', ':',
+    null, ' ',
+    'number', '-5px',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagPositiveNumber',
+  'foo { padding: 5px; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'padding',
+    'operator', ':',
+    null, ' ',
+    'number', '5px',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagVendor',
+  'foo { -foo-box-sizing: -foo-border-box; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'meta', '-foo-',
+    'property', 'box-sizing',
+    'operator', ':',
+    null, ' ',
+    'meta', '-foo-',
+    'string-2', 'border-box',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagBogusProperty',
+  'foo { barhelloworld: 0; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property error', 'barhelloworld',
+    'operator', ':',
+    null, ' ',
+    'number', '0',
+    null, '; }'
+  ]
+);
+
+MT.testMode(
+  'tagTwoProperties',
+  'foo { margin: 0; padding: 0; }',
+  [
+    'tag', 'foo',
+    null, ' { ',
+    'property', 'margin',
+    'operator', ':',
+    null, ' ',
+    'number', '0',
+    null, '; ',
+    'property', 'padding',
+    'operator', ':',
+    null, ' ',
+    'number', '0',
+    null, '; }'
+  ]
+);
+//
+//MT.testMode(
+//  'tagClass',
+//  '@media only screen and (min-width: 500px), print {foo.bar#hello { color: black !important; background: #f00; margin: -5px; padding: 5px; -foo-box-sizing: border-box; } /* world */}',
+//  [
+//    'def', '@media',
+//    null, ' ',
+//    'keyword', 'only',
+//    null, ' ',
+//    'attribute', 'screen',
+//    null, ' ',
+//    'operator', 'and',
+//    null, ' ',
+//    'bracket', '(',
+//    'property', 'min-width',
+//    'operator', ':',
+//    null, ' ',
+//    'number', '500px',
+//    'bracket', ')',
+//    null, ', ',
+//    'attribute', 'print',
+//    null, ' {',
+//    'tag', 'foo',
+//    'qualifier', '.bar',
+//    'header', '#hello',
+//    null, ' { ',
+//    'property', 'color',
+//    'operator', ':',
+//    null, ' ',
+//    'keyword', 'black',
+//    null, ' ',
+//    'builtin', '!important',
+//    null, '; ',
+//    'property', 'background',
+//    'operator', ':',
+//    null, ' ',
+//    'atom', '#f00',
+//    null, '; ',
+//    'property', 'padding',
+//    'operator', ':',
+//    null, ' ',
+//    'number', '5px',
+//    null, '; ',
+//    'property', 'margin',
+//    'operator', ':',
+//    null, ' ',
+//    'number', '-5px',
+//    null, '; ',
+//    'meta', '-foo-',
+//    'property', 'box-sizing',
+//    'operator', ':',
+//    null, ' ',
+//    'string-2', 'border-box',
+//    null, '; } ',
+//    'comment', '/* world */',
+//    null, '}'
+//  ]
+//);

--- a/test/index.html
+++ b/test/index.html
@@ -39,6 +39,8 @@
     <script src="driver.js"></script>
     <script src="test.js"></script>
     <script src="mode_test.js"></script>
+    <script src="../mode/css/css.js"></script>
+    <script src="../mode/css/test.js"></script>
     <script src="../mode/markdown/markdown.js"></script>
     <script src="../mode/markdown/test.js"></script>
     <script src="../mode/stex/stex.js"></script>


### PR DESCRIPTION
- Added link to tests on mode page
- More consistent naming with CSS spec (some of the previous var naming was completely incorrect/misleading)
- Improved highlighting
  - Match vendor prefixes
  - Check for known properties and values (known properties are bold, unknown are not)
  - Added highlighting for media queries
- Cleaner stacking of state
