### PR TITLE
Add a text-shadow behind test progress text so it's readable while the progress bar hasn't passed yet.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
       #progress {
         background: #45d;
         color: white;
+        text-shadow: 0 0 1px #45d, 0 0 2px #45d, 0 0 3px #45d;
         font-weight: bold;
         white-space: pre;
       }


### PR DESCRIPTION
The progress text (`Ran # of # tests`) is impossible to read at the beginning of the test suite. This patch simply adds a shadow behind the text that's the same color as the progress bar, so it's readable while testing and doesn't affect the final display.
