### PR TITLE
[vim keymap] Implement search behavior

### DIFF
--- a/demo/vim.html
+++ b/demo/vim.html
@@ -5,9 +5,10 @@
     <title>CodeMirror: Vim bindings demo</title>
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>
+    <script src="../lib/util/dialog.js"></script>
+    <script src="../lib/util/searchcursor.js"></script>
     <script src="../mode/clike/clike.js"></script>
     <script src="../keymap/vim.js"></script>
-    <script src="../lib/util/dialog.js"></script>
     <link rel="stylesheet" href="../doc/docs.css">
     <link rel="stylesheet" href="../lib/util/dialog.css">
 

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -155,6 +155,8 @@
     { keys: ['<'], type: 'operator', operator: 'indent',
         operatorArgs: { indentRight: false }},
     { keys: ['g', '~'], type: 'operator', operator: 'swapcase' },
+    { keys: ['n'], type: 'motion', motion: 'findNext' },
+    { keys: ['N'], type: 'motion', motion: 'findPrev' },
     // Operator-Motion dual commands
     { keys: ['x'], type: 'operatorMotion', operator: 'delete',
         motion: 'moveByCharacters', motionArgs: { forward: true },
@@ -200,12 +202,22 @@
     { keys: ['Ctrl-r'], type: 'action', action: 'redo' },
     { keys: ['m', 'character'], type: 'action', action: 'setMark' },
     { keys: ['\"', 'character'], type: 'action', action: 'setRegister' },
+    { keys: [',', '/'], type: 'action', action: 'clearSearch' },
     // Text object motions
     { keys: ['a', 'character'], type: 'motion',
         motion: 'textObjectManipulation' },
     { keys: ['i', 'character'], type: 'motion',
         motion: 'textObjectManipulation',
-        motionArgs: { textObjectInner: true }}
+        motionArgs: { textObjectInner: true }},
+    // Search
+    { keys: ['/'], type: 'search',
+        searchArgs: { forward: true, querySrc: 'prompt' }},
+    { keys: ['?'], type: 'search',
+        searchArgs: { forward: false, querySrc: 'prompt' }},
+    { keys: ['*'], type: 'search',
+        searchArgs: { forward: true, querySrc: 'wordUnderCursor' }},
+    { keys: ['#'], type: 'search',
+        searchArgs: { forward: false, querySrc: 'wordUnderCursor' }}
   ];
 
   var Vim = function() {
@@ -268,6 +280,29 @@
       }
       return false;
     }
+    function getVimState(cm) {
+      if (!cm.vimState) {
+        // Store instance state in the CodeMirror object.
+        cm.vimState = {
+          inputState: new InputState(),
+          // When using jk for navigation, if you move from a longer line to a
+          // shorter line, the cursor may clip to the end of the shorter line.
+          // If j is pressed again and cursor goes to the next line, the
+          // cursor should go back to its horizontal position on the longer
+          // line if it can. This is to keep track of the horizontal position.
+          lastHPos: -1,
+          // The last motion command run. Cleared if a non-motion command gets
+          // executed in between.
+          lastMotion: null,
+          marks: {},
+          registerController: new RegisterController({}),
+          visualMode: false,
+          // If we are in visual line mode. No effect if visualMode is false.
+          visualLine: false
+        };
+      }
+      return cm.vimState;
+    }
 
     var vimApi= {
       addKeyMap: function() {
@@ -280,32 +315,12 @@
       // Initializes vim state variable on the CodeMirror object. Should only be
       // called lazily by handleKey or for testing.
       maybeInitState: function(cm) {
-        if (!cm.vimState) {
-          // Store instance state in the CodeMirror object.
-          cm.vimState = {
-            inputState: new InputState(),
-            // When using jk for navigation, if you move from a longer line to a
-            // shorter line, the cursor may clip to the end of the shorter line.
-            // If j is pressed again and cursor goes to the next line, the
-            // cursor should go back to its horizontal position on the longer
-            // line if it can. This is to keep track of the horizontal position.
-            lastHPos: -1,
-            // The last motion command run. Cleared if a non-motion command gets
-            // executed in between.
-            lastMotion: null,
-            marks: {},
-            registerController: new RegisterController({}),
-            visualMode: false,
-            // If we are in visual line mode. No effect if visualMode is false.
-            visualLine: false
-          };
-        }
+        getVimState(cm);
       },
       // This is the outermost function called by CodeMirror, after keys have
       // been mapped to their Vim equivalents.
       handleKey: function(cm, key) {
-        this.maybeInitState(cm);
-        var vim = cm.vimState;
+        var vim = getVimState(cm);
         if (key == 'Esc') {
           // Clear input state and get back to normal mode.
           vim.inputState.reset();
@@ -523,6 +538,9 @@
           case 'action':
             this.processAction(cm, vim, command);
             break;
+          case 'search':
+            this.processSearch(cm, vim, command);
+            break;
           default:
             break;
         }
@@ -592,6 +610,36 @@
         inputState.reset();
         vim.lastMotion = null,
         actions[command.action](cm, actionArgs, vim);
+      },
+      processSearch: function(cm, vim, command) {
+        if (!cm.getSearchCursor) {
+          // Search depends on SearchCursor.
+          return;
+        }
+        var forward = command.searchArgs.forward;
+        getSearchState(cm).reversed = !forward;
+        var promptPrefix = (forward) ? '/' : '?';
+        var handleQuery = function(query) {
+          updateSearchQuery(cm, query);
+          commandDispatcher.processMotion(cm, vim, {
+            type: 'motion',
+            motion: 'findNext'
+          });
+        }
+        switch (command.searchArgs.querySrc) {
+          case 'prompt':
+            showPrompt(cm, handleQuery, promptPrefix, searchPromptDesc);
+            break;
+          case 'wordUnderCursor':
+            var word = expandToWord(cm, false /** inclusive */,
+                true /** forward */, false /** bigWord */);
+            var query = cm.getLine(word.start.line).substring(word.start.ch,
+                word.end.ch + 1);
+            // Use \b (word boundary) to simulate \< \> in Vim.
+            query = '\\b' + query + '\\b';
+            handleQuery(query);
+            break;
+        }
       },
       evalInput: function(cm, vim) {
         // If the motion comand is set, execute both the operator and motion.
@@ -731,6 +779,12 @@
         var endLine = Math.min(cm.lineCount(),
             cursor.line + motionArgs.repeat - 1);
         return { line: endLine, ch: lineLength(cm, endLine) };
+      },
+      findNext: function(cm, motionArgs, vim) {
+        return findNext(cm, false /** prev */, motionArgs.repeat);
+      },
+      findPrev: function(cm, motionArgs, vim) {
+        return findNext(cm, true /** prev */, motionArgs.repeat);
       },
       goToMark: function(cm, motionArgs, vim) {
         var mark = vim.marks[motionArgs.selectedCharacter];
@@ -932,6 +986,7 @@
     };
 
     var actions = {
+      clearSearch: clearSearch,
       enterInsertMode: function(cm, actionArgs) {
         var insertAt = (actionArgs) ? actionArgs.insertAt : null;
         if (insertAt == 'eol') {
@@ -1557,6 +1612,141 @@
         end: {line: cur.line, ch: end}
       };
     }
+
+    // Search functions
+    function SearchState() {
+      this.query = null;
+      this.marked = [];
+      this.reversed = false;
+    }
+    function getSearchState(cm) {
+      var vim = getVimState(cm);
+      return vim._searchState || (vim._searchState = new SearchState());
+    }
+    function dialog(cm, text, shortText, callback) {
+      if (cm.openDialog) {
+        cm.openDialog(text, callback);
+      }
+      else {
+        callback(prompt(shortText, ""));
+      }
+    }
+    function parseQuery(cm, query) {
+      // First try to extract regex + flags from the input. If no flags found,
+      // extract just the regex. IE does not accept flags directly defined in the
+      // regex string in the form /regex/flags
+      var match = query.match(/^(.*)\/(.*)$/);
+      var insensitive = false;
+      var regexp;
+      if (match) {
+        insensitive = (match[2].indexOf('i') != -1);
+        regexp = match[1];
+      } else {
+        regexp = query;
+      }
+      // Heuristic: if the query string is all lowercase, do a case-insensitive
+      // search.
+      insensitive |= (/^[^A-Z]*$/).test(regexp);
+      var query;
+      try {
+        query = new RegExp(regexp, insensitive ? 'i' : undefined);
+        return query;
+      } catch (e) {
+        showConfirm(cm, 'Invalid regex: ' + regexp);
+      }
+    }
+    function showConfirm(cm, text) {
+      if (cm.openConfirm) {
+        cm.openConfirm('<span style="color: red">' + text +
+            '</span> <button type="button">OK</button>', function() {});
+      } else {
+        alert(text);
+      }
+    }
+    function makePrompt(prefix, desc) {
+      var raw = '';
+      if (prefix) {
+        raw += prefix;
+      }
+      raw += '<input type="text" style="width: 20em"/> ' +
+          '<span style="color: #888">';
+      if (desc) {
+        raw += '<span style="color: #888">';
+        raw += desc;
+        raw += '</span>'
+      }
+      return raw;
+    }
+    var searchPromptDesc = '(Javascript regexp)';
+    function showPrompt(cm, onPromptClose, prefix, desc) {
+      var shortText = (prefix || '') + ' ' + (desc || '');
+      dialog(cm, makePrompt(prefix, desc), shortText, onPromptClose);
+    }
+    function regexEqual(r1, r2) {
+      if (r1 instanceof RegExp && r2 instanceof RegExp) {
+          var props = ["global", "multiline", "ignoreCase", "source"];
+          for (var i = 0; i < props.length; i++) {
+              var prop = props[i];
+              if (r1[prop] !== r2[prop]) {
+                  return(false);
+              }
+          }
+          return(true);
+      }
+      return(false);
+    }
+    function updateSearchQuery(cm, query) {
+      cm.operation(function() {
+        var state = getSearchState(cm);
+        if (!query) return;
+        var newQuery = parseQuery(cm, query);
+        if (regexEqual(newQuery, state.query)) return;
+        clearSearch(cm);
+        state.query = newQuery;
+        if (!state.query) return;
+        if (cm.lineCount() < 2000) { // This is too expensive on big documents.
+          for (var cursor = cm.getSearchCursor(state.query); cursor.findNext();)
+            state.marked.push(cm.markText(cursor.from(), cursor.to(),
+                'CodeMirror-searching'));
+        }
+      });
+    }
+    function findNext(cm, prev, repeat) {
+      return cm.operation(function() {
+        var state = getSearchState(cm);
+        if (!state.query) {
+          return;
+        }
+        var pos = cm.getCursor();
+        // If search is initiated with ? instead of /, negate direction.
+        prev = (state.reversed) ? !prev : prev;
+        if (!prev) {
+          pos.ch += 1;
+        }
+        var cursor = cm.getSearchCursor(state.query, pos);
+        for (var i = 0; i < repeat; i++) {
+          if (!cursor.find(prev)) {
+            // SearchCursor may have returned null because it hit EOF, wrap
+            // around and try again.
+            cursor = cm.getSearchCursor(state.query,
+                (prev) ? { line: cm.lineCount() - 1} : {line: 0, ch: 0} );
+            if (!cursor.find(prev)) return;
+          }
+        }
+        return cursor.from();
+      });}
+    function clearSearch(cm) {
+      cm.operation(function() {
+        var state = getSearchState(cm);
+        if (!state.query) {
+          return;
+        }
+        state.query = null;
+        for (var i = 0; i < state.marked.length; ++i) {
+          state.marked[i].clear();
+        }
+        state.marked.length = 0;
+      });}
 
     function buildVimKeyMap() {
       /**

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="mode_test.css">
     <script src="../lib/codemirror.js"></script>
     <script src="../lib/util/overlay.js"></script>
+    <script src="../lib/util/searchcursor.js"></script>
     <script src="../mode/javascript/javascript.js"></script>
     <script src="../mode/xml/xml.js"></script>
     <script src="../keymap/vim.js"></script>

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -115,9 +115,15 @@ function testVim(name, run, opts, expectedFail) {
         eqPos(pos, cm.getCursor());
       }
     }
+    function fakeOpenDialog(result) {
+      return function(text, callback) {
+        return callback(result);
+      }
+    }
     var helpers = {
       doKeys: doKeysFn(cm),
-      assertCursorAt: assertCursorAtFn(cm)
+      assertCursorAt: assertCursorAtFn(cm),
+      fakeOpenDialog: fakeOpenDialog
     }
     var successful = false;
     try {
@@ -648,3 +654,59 @@ testVim('r', function(cm, vim, helpers) {
   eq('wuuuet', cm.getValue());
   eqPos(makeCursor(0, 3), cm.getCursor());
 }, { value: 'wordet' });
+testVim('/ and n/N', function(cm, vim, helpers) {
+  cm.openDialog = helpers.fakeOpenDialog('match');
+  helpers.doKeys('/');
+  helpers.assertCursorAt(makeCursor(0, 11));
+  helpers.doKeys('n');
+  helpers.assertCursorAt(makeCursor(1, 6));
+  helpers.doKeys('N');
+  helpers.assertCursorAt(makeCursor(0, 11));
+
+  cm.setCursor(0, 0);
+  helpers.doKeys('2', '/');
+  helpers.assertCursorAt(makeCursor(1, 6));
+}, { value: 'match nope match \n nope Match' });
+testVim('/_case', function(cm, vim, helpers) {
+  cm.openDialog = helpers.fakeOpenDialog('Match');
+  helpers.doKeys('/');
+  helpers.assertCursorAt(makeCursor(1, 6));
+}, { value: 'match nope match \n nope Match' });
+testVim('? and n/N', function(cm, vim, helpers) {
+  cm.openDialog = helpers.fakeOpenDialog('match');
+  helpers.doKeys('?');
+  helpers.assertCursorAt(makeCursor(1, 6));
+  helpers.doKeys('n');
+  helpers.assertCursorAt(makeCursor(0, 11));
+  helpers.doKeys('N');
+  helpers.assertCursorAt(makeCursor(1, 6));
+
+  cm.setCursor(0, 0);
+  helpers.doKeys('2', '?');
+  helpers.assertCursorAt(makeCursor(0, 11));
+}, { value: 'match nope match \n nope Match' });
+testVim(',/ clearSearch', function(cm, vim, helpers) {
+  cm.openDialog = helpers.fakeOpenDialog('match');
+  helpers.doKeys('?');
+  var origPos = cm.getCursor();
+  helpers.doKeys(',', '/', 'n');
+  helpers.assertCursorAt(origPos);
+}, { value: 'match nope match \n nope Match' });
+testVim('*', function(cm, vim, helpers) {
+  cm.setCursor(0, 9);
+  helpers.doKeys('*');
+  helpers.assertCursorAt(makeCursor(0, 22));
+
+  cm.setCursor(0, 9);
+  helpers.doKeys('2', '*');
+  helpers.assertCursorAt(makeCursor(1, 8));
+}, { value: 'nomatch match nomatch match \nnomatch Match' });
+testVim('#', function(cm, vim, helpers) {
+  cm.setCursor(0, 9);
+  helpers.doKeys('#');
+  helpers.assertCursorAt(makeCursor(1, 8));
+
+  cm.setCursor(0, 9);
+  helpers.doKeys('2', '#');
+  helpers.assertCursorAt(makeCursor(0, 22));
+}, { value: 'nomatch match nomatch match \nnomatch Match' });


### PR DESCRIPTION
The original keymap had support for `/`, `?`, `n`, and `N` that I regressed on. I assumed they were broken but it was because `demo/vim.html` didn't pull in `search.js` and `searchcursor.js`. I have restored the behavior with several extensions.

This implementation behaves more like vim than the old impl, and features:
- `*` and `#`
- `,/` for clearing the current query
- search as motions: `d/query, dn, dN, d*` etc, will work as expected (though I'm not sure how useful that is).
- supports repeat on search
- works as a visual mode motion.
- uses only Javascript regexp search,  so you don't have to type `'//query/'` to search a regexp. The original impl only matched regex if the query was surrounded by `'/'`.

This implementation depends on `searchcursor.js`. Search will just be unavailable if `cm.getSearchCursor` doesn't exist. It does not depend on `search.js`. A lot of the search code is ripped directly out of `search.js` but there were several vim specific changes that were incompatible with `search.js`'s API for search, so it made sense to have `vim.js`'s own version.
