### PR TITLE
fix double click to select a Chinese word in quotes

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1418,7 +1418,7 @@ window.CodeMirror = (function() {
         var startChar = line.charAt(start);
         var check = isWordChar(startChar) ? isWordChar :
                     /\s/.test(startChar) ? function(ch) {return /\s/.test(ch);} :
-                    function(ch) {return !/\s/.test(ch) && !isWordChar(ch);};
+                    function(ch) {return !/\s/.test(ch) && isWordChar(ch);};
         while (start > 0 && check(line.charAt(start - 1))) --start;
         while (end < line.length && check(line.charAt(end))) ++end;
       }
@@ -3101,7 +3101,7 @@ window.CodeMirror = (function() {
     return -1;
   }
   function isWordChar(ch) {
-    return /\w/.test(ch) || ch.toUpperCase() != ch.toLowerCase();
+    return /\w/.test(ch) || ch.toUpperCase() != ch.toLowerCase() || /[\u4E00-\u9FA5]/.test(ch);
   }
 
   // See if "".split is the broken IE version, if so, provide an


### PR DESCRIPTION
fix double click to select a Chinese word in quotes bug:
e.g: <div name="新增">新增<div> double click to select word 新增   
