### PR TITLE
Restore focus to line widget if it was focused before line was edited

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -564,8 +564,18 @@ window.CodeMirror = (function() {
         cur = cur.nextSibling;
       } else {
         // This line needs to be generated.
+        var activeElt = document.activeElement;
         var lineNode = buildLineElement(cm, line, lineNo, dims);
         container.insertBefore(lineNode, cur);
+        
+        if (line.widgets) {
+          // If the focused element was inside one of this line's widgets before we rebuilt it,
+          // restore the focus to it.
+          var child = activeElt;
+          while (child && child !== lineNode) child = child.parentNode;
+          if (child === lineNode) activeElt.focus();
+        }
+        
         lineNode.lineObj = line;
       }
       ++lineNo;


### PR DESCRIPTION
In Brackets, a number of our line widgets have children that can take focus (e.g. nested CodeMirror editors or UIs that have text input controls). If an edit is made in the parent editor to the line that the widget is attached to, `buildLineElement()` is called to rebuild the line. As part of this, the widget is temporarily removed from and then readded to the DOM, which causes it to lose focus.

This patch checks to see if the previously focused element is still a child of the rebuilt line, and if so, restores focus to it.
