### PR TITLE
Make htmlmixed properly check for "tag" style

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -5,7 +5,7 @@ CodeMirror.defineMode("htmlmixed", function(config) {
 
   function html(stream, state) {
     var style = htmlMode.token(stream, state.htmlState);
-    if (style == "tag" && stream.current() == ">" && state.htmlState.context) {
+    if (/(?:^|\s)tag(?:\s|$)/.test(style) && stream.current() == ">" && state.htmlState.context) {
       if (/^script$/i.test(state.htmlState.context.tagName)) {
         state.token = javascript;
         state.localState = jsMode.startState(htmlMode.indent(state.htmlState, ""));


### PR DESCRIPTION
This allows the xml mode to return a style with space separated classes and still work. I didn't use /\btag\b/ since that can match "tag-foo".
