### PR TITLE
Fix to make util/closetag work with overlay modes.

### DIFF
--- a/lib/util/closetag.js
+++ b/lib/util/closetag.js
@@ -34,6 +34,7 @@
 
 	function innerState(state) {
 		// htmlmixed uses .htmlState, PHP .html, XML just the top state object
+		state = state.base || state;
 		return state.htmlState || state.html || state;
 	}
 
@@ -51,8 +52,8 @@
 		}
 		
 		
-		if (/^(xml|php|htmlmixed)$/.test(resolveMode(cm.getOption('mode')))) {
 		
+		if (/(xml|php|htmlmixed)/.test(resolveMode(cm.getOption('mode')))) {
 			/*
 			 * Relevant structure of token:
 			 *


### PR DESCRIPTION
In defined HTML overlay modes (like `htmlmixed+liquid`), the current closetag implementation will just bail out during the very specific mode check. If you change just the mode check to let it pass, it still won't be able to get to the nested modes.

This patch is my, admittedly, naive attempt to fix both of these issues. I am fully aware that there is probably a better way to go about this, and welcome any such feedback :)
