### PR TITLE
fix extra indentation in array initialization

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -123,7 +123,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       if (style == "comment" || style == "meta") return style;
       if (ctx.align == null) ctx.align = true;
 
-      if ((curPunc == ";" || curPunc == ":") && ctx.type == "statement") popContext(state);
+      if ((curPunc == ";" || curPunc == ":" || curPunc == ",") && ctx.type == "statement") popContext(state);
       else if (curPunc == "{") pushContext(state, stream.column(), "}");
       else if (curPunc == "[") pushContext(state, stream.column(), "]");
       else if (curPunc == "(") pushContext(state, stream.column(), ")");


### PR DESCRIPTION
array initialization (one entry per line) results in extra indentation from second element onwards:
ex:-
const string[] fields = {
  "one",
    "two",
    "three"
};
