### PR TITLE
Fix context menus for non-Gecko/non-IE browsers

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1389,7 +1389,7 @@ window.CodeMirror = (function() {
     // Gecko browsers fire contextmenu *after* opening the menu, at
     // which point we can't mess with it anymore. Context menu is
     // handled in onMouseDown for Gecko.
-    if (captureMiddleClick) on(d.scroller, "contextmenu", function(e) {onContextMenu(cm, e);});
+    if (!captureMiddleClick) on(d.scroller, "contextmenu", function(e) {onContextMenu(cm, e);});
 
     on(d.scroller, "scroll", function() {
       setScrollTop(cm, d.scroller.scrollTop);


### PR DESCRIPTION
This fixes a logic error in commit c98271e6a0f0692610e02154029d16a71ecfff2e 

The "contextmenu" event handler should _not_ be added for gecko & IE < 9 browsers. If you look at the original commit, this line had `if (!gecko)`, but the new `captureMiddleClick` flag has the opposite meaning.
