### PR TITLE
Make runmode escaping global and affect >s too

### DIFF
--- a/lib/util/runmode.js
+++ b/lib/util/runmode.js
@@ -1,6 +1,6 @@
 CodeMirror.runMode = function(string, modespec, callback, options) {
   function esc(str) {
-    return str.replace(/[<&]/, function(ch) { return ch == "<" ? "&lt;" : "&amp;"; });
+    return str.replace(/[<>&]/g, function(ch) { return ch == "<" ? "&lt;" : (ch == ">" ? "&gt;" : "&amp;"); });
   }
 
   var mode = CodeMirror.getMode(CodeMirror.defaults, modespec);


### PR DESCRIPTION
Just a quick fix since I noticed using runmode on some test HTML resulted in unescaped tags hanging around in the output.

Reproducible with:

```
<!DOCTYPE html>
<html>
<head>
    <meta charset="UTF-8">
    <title>Test</title>
</head>
<body>
    <script>if (!Modernizr.backgroundsize) document.write('<div id="fallback-bg"><div><img src="assets/fallback-bg.jpg"></div></div>');</script>
</body>
</html>
```
