### PR TITLE
Add a "highlightMargin" option.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -336,6 +336,16 @@
       always rendered, and thus the browser's text search works on it.
       This <em>will</em> have bad effects on performance of big
       documents.</dd>
+
+      <dt id="option_highlightMargin"><code>highlightMargin (integer)</code></dt>
+      <dd>Specifies the amount of lines below the viewport that are
+      processed for highlighting styles, This affects the amount of
+      processing of highlighting styles needed when scrolling. You
+      should usually leave it at its default, 500. Can be set
+      to <code>Infinity</code> to make sure the whole document is
+      always processed, and thus no highlighting processing needed
+      on scrolling, however it will cause more work on rehighlighting
+      for each edit.</dd>
     </dl>
 
     <h2 id="events">Events</h2>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -861,7 +861,7 @@ window.CodeMirror = (function() {
     var end = +new Date + cm.options.workTime;
     var state = copyState(doc.mode, getStateBefore(cm, doc.frontier));
     var changed = [], prevChange;
-    doc.iter(doc.frontier, Math.min(doc.first + doc.size, cm.display.showingTo + 500), function(line) {
+    doc.iter(doc.frontier, Math.min(doc.first + doc.size, cm.display.showingTo + cm.options.highlightMargin), function(line) {
       if (doc.frontier >= cm.display.showingFrom) { // Visible
         var oldStyles = line.styles;
         line.styles = highlightLine(cm, line, state);
@@ -2874,6 +2874,7 @@ window.CodeMirror = (function() {
   option("pollInterval", 100);
   option("undoDepth", 40, function(cm, val){cm.doc.history.undoDepth = val;});
   option("viewportMargin", 10, function(cm){cm.refresh();}, true);
+  option("highlightMargin", 500);
 
   option("tabindex", null, function(cm, val) {
     cm.display.input.tabIndex = val || "";


### PR DESCRIPTION
This is to make it possible to specify how far past the viewport to generate highlighting styles, this is useful for me as I have a mode which has all of the processing cost front-loaded onto the first token call (it needs to process all the tokens that will be needed in one go - not ideal at all, but it isn't really avoidable for this case).
Anyway, one of the issues with this is that it nullifies the work done in CodeMirror to keep things responsive, meaning I have to take those same/similar measures myself. One being to only process what will actually be visible to the user (so as to make typing significantly more responsive, even though it does make scrolling less responsive).  This worked great up until b31f73e98c36aca38b0af2b0d8f6a49905e4f8d4 when the amount of highlighting styles processed increases to more than the visible area - which means I can no longer only process those tokens which fall into the visible area.

This option will allow me to use this optimisation once again and whilst I expect is a very niche option I hope that the the code to support it is small enough to not be a burden.
