### PR TITLE
Ignore certain events when target is inside a line widget

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1258,7 +1258,7 @@ window.CodeMirror = (function() {
     on(d.scroller, "mousedown", operation(cm, onMouseDown));
     on(d.scroller, "dblclick", operation(cm, e_preventDefault));
     on(d.lineSpace, "selectstart", function(e) {
-      if (!mouseEventInWidget(d, e)) e_preventDefault(e);
+      if (!eventInWidget(d, e)) e_preventDefault(e);
     });
     // Gecko browsers fire contextmenu *after* opening the menu, at
     // which point we can't mess with it anymore. Context menu is
@@ -1313,7 +1313,11 @@ window.CodeMirror = (function() {
       on(d.scroller, "dragover", drag_);
       on(d.scroller, "drop", operation(cm, onDrop));
     }
-    on(d.scroller, "paste", function(){focusInput(cm); fastPoll(cm);});
+    on(d.scroller, "paste", function(){
+      if (eventInWidget(d, e)) return;
+      focusInput(cm); 
+      fastPoll(cm);
+    });
     on(d.input, "paste", function() {
       d.pasteIncoming = true;
       fastPoll(cm);
@@ -1337,7 +1341,7 @@ window.CodeMirror = (function() {
     });
   }
 
-  function mouseEventInWidget(display, e) {
+  function eventInWidget(display, e) {
     for (var n = e_target(e); n != display.wrapper; n = n.parentNode)
       if (/\bCodeMirror-(?:line)?widget\b/.test(n.className) ||
           n.parentNode == display.sizer && n != display.mover) return true;
@@ -1362,7 +1366,7 @@ window.CodeMirror = (function() {
     var cm = this, display = cm.display, view = cm.view, sel = view.sel, doc = view.doc;
     sel.shift = e_prop(e, "shiftKey");
 
-    if (mouseEventInWidget(display, e)) {
+    if (eventInWidget(display, e)) {
       if (!webkit) {
         display.scroller.draggable = false;
         setTimeout(function(){display.scroller.draggable = true;}, 100);
@@ -1498,7 +1502,8 @@ window.CodeMirror = (function() {
 
   function onDrop(e) {
     var cm = this;
-    if (cm.options.onDragEvent && cm.options.onDragEvent(cm, addStop(e))) return;
+    if (eventInWidget(cm.display, e) || (cm.options.onDragEvent && cm.options.onDragEvent(cm, addStop(e))))
+      return;
     e_preventDefault(e);
     var pos = posFromMouse(cm, e, true), files = e.dataTransfer.files;
     if (!pos || isReadOnly(cm)) return;
@@ -1567,6 +1572,8 @@ window.CodeMirror = (function() {
   }
 
   function onDragStart(cm, e) {
+    if (isInWidget(cm.display, e)) return;
+    
     var txt = cm.getSelection();
     e.dataTransfer.setData("Text", txt);
 
@@ -1815,7 +1822,10 @@ window.CodeMirror = (function() {
 
   var detectingSelectAll;
   function onContextMenu(cm, e) {
-    var display = cm.display, sel = cm.view.sel;
+    var display = cm.display;
+    if (eventInWidget(display, e)) return;
+    
+    var sel = cm.view.sel;
     var pos = posFromMouse(cm, e), scrollPos = display.scroller.scrollTop;
     if (!pos || opera) return; // Opera is difficult.
     if (posEq(sel.from, sel.to) || posLess(pos, sel.from) || !posLess(pos, sel.to))


### PR DESCRIPTION
The CM scroller handles some events like paste and context menus. When the target is in a line widget, CM shouldn't handle these events. This is a generalization of the logic in `onMouseDown()` that already ignores mouse events inside widgets.
