### PR TITLE
Move the previous mode property before adding mode extensions

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2794,7 +2794,11 @@ window.CodeMirror = (function() {
     var modeObj = mfactory(options, spec);
     if (modeExtensions.hasOwnProperty(spec.name)) {
       var exts = modeExtensions[spec.name];
-      for (var prop in exts) if (exts.hasOwnProperty(prop)) modeObj[prop] = exts[prop];
+      for (var prop in exts) {
+        if (!exts.hasOwnProperty(prop)) continue;
+        if (modeObj.hasOwnProperty(prop)) modeObj["_" + prop] = modeObj[prop];
+        modeObj[prop] = exts[prop];
+      }
     }
     modeObj.name = spec.name;
     return modeObj;


### PR DESCRIPTION
This stores the previous value for a mode property if an extension overwrites it with a new value. The old value is stored in a property prefixed with an underscore (e.g. "_token"). This allows extensions to piggyback the old value by still being able to access it.

Example:

```
function extendedToken(stream, state)
{
    var style = this._token(stream, state);
    return style && (style + " m-" + this.name);
}

CodeMirror.extendMode("css", {token: extendedToken});
```
