### PR TITLE
Adding application/javascript as a valid MIME type for JS files

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -414,6 +414,9 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
 });
 
 CodeMirror.defineMIME("text/javascript", "javascript");
+CodeMirror.defineMIME("text/ecmascript", "javascript");
+CodeMirror.defineMIME("application/javascript", "javascript");
+CodeMirror.defineMIME("application/ecmascript", "javascript");
 CodeMirror.defineMIME("application/json", {name: "javascript", json: true});
 CodeMirror.defineMIME("text/typescript", { name: "javascript", typescript: true });
 CodeMirror.defineMIME("application/typescript", { name: "javascript", typescript: true });


### PR DESCRIPTION
According to [RFC 4329](http://www.rfc-editor.org/rfc/rfc4329.txt) the MIME type for javascript files should be either application/javascript or application/ecmascript.

For history's sake I've also added text/ecmascript.
