### PR TITLE
[markdown] Fix performance issue with regex matching of single closing chars (closes #862).

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -287,15 +287,16 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     return linkhref;
   }
 
+  var savedInlineRE = [];
   function inlineRE(endChar) {
-    if (!inlineRE[endChar]) {
+    if (!savedInlineRE[endChar]) {
       // Escape endChar for RegExp (taken from http://stackoverflow.com/a/494122/526741)
       endChar = (endChar+'').replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
       // Match any non-endChar, escaped character, as well as the closing 
       // endChar.
-      inlineRE[endChar] = new RegExp('^(?:[^\\\\]+?|\\\\.)*?(' + endChar + ')');
+      savedInlineRE[endChar] = new RegExp('^(?:[^\\\\]|\\\\.)*?(' + endChar + ')');
     }
-    return inlineRE[endChar];
+    return savedInlineRE[endChar];
   }
 
   function inlineElement(type, endChar, next) {


### PR DESCRIPTION
The performance issue came from using `[^\\\\]+?` instead of just `[^\\\\]` inside the regex.

Also, a global variable snuck through, so I fixed that as well.
