### PR TITLE
Support Scala in GFM mode.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -10,7 +10,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     "c++": "text/x-c++src",
     java: "text/x-java",
     csharp: "text/x-csharp",
-    "c#": "text/x-csharp"
+    "c#": "text/x-csharp",
+    scala: "text/x-scala"
   };
 
   var getMode = (function () {


### PR DESCRIPTION
As Scala is also defined in the clike-mode it could be easily supported in the GFM-mode just like Java or C-Sharp.
