### PR TITLE
Wrap undo/redo in an operation

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4254,8 +4254,8 @@ window.CodeMirror = (function() {
     replaceSelection: function(code, collapse, origin) {
       makeChange(this, {from: this.sel.from, to: this.sel.to, text: splitLines(code), origin: origin}, collapse || "around");
     },
-    undo: function() {makeChangeFromHistory(this, "undo");},
-    redo: function() {makeChangeFromHistory(this, "redo");},
+    undo: docOperation(function() {makeChangeFromHistory(this, "undo");}),
+    redo: docOperation(function() {makeChangeFromHistory(this, "redo");}),
 
     setExtending: function(val) {this.sel.extend = val;},
 


### PR DESCRIPTION
Currently, undo/redo are not in an operation, which means that if an edit that batches together a large number of text changes (e.g. adding indents to the beginning of each line in a long file) is undone, each change is undone as a separate operation.

I'm assuming this was just an oversight, but let me know if there's some reason these weren't wrapped originally--if so, we'll need to figure out what to do about large batched edits.
