### PR TITLE
fix extra indentation caused by ';' in 'top'/'}' contexts.

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -133,7 +133,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         while (ctx.type == "statement") ctx = popContext(state);
       }
       else if (curPunc == ctx.type) popContext(state);
-      else if (ctx.type == "}" || ctx.type == "top" || (ctx.type == "statement" && curPunc == "newstatement"))
+      else if (((ctx.type == "}" || ctx.type == "top") && curPunc != ';') || (ctx.type == "statement" && curPunc == "newstatement"))
         pushContext(state, stream.column(), "statement");
       state.startOfLine = false;
       return style;


### PR DESCRIPTION
';' after end of class definition is changing context to 'statement' from 'top' (or '}'). This results in subsequent lines to be indented with 2-spaces (extra).
Fix is not to pushContext when curPunc is ';' and context.type is '} or 'top'.
