### PR TITLE
Enable JS autocomplete on other variable types.

### DIFF
--- a/lib/util/javascript-hint.js
+++ b/lib/util/javascript-hint.js
@@ -40,8 +40,8 @@
           }
         } while (level > 0);
         tprop = getToken(editor, {line: cur.line, ch: tprop.start});
-	if (tprop.type == 'variable')
-	  tprop.type = 'function';
+	if (tprop.type.indexOf("variable") === 0)
+	  tprop.type = "function";
 	else return; // no clue
       }
       if (!context) var context = [];
@@ -106,7 +106,7 @@
       // If this is a property, see if it belongs to some object we can
       // find in the current environment.
       var obj = context.pop(), base;
-      if (obj.type == "variable") {
+      if (obj.type.indexOf("variable") === 0) {
         if (options && options.additionalContext)
           base = options.additionalContext[obj.string];
         base = base || window[obj.string];


### PR DESCRIPTION
mode-javascript sets "variable-2" or "variable-3" types in addition to "variable". They should trigger autocompletion, too.

Test case:
<code>function(obj.</code>
