### PR TITLE
position:"top" in options for addLineWidget

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -556,7 +556,10 @@ window.CodeMirror = (function() {
                   node.style.position = "relative";
                   if (!widget.noHScroll) node.style.marginLeft = -display.gutters.offsetWidth + "px";
                 }
-                wrap.appendChild(node);
+                if (widget.position=="top")
+                    wrap.insertBefore(node,(lineNumbers && !line.hidden) ? gutterWrap : lineElement);
+                else
+                    wrap.appendChild(node);
               }
             lineElement = wrap;
             if (ie_lt8) lineElement.style.zIndex = 2;
@@ -575,17 +578,31 @@ window.CodeMirror = (function() {
   function selHead(view) {
     return view.sel.inverted ? view.sel.from : view.sel.to;
   }
-
+   
+  function cursorCoordsWidgetPatched(cm, pos, context, lineObj) {
+    lineObj = lineObj || getLine(cm.view.doc, pos.line);
+    pos = cursorCoords(cm,pos,context,lineObj);
+    if (lineObj.widgets) {
+      for (var i=0;i<lineObj.widgets.length;i++) {
+        var widget = lineObj.widgets[i];
+        if (widget.position=="top") {
+          pos.top += widget.node.offsetHeight;
+          pos.bottom += widget.node.offsetHeight;
+        }
+      }
+    } 
+    return pos;
+  }
+    
   function updateSelection(cm) {
     var headPos, display = cm.display, doc = cm.view.doc, sel = cm.view.sel;
     if (posEq(sel.from, sel.to)) { // No selection, single cursor
-      var pos = headPos = cursorCoords(cm, sel.from, "div");
+      var pos = headPos = cursorCoordsWidgetPatched(cm, sel.from, "div");
       display.cursor.style.left = pos.left + "px";
       display.cursor.style.top = pos.top + "px";
       display.cursor.style.height = Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight + "px";
       display.cursor.style.display = "";
       display.selectionDiv.style.display = "none";
-
       if (pos.other) {
         display.otherCursor.style.display = "";
         display.otherCursor.style.left = pos.other.left + "px";
@@ -593,7 +610,7 @@ window.CodeMirror = (function() {
         display.otherCursor.style.height = (pos.other.bottom - pos.other.top) * .85 + "px";
       } else { display.otherCursor.style.display = "none"; }
     } else {
-      headPos = cursorCoords(cm, selHead(cm.view), "div");
+      headPos = cursorCoordsWidgetPatched(cm, selHead(cm.view), "div");
       var fragment = document.createDocumentFragment();
       var clientWidth = display.lineSpace.clientWidth;
       var add = function(left, top, width, bottom) {
@@ -606,7 +623,7 @@ window.CodeMirror = (function() {
       var middleFrom = sel.from.line + 1, middleTo = sel.to.line - 1, sameLine = sel.from.line == sel.to.line;
       var drawForLine = function(line, from, toArg, retTop) {
         var lineObj = getLine(doc, line), lineLen = lineObj.text.length;
-        var coords = function(ch) { return charCoords(cm, {line: line, ch: ch}, "div", lineObj); };
+        var coords = function(ch) { return cursorCoordsWidgetPatched(cm, {line: line, ch: ch}, "div", lineObj); };
         var rVal = retTop ? Infinity : -Infinity;
         iterateBidiSections(getOrder(lineObj), from, toArg == null ? lineLen : toArg, function(from, to, dir) {
           var leftPos = coords(dir == "rtl" ? to - 1 : from);
@@ -642,7 +659,7 @@ window.CodeMirror = (function() {
         // Kludge to try and prevent fetching coordinates twice if
         // start end end are on same line.
         var top = (middleFrom != middleTo || botLine.height > bottom.bottom - bottom.top) ?
-          charCoords(cm, {line: middleFrom, ch: 0}, "div") : bottom;
+          cursorCoordsWidgetPatched(cm, {line: middleFrom, ch: 0}, "div") : bottom;
         middleTop = Math.min(middleTop, top.top);
         middleBot = Math.max(middleBot, bottom.bottom);
       }
@@ -788,7 +805,6 @@ window.CodeMirror = (function() {
                 top: top, bottom: bottom, left: left, right: right};
     if (cache.length == 8) cache[++cache.pos % 8] = memo;
     else cache.push(memo);
-
     return {top: top, bottom: bottom, left: left, right: right};
   }
 


### PR DESCRIPTION
Widget now can be positioned on top of it's line.
That's useful if using as widget as an alternative code repsentation, 
so folded code appears below widget that makes sense.

There was issues with cursor position and selection, so i've created own
version for cursorCoords. Not sure about function naming - 
i didn't understand the logic of your naming, sorry.

Here is sample case (click on widgets to show/hide code below):
http://uxcandy.com/~boomyjee/cm-test/
