### PR TITLE
Support for x-javascript and x-ecmascript mime types

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -11,7 +11,7 @@ CodeMirror.defineMode("htmlmixed", function(config) {
         // Script block: mode to change to depends on type attribute
         var scriptType = stream.string.slice(Math.max(0, stream.pos - 100), stream.pos).match(/\btype\s*=\s*("[^"]+"|'[^']+'|\S+)[^<]*$/i);
         scriptType = scriptType && scriptType[1];
-        if (!scriptType || scriptType.match(/(text|application)\/(java|ecma)script/i)) {
+        if (!scriptType || scriptType.match(/(text|application)\/(x-)?(java|ecma)script/i)) {
           state.token = javascript;
           state.localMode = jsMode;
           state.localState = jsMode.startState(htmlMode.indent(state.htmlState, ""));


### PR DESCRIPTION
Add support for x-javascript and x-ecmascript mime types as described in the HTML5 spec:
http://www.w3.org/TR/html5/scripting-1.html#the-script-element

This fixes another case of https://github.com/adobe/brackets/issues/2023.
