### PR TITLE
[markdown] Fix bug with false positive matches of inline links.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -181,7 +181,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return getType(state);
     }
     
-    if (ch === '[' && stream.match(/.*\] ?(?:\(|\[)/, false)) {
+    if (ch === '[' && stream.match(/.*\](\(| ?\[)/, false)) {
       return switchInline(stream, state, linkText);
     }
     

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -660,6 +660,17 @@ MT.testMode(
   ]
 );
 
+// Not a link. Should be normal text due to square brackets being used
+// regularly in text, especially in quoted material, and no space is allowed
+// between square brackets and parentheses (per Dingus).
+MT.testMode(
+  'notALink',
+  '[foo] (bar)',
+  [
+    null, '[foo] (bar)'
+  ]
+);
+
 // Reference-style links
 MT.testMode(
   'linkReference',


### PR DESCRIPTION
- Inline links (square brackets followed by parentheses) cannot be separated by space (per Documentation and [Dingus](http://daringfireball.net/projects/markdown/dingus)).
- Added test that checks both for this fix and correct highlighting of square brackets by themselves (fixed in 8b3c1b4e3d6b0d9bc0e2d66247d564ca0d36f339)
