### PR TITLE
Fix fat cursor

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -46,7 +46,7 @@
 .CodeMirror div.CodeMirror-secondarycursor {
   border-left: 1px solid silver;
 }
-.cm-keymap-fat-cursor div.CodeMirror-cursor {
+.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor {
   width: auto;
   border: 0;
   background: transparent;
@@ -54,7 +54,7 @@
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#6600c800, endColorstr=#4c00c800);
 }
 /* Kludge to turn off filter in ie9+, which also accepts rgba */
-.cm-keymap-fat-cursor div.CodeMirror-cursor:not(#nonsense_id) {
+.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor:not(#nonsense_id) {
   filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
 }
 /* Can style cursor different in overwrite (non-insert) mode */


### PR DESCRIPTION
Fat cursor broken by https://github.com/marijnh/CodeMirror/commit/1fc80e4ef6dce8dca96bbbd670a1ba0e955408cd, fixed with CSS specificity hack.
