### PR TITLE
Support blank lines in CodeMirror.multiplexingMode

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -949,6 +949,8 @@
       the <code>open</code> fields of the passed objects. When in a
       sub-mode, it will go back to the top mode again when
       the <code>close</code> string is encountered.
+      Pass <code>"\n"</code> for <code>open</code> or <code>close</code>
+      if you want to switch on a blank line.
       When <code>delimStyle</code> is specified, it will be the token
       style returned for the delimiter tokens. The outer mode will not
       see the content between the delimiters.

--- a/lib/util/multiplex.js
+++ b/lib/util/multiplex.js
@@ -68,6 +68,24 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
       return mode.indent(state.innerActive ? state.inner : state.outer, textAfter);
     },
 
+    blankLine: function(state) {
+      var mode = state.innerActive ? state.innerActive.mode : outer;
+      if (mode.blankLine) {
+        mode.blankLine(state.innerActive ? state.inner : state.outer);
+      }
+      if (!state.innerActive) {
+        for (var i = 0; i < n_others; ++i) {
+          var other = others[i];
+          if (other.open === "\n") {
+            state.innerActive = other;
+            state.inner = CodeMirror.startState(other.mode, mode.indent ? mode.indent(state.outer, "") : 0);
+          }
+        }
+      } else if (mode.close === "\n") {
+        state.innerActive = state.inner = null;
+      }
+    },
+
     electricChars: outer.electricChars,
 
     innerMode: function(state) {


### PR DESCRIPTION
This adds a blankLine method that calls the current mode's blankLine if
it has one. It has allows switching on a blank line if "\n" is specified
for "open" or "close".

Use case: for an API client is writing, I'm showing the raw HTTP response in a CodeMirror editor. I want the HTTP headers to be highlighted by the "http" mode and the HTTP body to be highlighted by a different mode, depending on the response's content-type. In code:

```
setResponseEditorMode: function(innerModer) {
   CodeMirror.defineMode("explorpcResponse", function(config) {
      return CodeMirror.multiplexingMode(
         CodeMirror.getMode(config, "message/http"), {
            open: "\n",     
            close: "\0",
            mode: CodeMirror.getMode(config, innerMode)
         }
      ); 
   });
   this._responseEditor.setOption('mode', 'explorpcResponse');
}

```
