### PR TITLE
Allow theme styles to be based on the mode.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3417,6 +3417,10 @@ window.CodeMirror = (function() {
     if (line.text == "" && mode.blankLine) mode.blankLine(state);
     while (!stream.eol()) {
       var style = mode.token(stream, state), substr = stream.current();
+      if (style) {
+        var innerMode = CodeMirror.innerMode(mode, state).mode;
+        style += " m-" + innerMode.name;
+      }
       stream.start = stream.pos;
       if (!flattenSpans || curStyle != style) {
         if (curText) {


### PR DESCRIPTION
The colors for tokens are awkward for some modes and would be helped if the theme CSS could target the mode and the token. So CSS properties and keywords don't need to be the same colors as the equivalent HTML or JavaScript tokens.

For example:

.cm-string { color: green; }
.cm-m-css.cm-string { color: red; }
.cm-m-xml.cm-string { color: orange; }
