### PR TITLE
[vim keymap] Search highlighting using overlay mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1822,6 +1822,12 @@
       setMarked: function(marked) {
         this.marked = marked;
       },
+      getOverlay: function() {
+        return this.searchOverlay;
+      },
+      setOverlay: function(overlay) {
+        this.searchOverlay = overlay;
+      },
       isReversed: function() {
         return getVimGlobalState().isReversed;
       },
@@ -1953,17 +1959,53 @@
         state.setQuery(query);
       });
     }
+    function searchOverlay(query) {
+      return {
+        token: function(stream) {
+          var match = stream.match(query, false);
+          if (match) {
+            if (!stream.sol()) {
+              // Backtrack 1 to match \b
+              stream.backUp(1);
+              if (!query.exec(stream.next() + match[0])) {
+                stream.next();
+                return null;
+              }
+            }
+            stream.match(query);
+            return "searching";
+          }
+          while (!stream.eol()) {
+            stream.next();
+            if (stream.match(query, false)) break;
+          }
+        },
+        query: query
+      };
+    }
     function highlightSearchMatches(cm, query) {
-      // TODO: Highlight only text inside the viewport. Highlighting everything
-      // is inefficient and expensive.
-      if (cm.lineCount() < 2000) { // This is too expensive on big documents.
-        var marked = [];
-        for (var cursor = cm.getSearchCursor(query);
-            cursor.findNext();) {
-          marked.push(cm.markText(cursor.from(), cursor.to(),
-              { className: 'cm-searching' }));
+      if (cm.addOverlay) {
+        var overlay = getSearchState(cm).getOverlay();
+        if (!overlay || query != overlay.query) {
+          if (overlay) {
+            cm.removeOverlay(overlay);
+          }
+          overlay = searchOverlay(query);
+          cm.addOverlay(overlay);
+          getSearchState(cm).setOverlay(overlay);
         }
-        getSearchState(cm).setMarked(marked);
+      } else {
+        // TODO: Highlight only text inside the viewport. Highlighting everything
+        // is inefficient and expensive.
+        if (cm.lineCount() < 2000) { // This is too expensive on big documents.
+          var marked = [];
+          for (var cursor = cm.getSearchCursor(query);
+              cursor.findNext();) {
+            marked.push(cm.markText(cursor.from(), cursor.to(),
+                { className: 'cm-searching' }));
+          }
+          getSearchState(cm).setMarked(marked);
+        }
       }
     }
     function findNext(cm, prev, repeat) {
@@ -1997,20 +2039,26 @@
         return cursor.from();
       });}
     function clearSearchHighlight(cm) {
-      cm.operation(function() {
-        var state = getSearchState(cm);
-        if (!state.getQuery()) {
-          return;
-        }
-        var marked = state.getMarked();
-        if (!marked) {
-          return;
-        }
-        for (var i = 0; i < marked.length; ++i) {
-          marked[i].clear();
-        }
-        state.setMarked(null);
-      });}
+      if (cm.addOverlay) {
+        cm.removeOverlay(getSearchState(cm).getOverlay());
+        getSearchState(cm).setOverlay(null);
+      } else {
+        cm.operation(function() {
+          var state = getSearchState(cm);
+          if (!state.getQuery()) {
+            return;
+          }
+          var marked = state.getMarked();
+          if (!marked) {
+            return;
+          }
+          for (var i = 0; i < marked.length; ++i) {
+            marked[i].clear();
+          }
+          state.setMarked(null);
+        });
+      }
+    }
     /**
      * Check if pos is in the specified range, INCLUSIVE.
      * Range can be specified with 1 or 2 arguments.


### PR DESCRIPTION
Depends on https://github.com/marijnh/CodeMirror/pull/1067, and I know I said I wouldn't touch highlighting again so soon but this idea just hit me. It will cause the same className merge conflict :)
### Motivation

A big gripe I had about how search was implemented was that if you search for something, edit the file, and then insert some text that match your previous query, it doesn't get highlighted. Doing `findNext` will find it, but won't highlight it.

I attempted to avoid this in the vim keymap by redoing highlighting on findNext, but that was too expensive for short terms like `a` or `i`, though ok for long terms on a 2000 line file. It still isn't good enough since it won't highlight as you type.

I put some thought into highlighting only the current viewport, then listening to `viewportChange` and `change` events on CodeMirror to update highlights. But brooding about this for a while, I realized the approach I wanted to sounded awfully like what modes do.
### Search overlay mode

Vim defines a search overlay mode `vim-search` that accepts a query regex and a baseMode as config options. When a search is activated in Vim, an overlay mode is created, combining the search highlighting and the current mode. CodeMirror takes over seeking through the document and updating highlights. CodeMirror's awesome mode system also takes over highlighting matches as you type them and clearing highlights when terms no longer match. All Vim does is tell CodeMirror what to highlight.
### Issues
- Vim is swapping out the user specified mode with another mode, without telling the user. While the impacts are minimal from the user's perspective, it's not quite elegant.
  - I try to mitigate problems by keeping track of the mode that was swapped out, and restoring the mode when highlighting is cleared
  - There's still the issue that modes have configuration options. Vim has no way to get at these options, so Vim has no way to restore them when search highlight is cleared. This is very bad if there are multiple `cm` instances around with different options but the same mode.
- Highlighting lags a bit (< 500ms) when the mode is swapped, probably because CodeMirror's mode parsing runs on a timeout. It's a tiny, acceptable lag though, at least to me. Not sure how others would feel though.
### Feature request

The consistency issues (losing configuration) with swapping modes could be avoided if there was a way to restore the base mode on CodeMirror using a setMode() function rather than using setOption('mode', baseMode). Would that be a reasonable thing to add to the API, or an extension?

It would be even better if there were API methods like addOverlayMode() and removeOverlayMode(). While it's possible to add multiple overlays by chaining OverlayMode, turning them on/off selectively would be an ugly mess if the overlays are defined in different extensions.
