### PR TITLE
Proposal: HTML5 placeholder emulation

### DIFF
--- a/demo/placeholder.html
+++ b/demo/placeholder.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CodeMirror: Placeholder Demo</title>
+    <link rel="stylesheet" href="../lib/codemirror.css">
+    <script src="../lib/codemirror.js"></script>
+    <link rel="stylesheet" href="../doc/docs.css">
+
+    <style type="text/css">
+      .CodeMirror {border: 1px solid black; border-bottom: 1px solid black;}
+    </style>
+  </head>
+  <body>
+    <h1>CodeMirror: Placeholder Demo</h1>
+
+    <form><textarea id="code" name="code" placeholder="This is a placeholder. Click me!"></textarea></form>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"));
+    </script>
+
+    <p>A textarea with the <code>placeholder</code> attribute defined.</p>
+
+  </body>
+</html>

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -96,6 +96,10 @@
   outline: none !important;
 }
 
+.CodeMirror-empty pre {
+  color: #999 !important;
+}
+
 .CodeMirror pre.CodeMirror-cursor {
   z-index: 10;
   position: absolute;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -94,6 +94,10 @@ window.CodeMirror = (function() {
     // Initialize the content.
     operation(function(){setValue(options.value || ""); updateInput = false;})();
     var history = new History();
+    if (getValue().length === 0 && options.placeholder) {
+      wrapper.className += " CodeMirror-empty";
+      setValue(options.placeholder);
+    }
 
     // Register our event handlers.
     connect(scroller, "mousedown", operation(onMouseDown));
@@ -396,6 +400,9 @@ window.CodeMirror = (function() {
       updateInput = true;
     }
     function getValue(lineSep) {
+      if (wrapper.className.search(/\bCodeMirror-empty\b/) !== -1) {
+        return '';
+      }
       var text = [];
       doc.iter(0, doc.size, function(line) { text.push(line.text); });
       return text.join(lineSep || "\n");
@@ -698,6 +705,10 @@ window.CodeMirror = (function() {
     function onFocus() {
       if (options.readOnly == "nocursor") return;
       if (!focused) {
+        if (wrapper.className.search(/\bCodeMirror-empty\b/) !== -1) {
+          wrapper.className = wrapper.className.replace(" CodeMirror-empty", "");
+          setValue('');
+        }
         if (options.onFocus) options.onFocus(instance);
         focused = true;
         if (scroller.className.search(/\bCodeMirror-focused\b/) == -1)
@@ -708,6 +719,10 @@ window.CodeMirror = (function() {
     }
     function onBlur() {
       if (focused) {
+        if (getValue().length === 0 && options.placeholder) {
+          wrapper.className += " CodeMirror-empty";
+          setValue(options.placeholder);
+        }
         if (options.onBlur) options.onBlur(instance);
         focused = false;
         if (bracketHighlighted)
@@ -2033,6 +2048,7 @@ window.CodeMirror = (function() {
     undoDepth: 40,
     tabindex: null,
     autofocus: null,
+    placeholder: "",
     lineNumberFormatter: function(integer) { return integer; }
   };
 
@@ -2232,6 +2248,8 @@ window.CodeMirror = (function() {
   CodeMirror.fromTextArea = function(textarea, options) {
     if (!options) options = {};
     options.value = textarea.value;
+    if (!options.placeholder && textarea.hasAttribute('placeholder'))
+      options.placeholder = textarea.getAttribute('placeholder');
     if (!options.tabindex && textarea.tabindex)
       options.tabindex = textarea.tabindex;
     // Set autofocus to true if this textarea is focused, or if it has


### PR DESCRIPTION
I think CodeMirror should emulate [HTML5 placeholders](http://dev.w3.org/html5/spec/single-page.html#attr-input-placeholder) when an instance is constructed via fromTextArea() and the textarea has the "placeholder" attribute, since there's many places where placeholders are useful (e.g. the GitHub box I'm typing in). This commit adds basic support for placeholders via a CSS class that's toggled on focus and blur. Let me know if the basic concept is sound, and if so I'll clean the code up, add docs, and write some tests.
