### PR TITLE
iPad fixes

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -136,7 +136,7 @@ window.CodeMirror = (function() {
     if (place.appendChild) place.appendChild(d.wrapper); else place(d.wrapper);
 
     // Needed to hide big blue blinking cursor on Mobile Safari
-    if (ios) input.style.width = "0px";
+    if (ios) input.style.right = "100%";
     if (!webkit) d.scroller.draggable = true;
     // Needed to handle Tab key in KHTML
     if (khtml) { d.inputDiv.style.height = "1px"; d.inputDiv.style.position = "absolute"; }


### PR DESCRIPTION
Here are a few fixes for the iPad that make CodeMirror usable. So far, I've only been able to test on an older iPad (getting access to a newer one later today--feel free to hold off on merging until I test that as well). I also haven't tested the iPhone, but it may affect that as well. (I encourage feedback from people who can test!)

I've kept the commits separate in case you only want to pull in 1 or 2 of the fixes. If you don't include the first commit, be sure to add the userAgent check for iPads.
### Fix issue with cursor position on iPad.

The cursor position gradually gets further and further away from the correct position on longer lines as it reaches the end (kerning and subpixel rendering causing measurements to be off, perhaps?). Separating each character into its own `<span>` solves the issue, but it's rather hacky. (Regressed between v2.38 and v3.0.)

This issue is also present on older Android (v2.3.4), but it's also unusable (no keyboard pops up), so I didn't worry about it. I'll test out a newer Android device later if I can.
### Fix bug with placing cursor on iPad when scrolled.

When the entire page is scrolled on the iPad, touching a location results in the cursor being placed at touch-position + scroll-position. That is, if the page isn't scrolled, the cursor is placed in the correct spot. However, if the page is scrolled 50px, the cursor will be placed 50px below the spot it should be. 
### Hide blue cursor on mobile safari (specifically iPad).

The blinking blue cursor isn't hidden on the iPad. Moving the textarea off screen seems to solve the issue, but not sure if it works on iPhone.
