### PR TITLE
[vim keymap] Fix operations/actions on last character of the line

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -837,6 +837,9 @@
         var cur = cm.getCursor();
         var repeat = motionArgs.repeat;
         var line = motionArgs.forward ? cur.line + repeat : cur.line - repeat;
+        if (line < 0 || line > cm.lineCount() - 1) {
+          return null;
+        }
         return { line: line, ch: endCh };
       },
       moveByPage: function(cm, motionArgs) {
@@ -1456,8 +1459,12 @@
               cur.ch = word.from;
             }
           } else {
-            // No more words to be found. Move to end of line.
-            return { line: cur.line, ch: lineLength(cm, cur.line) };
+            // No more words to be found. Move to the end.
+            if (forward) {
+              return { line: cur.line, ch: lineLength(cm, cur.line) };
+            } else {
+              return { line: cur.line, ch: 0 };
+            }
           }
         }
       }


### PR DESCRIPTION
@siefkenj The addition of clipCursorToContent in https://github.com/marijnh/CodeMirror/pull/1036 broke character operations at the end of line, like a,x,s,d/y/c l because motions would no longer advance the cursor past the last character on a line, and operators would refuse to include it.

The fix moves the clipCursorToContent call into evalInput, after the motion is executed.

Also fixed a few edge cases (quite literally) for various motions.

Added tests to prevent future regression. Past 100 mark for number of vim tests!
