### PR TITLE
Fix for invalid matching symbol in vim keymap.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1726,8 +1726,13 @@
         nextCh = lineText.charAt(index);
         if (!nextCh) {
           line += increment;
-          index = 0;
           lineText = cm.getLine(line) || '';
+          if (increment > 0) {
+            index = 0;
+          } else {
+            var lineLen = lineText.length;
+            index = (lineLen > 0) ? (lineLen-1) : 0;
+          }
           nextCh = lineText.charAt(index);
         }
         if (nextCh === symb) {


### PR DESCRIPTION
When the matching symbol of a closing bracket is on a different
line, it will match to the incorrect opening bracket. For example,
go to http://codemirror.net/demo/vim.html and place the cursor on
the closing brace at line 11 and press '%'.  It will incorrectly
match the opening brace on line 4 instead of the brace on line 8.
This patch fixes that by starting the line search at the _end_ of
the line when searching backwards. @mightyguava
