### PR TITLE
[gfm] Remove incorrect information

### DIFF
--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -33,7 +33,7 @@ Everything from markdown plus GFM features:
 
 Underscores_are_allowed_between_words.
 
-## Fenced code blocks (and syntax highlighting... someday)
+## Fenced code blocks (and syntax highlighting)
 
 ```javascript
 for (var i = 0; i &lt; items.length; i++) {


### PR DESCRIPTION
Fenced code blocks _do_ have syntax highlighting. I had added the text when I first started working on rewriting the mode (as a reminder) and forgot to remove it when I finally added syntax highlighting back for fenced code blocks.
