### PR TITLE
Improve the check for whether the CodeMirror should be cleaned up

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1396,10 +1396,14 @@ window.CodeMirror = (function() {
     // Prevent wrapper from ever scrolling
     on(d.wrapper, "scroll", function() { d.wrapper.scrollTop = d.wrapper.scrollLeft = 0; });
     on(window, "resize", function resizeHandler() {
+      var currentParent = d.wrapper.parentNode;
       // Might be a text scaling operation, clear size caches.
       d.cachedCharWidth = d.cachedTextHeight = null;
       clearCaches(cm);
-      if (d.wrapper.parentNode) runInOp(cm, bind(regChange, cm));
+      while (currentParent !== document.body && currentParent !== null) {
+        currentParent = currentParent.parentNode;
+      }
+      if (currentParent === document.body) runInOp(cm, bind(regChange, cm));
       else off(window, "resize", resizeHandler);
     });
 


### PR DESCRIPTION
When checking whether the wrapper element is still part of the DOM, check all the way up to the document body.
Currently, when removing an ancestor of the wrapper element from the DOM which is not its parent, the `resizeHandler` is not unregistered.
