### PR TITLE
Add support for right to left mode

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -237,3 +237,19 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
     visibility: hidden;
   }
 }
+
+/* Right to left text */
+.CodeMirror-rtl {
+  direction: rtl;
+}
+
+.CodeMirror-rtl .CodeMirror-gutters {
+  right: 0 !important;
+  left: auto !important;
+  border-left: 1px solid #ddd;
+}
+
+.CodeMirror-rtl .CodeMirror-linenumber {
+  padding: 0 5px 0 3px;
+  text-align: left;
+}

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -57,6 +57,10 @@ window.CodeMirror = (function() {
     if (options.lineWrapping)
       this.display.wrapper.className += " CodeMirror-wrap";
 
+    // Enable right to left support if requested
+    if (options.direction == "rtl")
+      this.display.wrapper.className += " CodeMirror-rtl";
+
     // Initialize the content.
     this.setValue(options.value || "");
     // Override magic textarea content restore that IE sometimes does
@@ -420,7 +424,10 @@ window.CodeMirror = (function() {
 
     if (changes && maybeUpdateLineNumberWidth(cm))
       changes = true;
-    display.sizer.style.marginLeft = display.scrollbarH.style.left = display.gutters.offsetWidth + "px";
+
+    var sizerStyle = cm.options.direction == "rtl" ? "marginRight" : "marginLeft",
+    scrollbarStyle = cm.options.direction == "rtl" ? "right" : "left";
+    display.sizer.style[sizerStyle] = display.scrollbarH.style[scrollbarStyle] = display.gutters.offsetWidth + "px";
 
     // When merged lines are present, the line that needs to be
     // redrawn might not be the one that was changed.
@@ -591,7 +598,8 @@ window.CodeMirror = (function() {
 
     var wrap = elt("div", null, line.wrapClass, "position: relative");
     if (cm.options.lineNumbers || markers) {
-      var gutterWrap = wrap.appendChild(elt("div", null, null, "position: absolute; left: " +
+      var wrapSide = cm.options.direction == "rtl" ? "right" : "left";
+      var gutterWrap = wrap.appendChild(elt("div", null, null, "position: absolute; " + wrapSide + ": " +
                                             dims.fixedPos + "px"));
       wrap.alignable = [gutterWrap];
       if (cm.options.lineNumbers && (!markers || !markers["CodeMirror-linenumbers"]))


### PR DESCRIPTION
Add a new 'direction' option that, when set to 'rtl', moves line numbers to the right and right aligns text.

This is what it looks like in Arabic:

![Arabic Editor](https://f.cloud.github.com/assets/412966/21036/4a15210e-497b-11e2-9aed-8ed836fbf5c0.png)

It still has issues highlighting, navigating through the text, and responding to mouse clicks. I'm not sure how to tackle these issues, but I'm more than happy to take ownership of this use case because it affects me directly.
