### PR TITLE
[css] Fix class matching.

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -228,7 +228,7 @@ CodeMirror.defineMode("css", function(config) {
     else if (/[,+>*\/]/.test(ch)) {
       return ret(null, "select-op");
     }
-    else if (ch == "." && stream.match(/^\w+/)) {
+    else if (ch == "." && stream.match(/^-?[_a-z][_a-z0-9-]*/i)) {
       return ret("qualifier", type);
     }
     else if (ch == ":") {

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -217,9 +217,9 @@ MT.testMode(
 
 MT.testMode(
   'classSelector',
-  '.foo { }',
+  '.foo-bar_hello { }',
   [
-    'qualifier', '.foo',
+    'qualifier', '.foo-bar_hello',
     null, ' { }'
   ]
 );


### PR DESCRIPTION
This basically matches the CSS3 spec, except it doesn't match non-ascii characters. It can always be added in later if needed, but I'm not sure the demand is there for it.
