### PR TITLE
Fix for IE7/8 issue when submitting with form.submit()

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2236,8 +2236,8 @@ window.CodeMirror = (function() {
     if (textarea.form) {
       // Deplorable hack to make the submit method do the right thing.
       var rmSubmit = connect(textarea.form, "submit", save, true);
-      if (typeof textarea.form.submit == "function") {
-        var realSubmit = textarea.form.submit;
+      var realSubmit = textarea.form.submit;
+      if (typeof realSubmit == "function" || typeof realSubmit == "object") {
         textarea.form.submit = function wrappedSubmit() {
           save();
           textarea.form.submit = realSubmit;


### PR DESCRIPTION
For some reason "typeof textarea.form.submit" evaluates to "object" under IE8 instead of "function".  This bypasses the region of code that is supposed to make sure changes get saved when using form.submit() instead of using a submit button.

I don't understand why that "if" statement is there in the first place, but to be as low impact as possible I just expanded it to accept "object" as a type.
