### PR TITLE
improper CodeMirror.indentRangeFinder in util/foldcolde.js

### DIFF
--- a/lib/util/foldcode.js
+++ b/lib/util/foldcode.js
@@ -142,9 +142,11 @@ CodeMirror.indentRangeFinder = function(cm, start) {
   var myIndent = CodeMirror.countColumn(firstLine, null, tabSize);
   for (var i = start.line + 1, end = cm.lineCount(); i < end; ++i) {
     var curLine = cm.getLine(i);
-    if (CodeMirror.countColumn(curLine, null, tabSize) < myIndent)
+    if ((CodeMirror.countColumn(curLine, null, tabSize) == myIndent)&&
+          (CodeMirror.countColumn(cm.getLine(i-1), null, tabSize) > myIndent)){
       return {from: {line: start.line, ch: firstLine.length},
               to: {line: i, ch: curLine.length}};
+    }
   }
 };
 


### PR DESCRIPTION
For languages with indentation determined block structure, code folding on the first line would not work:
![Screen Shot 2012-12-29 at 3 35 33 PM](https://f.cloud.github.com/assets/936436/35188/998591d8-51b4-11e2-9112-201cde5eaf7e.png)
In order to fold you have to go to the second line:
![Screen Shot 2012-12-29 at 3 35 21 PM](https://f.cloud.github.com/assets/936436/35189/999b87a4-51b4-11e2-9e8a-be40537eb4a5.png)
and this is what it will look like:
![Screen Shot 2012-12-29 at 3 35 57 PM](https://f.cloud.github.com/assets/936436/35187/99781c42-51b4-11e2-9212-10995b8de845.png)

However the common way to code-fold in indented languages is this one:
![Screen Shot 2012-12-29 at 3 36 34 PM](https://f.cloud.github.com/assets/936436/35186/9955464a-51b4-11e2-989d-267320e02f26.png)

Here is a working solution to be placed in util/foldcolde.js:

``` javascript
CodeMirror.indentRangeFinder = function(cm, start) {
  var tabSize = cm.getOption("tabSize"), firstLine = cm.getLine(start.line);
  var myIndent = CodeMirror.countColumn(firstLine, null, tabSize);
  for (var i = start.line + 1, end = cm.lineCount(); i < end; ++i) {
    var curLine = cm.getLine(i);
    if ((CodeMirror.countColumn(curLine, null, tabSize) == myIndent)&&
          (CodeMirror.countColumn(cm.getLine(i-1), null, tabSize) > myIndent)){
      return {from: {line: start.line, ch: firstLine.length},
              to: {line: i, ch: curLine.length}};
    }
  }
};
```
