### PR TITLE
Set currentWheelTarget when manually handling horizontal wheel scroll

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1581,6 +1581,16 @@ window.CodeMirror = (function() {
     else if (dy == null) dy = e.wheelDelta;
 
     var scroll = cm.display.scroller;
+
+    function setCurrentWheelTarget() {
+      if (mac && webkit) for (var cur = e.target; cur != scroll; cur = cur.parentNode) {
+        if (cur.lineObj) {
+          cm.display.currentWheelTarget = cur;
+          break;
+        }
+      }
+    }
+    
     // On some browsers, horizontal scrolling will cause redraws to
     // happen before the gutter has been realigned, causing it to
     // wriggle around in a most unseemly way. When we have an
@@ -1588,6 +1598,7 @@ window.CodeMirror = (function() {
     // scrolling entirely here. It'll be slightly off from native, but
     // better than glitching out.
     if (dx && !gecko && !opera && wheelPixelsPerUnit != null) {
+      setCurrentWheelTarget();
       if (dy)
         setScrollTop(cm, Math.max(0, Math.min(scroll.scrollTop + dy * wheelPixelsPerUnit, scroll.scrollHeight - scroll.clientHeight)));
       setScrollLeft(cm, Math.max(0, Math.min(scroll.scrollLeft + dx * wheelPixelsPerUnit, scroll.scrollWidth - scroll.clientWidth)));
@@ -1597,16 +1608,11 @@ window.CodeMirror = (function() {
     }
 
     if (dy && wheelPixelsPerUnit != null) {
+      setCurrentWheelTarget();
       var pixels = dy * wheelPixelsPerUnit;
       var top = cm.view.scrollTop, bot = top + cm.display.wrapper.clientHeight;
       if (pixels < 0) top = Math.max(0, top + pixels - 50);
       else bot = Math.min(cm.view.doc.height, bot + pixels + 50);
-      if (mac && webkit) for (var cur = e.target; cur != scroll; cur = cur.parentNode) {
-        if (cur.lineObj) {
-          cm.display.currentWheelTarget = cur;
-          break;
-        }
-      }
       updateDisplay(cm, [], {top: top, bottom: bot});
     }
 


### PR DESCRIPTION
For #986. Not sure if you'll like the nested function stylistically (there are only two vars to close over), but since this functionality is very specific to `onScrollWheel()` it seemed to make sense.
