### PR TITLE
[markdown] Prevent leading spaces from being styled.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -456,10 +456,10 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         var indentation = stream.match(/^\s*/, true)[0].replace(/\t/g, '    ').length;
         var difference = Math.floor((indentation - state.indentation) / 4) * 4;
         if (difference > 4) difference = 4;
-        indentation = state.indentation + difference;
-        state.indentationDiff = indentation - state.indentation;
-        state.indentation = indentation;
-        if (indentation > 0) { return null; }
+        var adjustedIndentation = state.indentation + difference;
+        state.indentationDiff = adjustedIndentation - state.indentation;
+        state.indentation = adjustedIndentation;
+        if (indentation > 0) return null;
       }
       return state.f(stream, state);
     },

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -914,6 +914,17 @@ MT.testMode(
     'string', 'http://example.com/'
   ]
 );
+// Indented
+MT.testMode(
+  'labelIndented',
+  '   [foo]: http://example.com/',
+  [
+    null, '   ',
+    'link', '[foo]:',
+    null, ' ',
+    'string', 'http://example.com/'
+  ]
+);
 // Space in ID and title
 MT.testMode(
   'labelSpaceTitle',


### PR DESCRIPTION
Regression introduced in 984e15502fb54aebdf6c272910a7543ed1efe0e7.

Basically, I just added `adjustedIndentation` instead of writing over `indentation` and added a test that will catch this regression in the future. Also got rid of brackets that weren't necessary in the first place (that's what you prefer, right?).
