### PR TITLE
Add missing e argument in event listener

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1327,7 +1327,7 @@ window.CodeMirror = (function() {
       on(d.scroller, "dragover", drag_);
       on(d.scroller, "drop", operation(cm, onDrop));
     }
-    on(d.scroller, "paste", function(){
+    on(d.scroller, "paste", function(e){
       if (eventInWidget(d, e)) return;
       focusInput(cm); 
       fastPoll(cm);


### PR DESCRIPTION
This fix an error when compiling with Closure Compiler:
JSC_UNDEFINED_VARIABLE. variable e is undeclared at ~/CodeMirror/lib/codemirror.js line 1331 : 27

It might be good to use function(e) for all event listeners but I only changed the line that causes the error.

Thanks
