### PR TITLE
Fix issue with overwrite functionality (closes #828).

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1033,7 +1033,7 @@ window.CodeMirror = (function() {
     if (same < prevInput.length)
       sel.from = {line: sel.from.line, ch: sel.from.ch - (prevInput.length - same)};
     else if (view.overwrite && posEq(sel.from, sel.to))
-      sel.to = {line: sel.to.line, ch: Math.min(getLine(doc, sel.to.line).text.length, sel.to.ch + (text.length - same))};
+      sel.to = {line: sel.to.line, ch: Math.min(getLine(cm.view.doc, sel.to.line).text.length, sel.to.ch + (text.length - same))};
     cm.replaceSelection(text.slice(same), "end");
     if (text.length > 1000) { input.value = cm.display.prevInput = ""; }
     else cm.display.prevInput = text;


### PR DESCRIPTION
Just in case @azawawi doesn't submit a pull request for his patch.

Note: `view.doc` could be used instead of `cm.view.doc`, but I'm not sure if you just used the `view` variable as a quick hack to get CM working after the refactor faster, or if you want to stick with the shorter vars.
