### PR TITLE
Add note about mode dependency and links to highlighting tests.

### DIFF
--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -63,5 +63,9 @@ See http://github.github.com/github-flavored-markdown/.
       });
     </script>
 
+    <p>Optionally depends on other modes for properly highlighted code blocks.</p>
+
+    <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#gfm_*">normal</a>,  <a href="../../test/index.html#verbose,gfm_*">verbose</a>.</p>
+
   </body>
 </html>


### PR DESCRIPTION
Forgot to add links when I added tests.

As for the note, it wasn't there previously, but probably should have been (both for the explanation and for consistency in what's mentioned in the footer [see markdown mode page]).
