### PR TITLE
[vim] Ctrl-[ leaves insert mode, same as <Esc>

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -22,6 +22,9 @@
 // S, C TODO
 // cf<char>, cF<char>, ct<char>, cT<char>
 //
+// Leaving insert mode:
+// Esc, Ctrl-[
+//
 // Deleting text:
 // x, X
 // J
@@ -590,6 +593,8 @@
     "Ctrl-P": "autocomplete",
     fallthrough: ["default"]
   };
+  // Ctrl-[ is synonymous with <Esc> in vim, and many other places
+  CodeMirror.keyMap["vim-insert"]['Ctrl-['] = CodeMirror.keyMap["vim-insert"]['Esc'];
 
   function findMatchedSymbol(cm, cur, symb) {
     var line = cur.line;


### PR DESCRIPTION
As a die-hard vim addict, long ago, I retrained myself to type `Ctrl-[` to
leave insert mode. This sends the same control sequence as escape in
many other places, actually, and this patch brings such functionality to
CodeMirror.

From vim's `:help ctrl-[`

```
                                        *i_CTRL-[* *i_<Esc>*
<Esc> or CTRL-[
    End insert or Replace mode, go back to Normal mode.
    Finish abbreviation.
    Note: If your <Esc> key is hard to hit on your keyboard, train
    yourself to use CTRL-[.
```

Typing `CTRL-[` is particularly easy when caps-lock is remapped
to being another `CTRL` key, since now neither hand needs to move away
form the homerow, and both little fingers just slide a little, the left
little finger slides to the right to where caps lock used to be, and the
right little finger slides a little bit up to the `[` key
