### PR TITLE
[Markdown] [GFM] Rewrite GFM to inherit changes from Markdown mode better.

### DIFF
--- a/lib/util/overlay.js
+++ b/lib/util/overlay.js
@@ -49,6 +49,11 @@ CodeMirror.overlayMode = CodeMirror.overlayParser = function(base, overlay, comb
     },
     electricChars: base.electricChars,
 
-    innerMode: function(state) { return {state: state.base, mode: base}; }
+    innerMode: function(state) { return {state: state.base, mode: base}; },
+    
+    blankLine: function(state) {
+      if (base.blankLine) base.blankLine(state.base);
+      if (overlay.blankLine) overlay.blankLine(state.overlay);
+    }
   };
 };

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -1,150 +1,94 @@
 CodeMirror.defineMode("gfm", function(config, parserConfig) {
-  var mdMode = CodeMirror.getMode(config, "markdown");
-  var aliases = {
-    html: "htmlmixed",
-    js: "javascript",
-    json: "application/json",
-    c: "text/x-csrc",
-    "c++": "text/x-c++src",
-    java: "text/x-java",
-    csharp: "text/x-csharp",
-    "c#": "text/x-csharp"
-  };
-
-  // make this lazy so that we don't need to load GFM last
-  var getMode = (function () {
-    var i, modes = {}, mimes = {}, mime;
-
-    var list = CodeMirror.listModes();
-    for (i = 0; i < list.length; i++) {
-      modes[list[i]] = list[i];
-    }
-    var mimesList = CodeMirror.listMIMEs();
-    for (i = 0; i < mimesList.length; i++) {
-      mime = mimesList[i].mime;
-      mimes[mime] = mimesList[i].mime;
-    }
-
-    for (var a in aliases) {
-      if (aliases[a] in modes || aliases[a] in mimes)
-        modes[a] = aliases[a];
-    }
-    
-    return function (lang) {
-      return modes[lang] ? CodeMirror.getMode(config, modes[lang]) : null;
-    };
-  }());
-
-  function markdown(stream, state) {
-    // intercept fenced code blocks
-    if (stream.sol() && stream.match(/^```([\w+#]*)/)) {
-      // try switching mode
-      state.localMode = getMode(RegExp.$1);
-      if (state.localMode)
-        state.localState = state.localMode.startState();
-
-      state.token = local;
-      return 'code';
-    }
-
-    return mdMode.token(stream, state.mdState);
+  var codeDepth = 0;
+  function blankLine(state) {
+    state.code = false;
+    return null;
   }
-
-  function local(stream, state) {
-    if (stream.sol() && stream.match(/^```/)) {
-      state.localMode = state.localState = null;
-      state.token = markdown;
-      return 'code';
-    }
-    else if (state.localMode) {
-      return state.localMode.token(stream, state.localState);
-    } else {
-      stream.skipToEnd();
-      return 'code';
-    }
-  }
-
-  // custom handleText to prevent emphasis in the middle of a word
-  // and add autolinking
-  function handleText(stream, mdState) {
-    var match;
-    if (stream.match(/^\w+:\/\/\S+/)) {
-      return 'link';
-    }
-    if (stream.match(/^[^\[*\\<>` _][^\[*\\<>` ]*[^\[*\\<>` _]/)) {
-      return mdMode.getType(mdState);
-    }
-    if (match = stream.match(/^[^\[*\\<>` ]+/)) {
-      var word = match[0];
-      if (word[0] === '_' && word[word.length-1] === '_') {
-        stream.backUp(word.length);
-        return undefined;
-      }
-      return mdMode.getType(mdState);
-    }
-    if (stream.eatSpace()) {
-      return null;
-    }
-  }
-
-  return {
+  var gfmOverlay = {
     startState: function() {
-      var mdState = mdMode.startState();
-      mdState.text = handleText;
-      return {token: markdown, mode: "markdown", mdState: mdState,
-              localMode: null, localState: null};
+      return {
+        code: false,
+        codeBlock: false,
+        ateSpace: false
+      };
     },
-
-    copyState: function(state) {
-      return {token: state.token, mdState: CodeMirror.copyState(mdMode, state.mdState),
-              localMode: state.localMode,
-              localState: state.localMode ? CodeMirror.copyState(state.localMode, state.localState) : null};
+    copyState: function(s) {
+      return {
+        code: s.code,
+        codeBlock: s.codeBlock,
+        ateSpace: s.ateSpace
+      };
     },
-
     token: function(stream, state) {
-        /* Parse GFM double bracket links */
-        var ch;
-        if ((ch = stream.peek()) != undefined && ch == '[') {
-            stream.next(); // Advance the stream
-
-            /* Only handle double bracket links */
-            if ((ch = stream.peek()) == undefined || ch != '[') {
-                stream.backUp(1);
-                return state.token(stream, state);
-            } 
-
-            while ((ch = stream.next()) != undefined && ch != ']') {}
-
-            if (ch == ']' && (ch = stream.next()) != undefined && ch == ']') 
-                return 'link';
-
-            /* If we did not find the second ']' */
-            stream.backUp(1);
+      // Hack to prevent formatting override inside code blocks (block and inline)
+      if (state.codeBlock) {
+        if (stream.match(/^```/)) {
+          state.codeBlock = false;
+          return null;
         }
-
-        /* Match GFM latex formulas, as well as latex formulas within '$' */
-        if (stream.match(/^\$[^\$]+\$/)) {
-            return "string";
+        stream.skipToEnd();
+        return null;
+      }
+      if (stream.sol()) {
+        state.code = false;
+      }
+      if (stream.sol() && stream.match(/^```/)) {
+        stream.skipToEnd();
+        state.codeBlock = true;
+        return null;
+      }
+      // If this block is changed, it may need to be updated in Markdown mode
+      if (stream.peek() === '`') {
+        stream.next();
+        var before = stream.pos;
+        stream.eatWhile('`');
+        var difference = 1 + stream.pos - before;
+        if (!state.code) {
+          codeDepth = difference;
+          state.code = true;
+        } else {
+          if (difference === codeDepth) { // Must be exact
+            state.code = false;
+          }
         }
-
-        if (stream.match(/^\\\((.*?)\\\)/)) {
-            return "string";
+        return null;
+      } else if (state.code) {
+        stream.next();
+        return null;
+      }
+      // Check if space. If so, links can be formatted later on
+      if (stream.eatSpace()) {
+        state.ateSpace = true;
+        return null;
+      }
+      if (stream.sol() || state.ateSpace) {
+        state.ateSpace = false;
+        if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
+          // User/Project@SHA
+          // User@SHA
+          // SHA
+          return "link";
+        } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+)?#[0-9]+\b/)) {
+          // User/Project#Num
+          // User#Num
+          // #Num
+          return "link";
         }
-
-        if (stream.match(/^\$\$[^\$]+\$\$/)) {
-            return "string";
-        }
-        
-        if (stream.match(/^\\\[(.*?)\\\]/)) {
-            return "string";
-        }
-
-        return state.token(stream, state);
+      }
+      if (stream.match(/^((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i)) {
+        // URLs
+        // Taken from http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+        return "link";
+      }
+      stream.next();
+      return null;
     },
-
-    innerMode: function(state) {
-      if (state.token == markdown) return {state: state.mdState, mode: mdMode};
-      else return {state: state.localState, mode: state.localMode};
-    }
+    blankLine: blankLine
   };
-}, "markdown");
+  CodeMirror.defineMIME("gfmBase", {
+    name: "markdown",
+    underscoresBreakWords: false,
+    fencedCodeBlocks: true
+  });
+  return CodeMirror.overlayMode(CodeMirror.getMode(config, "gfmBase"), gfmOverlay);
+});

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -5,10 +5,17 @@
     <title>CodeMirror: GFM mode</title>
     <link rel="stylesheet" href="../../lib/codemirror.css">
     <script src="../../lib/codemirror.js"></script>
+    <script src="../../lib/util/overlay.js"></script>
     <script src="../xml/xml.js"></script>
     <script src="../markdown/markdown.js"></script>
     <script src="gfm.js"></script>
+    
+    <!-- Code block highlighting modes -->
     <script src="../javascript/javascript.js"></script>
+    <script src="../css/css.js"></script>
+    <script src="../htmlmixed/htmlmixed.js"></script>
+    <script src="../clike/clike.js"></script>
+    
     <link rel="stylesheet" href="../markdown/markdown.css">
     <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
     <link rel="stylesheet" href="../../doc/docs.css">
@@ -16,14 +23,17 @@
   <body>
     <h1>CodeMirror: GFM mode</h1>
 
-<!-- source: http://daringfireball.net/projects/markdown/basics.text -->
 <form><textarea id="code" name="code">
-Github Flavored Markdown
+GitHub Flavored Markdown
 ========================
 
 Everything from markdown plus GFM features:
 
-## Fenced code blocks
+## URL autolinking
+
+Underscores_are_allowed_between_words.
+
+## Fenced code blocks (and syntax highlighting... someday)
 
 ```javascript
 for (var i = 0; i &lt; items.length; i++) {
@@ -31,7 +41,16 @@ for (var i = 0; i &lt; items.length; i++) {
 }
 ```
 
-See http://github.github.com/github-flavored-markdown/
+## A bit of GitHub spice
+
+* SHA: be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User@SHA ref: mojombo@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User/Project@SHA: mojombo/god@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* \#Num: #1
+* User/#Num: mojombo#1
+* User/Project#Num: mojombo/god#1
+
+See http://github.github.com/github-flavored-markdown/.
 
 </textarea></form>
 

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -1,0 +1,225 @@
+// Initiate ModeTest and set defaults
+var MT = ModeTest;
+MT.modeName = 'gfm';
+MT.modeOptions = {};
+
+// Emphasis characters within a word
+MT.testMode(
+  'emInWordAsterisk',
+  'foo*bar*hello',
+  [
+    null, 'foo',
+    'em', '*bar*',
+    null, 'hello'
+  ]
+);
+MT.testMode(
+  'emInWordUnderscore',
+  'foo_bar_hello',
+  [
+    null, 'foo_bar_hello'
+  ]
+);
+MT.testMode(
+  'emStrongUnderscore',
+  '___foo___ bar',
+  [
+    'strong', '__',
+    'emstrong', '_foo__',
+    'em', '_',
+    null, ' bar'
+  ]
+);
+
+// Fenced code blocks
+MT.testMode(
+  'fencedCodeBlocks',
+  '```\nfoo\n\n```\nbar',
+  [
+    'comment', '```',
+    'comment', 'foo',
+    'comment', '```',
+    null, 'bar'
+  ]
+);
+// Fenced code block mode switching
+MT.testMode(
+  'fencedCodeBlockModeSwitching',
+  '```javascript\nfoo\n\n```\nbar',
+  [
+    'comment', '```javascript',
+    'variable', 'foo',
+    'comment', '```',
+    null, 'bar'
+  ]
+);
+
+// SHA
+MT.testMode(
+  'SHA',
+  'foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2 bar',
+  [
+    null, 'foo ',
+    'link', 'be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2',
+    null, ' bar'
+  ]
+);
+// GitHub highlights hashes 7-40 chars in length
+MT.testMode(
+  'shortSHA',
+  'foo be6a8cc bar',
+  [
+    null, 'foo ',
+    'link', 'be6a8cc',
+    null, ' bar'
+  ]
+);
+// Invalid SHAs
+// 
+// GitHub does not highlight hashes shorter than 7 chars
+MT.testMode(
+  'tooShortSHA',
+  'foo be6a8c bar',
+  [
+    null, 'foo be6a8c bar'
+  ]
+);
+// GitHub does not highlight hashes longer than 40 chars
+MT.testMode(
+  'longSHA',
+  'foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd22 bar',
+  [
+    null, 'foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd22 bar'
+  ]
+);
+MT.testMode(
+  'badSHA',
+  'foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cg2 bar',
+  [
+    null, 'foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cg2 bar'
+  ]
+);
+// User@SHA
+MT.testMode(
+  'userSHA',
+  'foo bar@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2 hello',
+  [
+    null, 'foo ',
+    'link', 'bar@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2',
+    null, ' hello'
+  ]
+);
+// User/Project@SHA
+MT.testMode(
+  'userProjectSHA',
+  'foo bar/hello@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2 world',
+  [
+    null, 'foo ',
+    'link', 'bar/hello@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2',
+    null, ' world'
+  ]
+);
+
+// #Num
+MT.testMode(
+  'num',
+  'foo #1 bar',
+  [
+    null, 'foo ',
+    'link', '#1',
+    null, ' bar'
+  ]
+);
+// bad #Num
+MT.testMode(
+  'badNum',
+  'foo #1bar hello',
+  [
+    null, 'foo #1bar hello'
+  ]
+);
+// User#Num
+MT.testMode(
+  'userNum',
+  'foo bar#1 hello',
+  [
+    null, 'foo ',
+    'link', 'bar#1',
+    null, ' hello'
+  ]
+);
+// User/Project#Num
+MT.testMode(
+  'userProjectNum',
+  'foo bar/hello#1 world',
+  [
+    null, 'foo ',
+    'link', 'bar/hello#1',
+    null, ' world'
+  ]
+);
+
+// Vanilla links
+MT.testMode(
+  'vanillaLink',
+  'foo http://www.example.com/ bar',
+  [
+    null, 'foo ',
+    'link', 'http://www.example.com/',
+    null, ' bar'
+  ]
+);
+MT.testMode(
+  'vanillaLinkPunctuation',
+  'foo http://www.example.com/. bar',
+  [
+    null, 'foo ',
+    'link', 'http://www.example.com/',
+    null, '. bar'
+  ]
+);
+MT.testMode(
+  'vanillaLinkExtension',
+  'foo http://www.example.com/index.html bar',
+  [
+    null, 'foo ',
+    'link', 'http://www.example.com/index.html',
+    null, ' bar'
+  ]
+);
+// Not a link
+MT.testMode(
+  'notALink',
+  '```css\nfoo {color:black;}\n```http://www.example.com/',
+  [
+    'comment', '```css',
+    'tag', 'foo',
+    null, ' {',
+    'property', 'color',
+    'operator', ':',
+    'keyword', 'black',
+    null, ';}',
+    'comment', '```',
+    'link', 'http://www.example.com/'
+  ]
+);
+// Not a link
+MT.testMode(
+  'notALink',
+  '``foo `bar` http://www.example.com/`` hello',
+  [
+    'comment', '``foo `bar` http://www.example.com/``',
+    null, ' hello'
+  ]
+);
+// Not a link
+MT.testMode(
+  'notALink',
+  '`foo\nhttp://www.example.com/\n`foo\n\nhttp://www.example.com/',
+  [
+    'comment', '`foo',
+    'link', 'http://www.example.com/',
+    'comment', '`foo',
+    'link', 'http://www.example.com/'
+  ]
+);

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -2,6 +2,46 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
   var htmlFound = CodeMirror.mimeModes.hasOwnProperty("text/html");
   var htmlMode = CodeMirror.getMode(cmCfg, htmlFound ? "text/html" : "text/plain");
+  var aliases = {
+    html: "htmlmixed",
+    js: "javascript",
+    json: "application/json",
+    c: "text/x-csrc",
+    "c++": "text/x-c++src",
+    java: "text/x-java",
+    csharp: "text/x-csharp",
+    "c#": "text/x-csharp"
+  };
+
+  var getMode = (function () {
+    var i, modes = {}, mimes = {}, mime;
+
+    var list = CodeMirror.listModes();
+    for (i = 0; i < list.length; i++) {
+      modes[list[i]] = list[i];
+    }
+    var mimesList = CodeMirror.listMIMEs();
+    for (i = 0; i < mimesList.length; i++) {
+      mime = mimesList[i].mime;
+      mimes[mime] = mimesList[i].mime;
+    }
+
+    for (var a in aliases) {
+      if (aliases[a] in modes || aliases[a] in mimes)
+        modes[a] = aliases[a];
+    }
+    
+    return function (lang) {
+      return modes[lang] ? CodeMirror.getMode(cmCfg, modes[lang]) : null;
+    };
+  }());
+  
+  // Should underscores in words open/close em/strong?
+  if (modeCfg.underscoresBreakWords === undefined)
+    modeCfg.underscoresBreakWords = true;
+  
+  // Turn on fenced code blocks? ("```" to start/end)
+  if (modeCfg.fencedCodeBlocks === undefined) modeCfg.fencedCodeBlocks = false;
   
   var codeDepth = 0;
   var prevLineHasContent = false
@@ -42,8 +82,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   function blankLine(state) {
     // Reset linkTitle state
     state.linkTitle = false;
-    // Reset CODE state
-    state.code = false;
     // Reset EM state
     state.em = false;
     // Reset STRONG state
@@ -58,7 +96,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   }
 
   function blockNormal(stream, state) {
-    var match;
     
     if (state.list !== false && state.indentationDiff >= 0) { // Continued list
       if (state.indentationDiff < 4) { // Only adjust indentation if *not* a code block
@@ -84,9 +121,15 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return switchInline(stream, state, footnoteLink);
     } else if (stream.match(hrRE, true)) {
       return hr;
-    } else if (match = stream.match(ulRE, true) || stream.match(olRE, true)) {
+    } else if (stream.match(ulRE, true) || stream.match(olRE, true)) {
       state.indentation += 4;
       state.list = true;
+    } else if (modeCfg.fencedCodeBlocks && stream.match(/^```([\w+#]*)/, true)) {
+      // try switching mode
+      state.localMode = getMode(RegExp.$1);
+      if (state.localMode) state.localState = state.localMode.startState();
+      switchBlock(stream, state, local);
+      return code;
     }
     
     return switchInline(stream, state, state.inline);
@@ -106,6 +149,30 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     return style;
   }
 
+  function local(stream, state) {
+    if (stream.sol() && stream.match(/^```/, true)) {
+      state.localMode = state.localState = null;
+      state.f = inlineNormal;
+      state.block = blockNormal;
+      return code;
+    } else if (state.localMode) {
+      return state.localMode.token(stream, state.localState);
+    } else {
+      stream.skipToEnd();
+      return code;
+    }
+  }
+
+  function codeBlock(stream, state) {
+    if(stream.match(codeBlockRE, true)){
+      state.f = inlineNormal;
+      state.block = blockNormal;
+      switchInline(stream, state, state.inline);
+      return code;
+    }
+    stream.skipToEnd();
+    return code;
+  }
 
   // Inline
   function getType(state) {
@@ -161,6 +228,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       }
     }
     
+    // If this block is changed, it may need to be updated in GFM mode
     if (ch === '`') {
       var t = getType(state);
       var before = stream.pos;
@@ -210,8 +278,20 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return "tag";
     }
       
+    var ignoreUnderscore = false;
+    if (!modeCfg.underscoresBreakWords) {
+      if (ch === '_' && stream.peek() !== '_' && stream.match(/(\w)/, false)) {
+        var prevPos = stream.pos - 2;
+        if (prevPos >= 0) {
+          var prevCh = stream.string.charAt(prevPos);
+          if (prevCh !== '_' && prevCh.match(/(\w)/, false)) {
+            ignoreUnderscore = true;
+          }
+        }
+      }
+    }
     var t = getType(state);
-    if (ch === '*' || ch === '_') {
+    if (ch === '*' || (ch === '_' && !ignoreUnderscore)) {
       if (state.strong === ch && stream.eat(ch)) { // Remove STRONG
         state.strong = false;
         return t;
@@ -334,6 +414,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         block: s.block,
         htmlState: CodeMirror.copyState(htmlMode, s.htmlState),
         indentation: s.indentation,
+        
+        localMode: s.localMode,
+        localState: s.localMode ? CodeMirror.copyState(s.localMode, s.localState) : null,
           
         inline: s.inline,
         text: s.text,
@@ -362,6 +445,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
         // Reset state.header
         state.header = false;
+        
+        // Reset state.code
+        state.code = false;
 
         state.f = state.block;
         var indentation = stream.match(/^\s*/, true)[0].replace(/\t/g, '    ').length;

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -41,6 +41,17 @@ MT.testMode(
   ]
 );
 
+// Block code using single backtick (shouldn't work)
+MT.testMode(
+  'blockCodeSingleBacktick',
+  '`\nfoo\n`',
+  [
+    'comment', '`',
+    null, 'foo',
+    'comment', '`'
+  ]
+);
+
 // Unclosed backticks
 // Instead of simply marking as CODE, it would be nice to have an 
 // incomplete flag for CODE, that is styled slightly different.

--- a/test/index.html
+++ b/test/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="../doc/docs.css">
     <link rel="stylesheet" href="mode_test.css">
     <script src="../lib/codemirror.js"></script>
+    <script src="../lib/util/overlay.js"></script>
     <script src="../mode/javascript/javascript.js"></script>
     <script src="../mode/xml/xml.js"></script>
 
@@ -44,6 +45,8 @@
     <script src="../mode/css/test.js"></script>
     <script src="../mode/markdown/markdown.js"></script>
     <script src="../mode/markdown/test.js"></script>
+    <script src="../mode/gfm/gfm.js"></script>
+    <script src="../mode/gfm/test.js"></script>
     <script src="../mode/stex/stex.js"></script>
     <script src="../mode/stex/test.js"></script>
     <script>


### PR DESCRIPTION
In short, GFM depended on a decent amount of copying and pasting in order to continue functioning properly (and was broken due to substantial changes to Markdown mode since it's inception). This patch gets rid of most of the copy and paste by switching to using `overlay` instead (GFM only handles highlighting of vanilla URLs and GitHub-specific links). Everything else is stored as an option in Markdown mode (to encourage extending it for other flavors in a similar fashion, without duplication of efforts).
- Add options to Markdown mode to make it easier to extend
- Add GFM text overlay
  - SHA, User@SHA, and User/Project@SHA
  - #Num, User/#Num, and User/Project#Num
  - Vanilla URLs
- Add GFM-specific tests
- Fix overlay code so blankLine() is called

**Note:** This should only be applied to v2. I have a separate pull request coming in for v3 (GFM was actually broken due to `listModes` and `listMimes` being removed).
