### PR TITLE
[vim keymap] Rewrite expandWordUnderCursor

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -736,3 +736,15 @@ testVim('#', function(cm, vim, helpers) {
   helpers.doKeys('2', '#');
   helpers.assertCursorAt(makeCursor(0, 22));
 }, { value: 'nomatch match nomatch match \nnomatch Match' });
+testVim('*_seek', function(cm, vim, helpers) {
+  // Should skip over space and symbols.
+  cm.setCursor(0, 3);
+  helpers.doKeys('*');
+  helpers.assertCursorAt(makeCursor(0, 22));
+}, { value: '    :=  match nomatch match \nnomatch Match' });
+testVim('#', function(cm, vim, helpers) {
+  // Should skip over space and symbols.
+  cm.setCursor(0, 3);
+  helpers.doKeys('#');
+  helpers.assertCursorAt(makeCursor(1, 8));
+}, { value: '    :=  match nomatch match \nnomatch Match' });


### PR DESCRIPTION
expandWordUnderCursor is completely rewritten using regex methods. It is much cleaner, handles matches better, optionally can expand on symbols, and seeks past whitespace for first word after.
