### PR TITLE
Replace tab in searchcursor.js with spaces.

### DIFF
--- a/lib/util/searchcursor.js
+++ b/lib/util/searchcursor.js
@@ -18,7 +18,7 @@
           var line = cm.getLine(pos.line).slice(0, pos.ch), match = query.exec(line), start = 0;
           while (match) {
             start += match.index + 1;
-	    line = line.slice(start);
+            line = line.slice(start);
             query.lastIndex = 0;
             var newmatch = query.exec(line);
             if (newmatch) match = newmatch;


### PR DESCRIPTION
There is a stay tab character in searchcursor.js that is messing up the indentation.
