### PR TITLE
Add "dirty state" tracking to history mechanism

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1812,11 +1812,12 @@ window.CodeMirror = (function() {
     return updateDocNoUndo(cm, from, to, lines, selUpdate);
   }
 
-  function unredoHelper(cm, from, to) {
-    var doc = cm.view.doc;
+  function unredoHelper(cm, from, to, dir) {
+    var doc = cm.view.doc, hist = cm.view.history;
     if (!from.length) return;
     var set = from.pop(), out = [];
     for (var i = set.length - 1; i >= 0; i -= 1) {
+      hist.dirtyCounter += dir;
       var change = set[i];
       var replaced = [], end = change.start + change.added;
       doc.iter(change.start, end, function(line) { replaced.push(newHL(line.text, line.markedSpans)); });
@@ -2275,11 +2276,11 @@ window.CodeMirror = (function() {
 
     undo: operation(null, function() {
       var hist = this.view.history;
-      unredoHelper(this, hist.done, hist.undone);
+      unredoHelper(this, hist.done, hist.undone, -1);
     }),
     redo: operation(null, function() {
       var hist = this.view.history;
-      unredoHelper(this, hist.undone, hist.done);
+      unredoHelper(this, hist.undone, hist.done, 1);
     }),
 
     indentLine: operation(null, function(n, dir) {
@@ -2304,6 +2305,10 @@ window.CodeMirror = (function() {
 
     clearHistory: function() {this.view.history = makeHistory();},
 
+    isDirty: function () {return (this.view.history.dirtyCounter != 0);},
+
+    markClean: function() {this.view.history.dirtyCounter = 0;},
+      
     getHistory: function() {
       var hist = this.view.history;
       function cp(arr) {
@@ -3839,18 +3844,29 @@ window.CodeMirror = (function() {
   // and at almost the same time into bigger undoable units.
   function makeHistory() {
     return {time: 0, done: [], undone: [],
-            compound: 0, closed: false};
+            compound: 0, closed: false, dirtyCounter: 0};
   }
 
   function addChange(history, start, added, old) {
     history.undone.length = 0;
     var time = +new Date, cur = lst(history.done), last = cur && lst(cur);
     var dtime = time - history.time;
+    
+    function updateDirty() {
+      if (history.dirtyCounter < 0) {
+          // The user has made a change after undoing past the last clean state. 
+          // We can never get back to a clean state now until markClean() is called.
+          history.dirtyCounter = NaN;
+      }
+      history.dirtyCounter++;
+    }
 
     if (cur && !history.closed && history.compound) {
+      updateDirty();
       cur.push({start: start, added: added, old: old});
     } else if (dtime > 400 || !last || history.closed ||
                last.start > start + old.length || last.start + last.added < start) {
+      updateDirty();
       history.done.push([{start: start, added: added, old: old}]);
       history.closed = false;
     } else {


### PR DESCRIPTION
The intent of this new API is to make it possible to track the "dirty state" of a document, corresponding to the "dirty dot" functionality common in document editors. The dirty state reflects whether the user has undone/redone to the point where they last saved the document, corresponding (in this API) to the last time the `markClean()` function was called.

The heuristics are mostly straightforward, but there are a couple of edge cases that are worth calling out.
1. If the document is clean, the user makes changes, and then the user undoes those changes, the document is clean again.
2. If the user undoes past the last clean state, the document is dirty. If the user then redoes back to the clean state, the document is clean.
3. If the user undoes past the last clean state, and then makes changes without redoing, then the document can never become clean again until the next time `markClean()` is explicitly called (because there's no way to redo back to the clean state, since the redo history will be cleared).

We implemented this functionality back in our fork of v2, before the `getHistory()` API was available. I couldn't think of a straightforward way to implement this externally to CodeMirror even with that API, because it's hard for us to know exactly what kind of edit happened. It seems simpler to do it in CodeMirror, and I think the functionality would generally be useful for people implementing editors.
