### PR TITLE
Fix formatting demo's "[Un]Comment Selected" functionality (closes #826)

### DIFF
--- a/lib/util/formatting.js
+++ b/lib/util/formatting.js
@@ -128,15 +128,15 @@
 
   // Comment/uncomment the specified range
   CodeMirror.defineExtension("commentRange", function (isComment, from, to) {
-    var curMode = localModeAt(this, from);
+    var curMode = localModeAt(this, from), cm = this;
     this.operation(function() {
       if (isComment) { // Comment range
-        this.replaceRange(curMode.commentEnd, to);
-        this.replaceRange(curMode.commentStart, from);
+        cm.replaceRange(curMode.commentEnd, to);
+        cm.replaceRange(curMode.commentStart, from);
         if (from.line == to.line && from.ch == to.ch) // An empty comment inserted - put cursor inside
-          this.setCursor(from.line, from.ch + curMode.commentStart.length);
+          cm.setCursor(from.line, from.ch + curMode.commentStart.length);
       } else { // Uncomment range
-        var selText = this.getRange(from, to);
+        var selText = cm.getRange(from, to);
         var startIndex = selText.indexOf(curMode.commentStart);
         var endIndex = selText.lastIndexOf(curMode.commentEnd);
         if (startIndex > -1 && endIndex > -1 && endIndex > startIndex) {
@@ -147,7 +147,7 @@
           // From comment end till string end
             + selText.substr(endIndex + curMode.commentEnd.length);
         }
-        this.replaceRange(selText, from, to);
+        cm.replaceRange(selText, from, to);
       }
     });
   });


### PR DESCRIPTION
Only broken in v2, so no need to add this to v3 as well.
