### PR TITLE
showWidgets parameter for foldLines function

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -431,7 +431,8 @@ window.CodeMirror = (function() {
       // is magically replaced with a new node in the DOM, leaving
       // us with a reference to an orphan (nextSibling-less) node.
       if (!curNode) return;
-      if (!line.hidden) {
+      if (!line.hidden || (line.hidden.handle.showWidgets && line.widgets)) 
+      {
         var end = curNode.offsetHeight + curNode.offsetTop;
         var height = end - relativeTo, diff = line.height - height;
         if (height < 2) height = textHeight(display);
@@ -502,9 +503,11 @@ window.CodeMirror = (function() {
     cm.view.doc.iter(from, to, function(line) {
       if (nextIntact && nextIntact.to == j) nextIntact = intact.shift();
       if (!nextIntact || nextIntact.from > j) {
-        if (line.hidden) var lineElement = elt("div");
-        else {
-          var lineElement = lineContent(cm, line), markers = line.gutterMarkers;
+        if (line.hidden && (!line.hidden.handle.showWidgets || !line.widgets)) { 
+            var lineElement = elt("div");
+        } else {
+          var lineElement = line.hidden ? elt("div") : lineContent(cm, line)
+          var markers = line.gutterMarkers;
           if (line.className) lineElement.className = line.className;
           // Lines with gutter elements or a background class need
           // to be wrapped again, and have the extra elements added
@@ -2207,11 +2210,11 @@ window.CodeMirror = (function() {
       regChange(this, no, no + 1);
     }),
 
-    foldLines: operation(null, function(from, to, unfoldOnEnter) {
+    foldLines: operation(null, function(from, to, unfoldOnEnter, showWidgets) {
       if (typeof from != "number") from = lineNo(from);
       if (typeof to != "number") to = lineNo(to);
       if (from > to) return;
-      var lines = [], handle = {lines: lines, unfoldOnEnter: unfoldOnEnter}, cm = this, view = cm.view, doc = view.doc;
+      var lines = [], handle = {lines: lines, unfoldOnEnter: unfoldOnEnter, showWidgets: showWidgets}, cm = this, view = cm.view, doc = view.doc;
       doc.iter(from, to, function(line) {
         lines.push(line);
         if (!line.hidden && line.text.length == cm.view.maxLine.text.length)


### PR DESCRIPTION
There are cases when widget could be a different repsentation of code, so while folding the code 
one may want to show widgets for hidden lines.

I added showWidgets parameter to foldLines, if set it allows widgets for hidden lines to be shown.
Here is a simple showcase where this functionality is needed:
http://uxcandy.com/~boomyjee/dayside/plugins/teapot-copy/
