### PR TITLE
Fix bug in autoFormatRange where blank lines get stripped 

### DIFF
--- a/lib/util/formatting.js
+++ b/lib/util/formatting.js
@@ -95,7 +95,7 @@
           newline();
       }
       if (!stream.pos && outer.blankLine) outer.blankLine(state);
-      if (!atSol) newline();
+      if (!stream.pos || !atSol) newline();
     }
 
     cm.operation(function () {

--- a/test/formatting_test.js
+++ b/test/formatting_test.js
@@ -1,0 +1,10 @@
+test("autoFormatRange_xml", function() {
+  var te = document.getElementById("code");
+  te.value = "<?xml version='1.0'?><a><b/><c foo='bar'>\n\n</c></a>";
+  var cm = CodeMirror.fromTextArea(te, { mode: "application/xml" });
+  cm.autoFormatRange({ line: 0, ch: 0 }, { line: 2, ch: cm.getLine(2).length });
+
+  // @todo fix whitespace that's added inside <c> and the newline appended to end
+  var expected = "<?xml version='1.0'?>\n<a>\n  <b/>\n  <c foo='bar'>\n    \n  </c>\n</a>\n";
+  eq(cm.getValue(), expected);
+});

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="mode_test.css">
     <script src="../lib/codemirror.js"></script>
     <script src="../lib/util/overlay.js"></script>
+    <script src="../lib/util/formatting.js"></script>
     <script src="../mode/javascript/javascript.js"></script>
     <script src="../mode/xml/xml.js"></script>
     <script src="../keymap/vim.js"></script>
@@ -50,6 +51,7 @@
     <script src="../mode/gfm/test.js"></script>
     <script src="../mode/stex/stex.js"></script>
     <script src="../mode/stex/test.js"></script>
+    <script src="formatting_test.js"></script>
     <script src="vim_test.js"></script>
     <script>
       window.onload = function() {


### PR DESCRIPTION
It looks like 0993cdc5aec933ac869d75f9c5072ad1045c084b introduced a bug where all blank lines get stripped when autoFormatRange is run. I made a fix and added the beginnings of a test suite for formatting.js.
