### PR TITLE
Add findH() to commands

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2681,6 +2681,10 @@ window.CodeMirror = (function() {
       extendSelection(this.doc, pos, pos, dir);
     }),
 
+    findH: operation(null, function(dir, unit) {
+      return findPosH(this.doc, dir, unit, false);
+    }),
+
     deleteH: operation(null, function(dir, unit) {
       var sel = this.doc.sel;
       if (!posEq(sel.from, sel.to)) replaceRange(this.doc, "", sel.from, sel.to, "delete");


### PR DESCRIPTION
Useful for automatically adding/removing characters when hitting a key. For example, in Markdown mode, it would be easy to make `backspace` to delete the preceding blank line to give a better feeling of "paragraphs". (But it would be aware of multiple blank lines, and automatically adjust to "snap" to a paragraph [i.e., the 2nd, 4th, ... blank line].)
