### PR TITLE
Make temporary wheel measurement vars per-instance

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1637,7 +1637,7 @@ window.CodeMirror = (function() {
   // is that it gives us a chance to update the display before the
   // actual scrolling happens, reducing flickering.
 
-  var wheelSamples = 0, wheelDX, wheelDY, wheelStartX, wheelStartY, wheelPixelsPerUnit = null;
+  var wheelSamples = 0, wheelPixelsPerUnit = null;
   // Fill in a browser-detected starting value on browsers where we
   // know one. These don't have to be accurate -- the result of them
   // being wrong would just be a slight flicker on the first wheel
@@ -1678,7 +1678,7 @@ window.CodeMirror = (function() {
         setScrollTop(cm, Math.max(0, Math.min(scroll.scrollTop + dy * wheelPixelsPerUnit, scroll.scrollHeight - scroll.clientHeight)));
       setScrollLeft(cm, Math.max(0, Math.min(scroll.scrollLeft + dx * wheelPixelsPerUnit, scroll.scrollWidth - scroll.clientWidth)));
       e_preventDefault(e);
-      wheelStartX = null; // Abort measurement, if in progress
+      cm.wheelStartX = null; // Abort measurement, if in progress
       return;
     }
 
@@ -1691,22 +1691,22 @@ window.CodeMirror = (function() {
     }
 
     if (wheelSamples < 20) {
-      if (wheelStartX == null) {
-        wheelStartX = scroll.scrollLeft; wheelStartY = scroll.scrollTop;
-        wheelDX = dx; wheelDY = dy;
+      if (cm.wheelStartX == null) {
+        cm.wheelStartX = scroll.scrollLeft; cm.wheelStartY = scroll.scrollTop;
+        cm.wheelDX = dx; cm.wheelDY = dy;
         setTimeout(function() {
-          if (wheelStartX == null) return;
-          var movedX = scroll.scrollLeft - wheelStartX;
-          var movedY = scroll.scrollTop - wheelStartY;
-          var sample = (movedY && wheelDY && movedY / wheelDY) ||
-            (movedX && wheelDX && movedX / wheelDX);
-          wheelStartX = wheelStartY = null;
+          if (cm.wheelStartX == null) return;
+          var movedX = scroll.scrollLeft - cm.wheelStartX;
+          var movedY = scroll.scrollTop - cm.wheelStartY;
+          var sample = (movedY && cm.wheelDY && movedY / cm.wheelDY) ||
+            (movedX && cm.wheelDX && movedX / cm.wheelDX);
+          cm.wheelStartX = cm.wheelStartY = null;
           if (!sample) return;
           wheelPixelsPerUnit = (wheelPixelsPerUnit * wheelSamples + sample) / (wheelSamples + 1);
           ++wheelSamples;
         }, 200);
       } else {
-        wheelDX += dx; wheelDY += dy;
+        cm.wheelDX += dx; cm.wheelDY += dy;
       }
     }
   }


### PR DESCRIPTION
In order to measure the average pixels-per-wheel-event, CodeMirror uses a number of temporary variables to track the dx/dy of a given wheel event and compare it to the actual distance scrolled. These variables are global to the CodeMirror module, so are shared by all CodeMirror instances, and are referred to asynchronously in a `setTimeout` function.

This causes a problem for Brackets, where we have CodeMirror editors nested inside each other. I believe the issue is that a single throw scroll can cross the boundary between the two editors, causing some wheel events to go to one editor and some to go to the other editor. That makes it so that one editor ends up referring to saved scroll/delta values that were set by another editor, leading to wildly erroneous values for `wheelPixelsPerUnit` (which ends up messing up things like the manual handling of horizontal scrolling).

This patch fixes the problem by storing `wheelDX`, `wheelDY`, `wheelStartX`, and `wheelStartY` on the CM instance instead of in module-global variables. `wheelPixelsPerUnit` and `wheelSamples` are still stored globally, so any instance can add its wheel measurement info to the global average; this doesn't seem to cause any problems since those updates are atomic.
