### PR TITLE
Slight improvement to addWidget positioning behavior

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2646,12 +2646,14 @@ window.CodeMirror = (function() {
       var top = pos.top, left = pos.left;
       node.style.position = "absolute";
       display.sizer.appendChild(node);
-      if (vert == "over") top = pos.top;
-      else if (vert == "near") {
+      if (vert == "above" || vert == "near") {
         var vspace = Math.max(display.wrapper.clientHeight, this.doc.height),
         hspace = Math.max(display.sizer.clientWidth, display.lineSpace.clientWidth);
-        if (pos.bottom + node.offsetHeight > vspace && pos.top > node.offsetHeight)
+        // Default to positioning above (if specified and possible); otherwise default to positioning below
+        if ((vert == 'above' || pos.bottom + node.offsetHeight > vspace) && pos.top > node.offsetHeight)
           top = pos.top - node.offsetHeight;
+        else if (pos.bottom + node.offsetHeight <= vspace)
+          top = pos.bottom;
         if (left + node.offsetWidth > hspace)
           left = hspace - node.offsetWidth;
       }


### PR DESCRIPTION
This pull makes the following changes to the addWidget function:
- "over" vertical positioning logic is removed since it's redundant (top is already set to pos.top by default, so no reason to assign it twice)
- new "above" vertical positioning logic, which will default to sticking the widget above the position (if space is available), and otherwise will stick it below (basically a variant of "near")
- "near" vertical positioning logic is revised to default to sticking the widget beneath the position, but if it will not fit it will stick it above
- If the widget will not fit either above or below the position, then it will should default to overlaying the position (same behavior as previously)
