### PR TITLE
[markdown] Fix incorrect highlighting of linked images.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -246,8 +246,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return getType(state);
     }
     
-    if (ch === '!' && stream.match(/\[.*\] ?(?:\(|\[)/, false)) {
-      stream.match(/\[.*\]/);
+    if (ch === '!' && stream.match(/\[[^\]]*\] ?(?:\(|\[)/, false)) {
+      stream.match(/\[[^\]]*\]/);
       state.inline = state.f = linkHref;
       return image;
     }

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -719,6 +719,20 @@ MT.testMode(
   ]
 );
 
+// Inline link with image
+MT.testMode(
+  'linkImage',
+  '[![foo](http://example.com/)](http://example.com/) bar',
+  [
+    'link', '[',
+    'tag', '![foo]',
+    'string', '(http://example.com/)',
+    'link', ']',
+    'string', '(http://example.com/)',
+    null, ' bar'
+  ]
+);
+
 // Inline link with Em
 MT.testMode(
   'linkEm',


### PR DESCRIPTION
Previously, extra brackets on the same line as an image would throw the highlighter off. For a live example, simply paste CodeMirror's README into the markdown mode.
