### PR TITLE
Fix f and t motion in vim mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -189,7 +189,7 @@
     var ch = toLetter(cHar), mo = motion_options;
     if (mo.forward) {
       idx = line.indexOf(ch, cur.ch + 1);
-      if (idx != -1 && mo.inclusive) idx += 1;
+      if (idx != -1 && !mo.inclusive) idx -= 1;
     } else {
       idx = line.lastIndexOf(ch, cur.ch);
       if (idx != -1 && !mo.inclusive) idx += 1;


### PR DESCRIPTION
The current behavior differs from vim; given the following line with the cursor at `$`:

```
$hello-there
```

Typing `f-` in normal mode should put the cursor on the `-`, and typing `t-` should put you on the `o` in hello. Current behavior in CodeMirror puts the cursor one character to the right of where it should be when searching left-to-right (`f-` puts the cursor on the `t`, `t-` puts the cursor on `-`), but behaves correctly when searching right-to-left.
