### PR TITLE
widget.remove() should be widget.clear()

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2601,7 +2601,7 @@ window.CodeMirror = (function() {
       return addLineWidget(this, handle, node, options);
     }),
 
-    removeLineWidget: function(widget) { widget.remove(); },
+    removeLineWidget: function(widget) { widget.clear(); },
 
     lineInfo: function(line) {
       if (typeof line == "number") {


### PR DESCRIPTION
See LineWidget refactoring in db1b28207d5b8b799d7202cf47bb9ece1c0afb3c. Appears to be an oversight.
