### PR TITLE
[vim keymap] Add {,} motions

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -115,6 +115,10 @@
         motion: 'moveByWords',
         motionArgs: { forward: false, wordEnd: true, bigWord: true,
             inclusive: true }},
+    { keys: ['{'], type: 'motion', motion: 'moveByParagraph',
+        motionArgs: { forward: false }},
+    { keys: ['}'], type: 'motion', motion: 'moveByParagraph',
+        motionArgs: { forward: true }},
     { keys: ['Ctrl-f'], type: 'motion',
         motion: 'moveByPage', motionArgs: { forward: true }},
     { keys: ['Ctrl-b'], type: 'motion',
@@ -932,6 +936,22 @@
         var curEnd = cm.getCursor();
         cm.setCursor(curStart);
         return curEnd;
+      },
+      moveByParagraph: function(cm, motionArgs) {
+        var line = cm.getCursor().line;
+        var repeat = motionArgs.repeat;
+        var inc = motionArgs.forward ? 1 : -1;
+        for (var i = 0; i < repeat; i++) {
+          if ((!motionArgs.forward && line === 0) ||
+              (motionArgs.forward && line == cm.lineCount() - 1)) {
+            break;
+          }
+          line += inc;
+          while (line !== 0 && line != cm.lineCount - 1 && cm.getLine(line)) {
+            line += inc;
+          }
+        }
+        return { line: line, ch: 0 };
       },
       moveByWords: function(cm, motionArgs) {
         return moveToWord(cm, motionArgs.repeat, !!motionArgs.forward,

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -266,6 +266,28 @@ testVim('Changing lines after Eol operation', function(cm, vim, helpers) {
   // same place we were at on line 1
   helpers.assertCursorAt({ line: 5, ch: lines[2].length - 2 });
 });
+testVim('}', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('}');
+  helpers.assertCursorAt(1, 0);
+  cm.setCursor(0, 0);
+  helpers.doKeys('2', '}');
+  helpers.assertCursorAt(4, 0);
+  cm.setCursor(0, 0);
+  helpers.doKeys('6', '}');
+  helpers.assertCursorAt(5, 0);
+}, { value: 'a\n\nb\nc\n\nd' });
+testVim('{', function(cm, vim, helpers) {
+  cm.setCursor(5, 0);
+  helpers.doKeys('{');
+  helpers.assertCursorAt(4, 0);
+  cm.setCursor(5, 0);
+  helpers.doKeys('2', '{');
+  helpers.assertCursorAt(1, 0);
+  cm.setCursor(5, 0);
+  helpers.doKeys('6', '{');
+  helpers.assertCursorAt(0, 0);
+}, { value: 'a\n\nb\nc\n\nd' });
 
 // Operator tests
 testVim('dl', function(cm, vim, helpers) {


### PR DESCRIPTION
Move by paragraph motions. Basically moves to next empty line in the specified direction.
