### PR TITLE
White BG & black text as default

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -5,6 +5,7 @@
   font-family: monospace;
   height: 300px;
   background: #fff;
+  color: #000;
 }
 .CodeMirror-scroll {
   /* Set scrolling behaviour here */


### PR DESCRIPTION
4 of the themes do not have a default BG color or text color defined and as the main CodeMirror class doesn't either, the styles of parent DOM elems are inherited and can cause completely unseen text in these themes.

To see this in action, set style="background: #000" on the body tag of http://codemirror.net/3/demo/theme.html. You can now no longer read default text on the default, eclipse, elegant or neat themes, because the main text color is inherited and as this is likely black too, you end up with black text on black BG.

Rather than add a white BG and black default text colors to these 4 themes, it is easier/better to this on the CodeMirror class itself, to provide a base level.
