### PR TITLE
Need a longer test substring for text/x-handlebars-template

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -9,7 +9,7 @@ CodeMirror.defineMode("htmlmixed", function(config) {
     if (/(?:^|\s)tag(?:\s|$)/.test(style) && stream.current() == ">" && state.htmlState.context) {
       if (/^script$/i.test(state.htmlState.context.tagName)) {
         // Script block: mode to change to depends on type attribute
-        var scriptType = stream.string.slice(stream.pos - 30, stream.pos).match(/\btype\s*=\s*("[^"]+"|'[^']+'|\S+)[^<]*$/i);
+        var scriptType = stream.string.slice(stream.pos - 40, stream.pos).match(/\btype\s*=\s*("[^"]+"|'[^']+'|\S+)[^<]*$/i);
         scriptType = scriptType && scriptType[1];
         if (!scriptType || scriptType.match(/(text|application)\/(java|ecma)script/i)) {
           state.token = javascript;


### PR DESCRIPTION
For `<script type="text/x-handlebars-template">`, using a 30 char substring, "type" is truncated from beginning of substring, so regex fails, so I bumped it up to 40.

Note that an id is required for handlebars, so if it happens to be after type attribute like `<script type="text/x-handlebars-template" id="top-navigation">` the substring needs to be _much_ longer than 40 chars.
