### PR TITLE
Added a few emacs key bindings

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -19,6 +19,7 @@
     "Ctrl-/": "undo", "Shift-Ctrl--": "undo", "Shift-Alt-,": "goDocStart", "Shift-Alt-.": "goDocEnd",
     "Ctrl-S": "findNext", "Ctrl-R": "findPrev", "Ctrl-G": "clearSearch", "Shift-Alt-5": "replace",
     "Ctrl-Z": "undo", "Cmd-Z": "undo", "Alt-/": "autocomplete", "Ctrl-V": "goPageDown", "Alt-V": "goPageUp",
+    "Ctrl-J": "newlineAndIndent",
     fallthrough: ["basic", "emacsy"]
   };
 


### PR DESCRIPTION
Added key bindings for page up, page down, and newline+indent. I'm not sure if the bindings for page up/down are desired or not. In codemirror.js there is a keymap called "emacsy" that already defines them. I assumed keymap/emacs.js is the primary place to put emacs key bindings, rather than the emacsy layout.
