### PR TITLE
Vertical Grid

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -199,6 +199,12 @@
       <dt id="option_lineWrapping"><code>lineWrapping (boolean)</code></dt>
       <dd>Whether CodeMirror should scroll or wrap for long lines.
       Defaults to <code>false</code> (scroll).</dd>
+      
+      <dt id="option_verticalGrid"><code>verticalGrid (boolean)</code></dt>
+      <dd>Enable it to force the selection to start and end exactly between
+      lines. See <a href="https://github.com/marijnh/CodeMirror/pull/1234">this</a>
+      for details. Only needed when changing the <code>line-height</code>
+      of the code.</dd>
 
       <dt id="option_lineNumbers"><code>lineNumbers (boolean)</code></dt>
       <dd>Whether to show line numbers to the left of the editor.</dd>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -968,8 +968,8 @@ window.CodeMirror = (function() {
   }
 
   function unpixelize(value) {
-    var match = /^(\d+)px$/.exec(value);
-    return match ? match[0][1] : null;
+    var m = /^(\d+)px$/.exec(value);
+    return m && m[1];
   }
 
   function measureLineInner(cm, line) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1007,7 +1007,8 @@ window.CodeMirror = (function() {
 
     for (var i = 0, cur; i < measure.length; ++i) if (cur = measure[i]) {
       var size = cur.getBoundingClientRect();
-      var top = Math.max(0, size.top - outer.top), bot = Math.min(size.bottom - outer.top, maxBot);
+      var top = size.top - outer.top, bot = size.bottom - outer.top;
+      top = Math.max(top,0), bot = Math.min(bot,maxBot);
       for (var j = 0; j < vranges.length; j += 2) {
         var rtop = vranges[j], rbot = vranges[j+1];
         if (rtop > bot || rbot < top) continue;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -967,6 +967,11 @@ window.CodeMirror = (function() {
     return measure;
   }
 
+  function unpixelize(value) {
+    var match = /^(\d+)px$/.exec(value);
+    return match ? match[0][1] : null;
+  }
+
   function measureLineInner(cm, line) {
     var display = cm.display, measure = emptyArray(line.text.length);
     var pre = lineContent(cm, line, measure);
@@ -1005,9 +1010,12 @@ window.CodeMirror = (function() {
     if (ie_lt9 && display.measure.first != pre)
       removeChildrenAndAdd(display.measure, pre);
 
+    var vg = (cm.options.verticalGrid && getComputedStyle) ?
+             unpixelize(getComputedStyle(pre)["line-height"]) : null;
     for (var i = 0, cur; i < measure.length; ++i) if (cur = measure[i]) {
       var size = cur.getBoundingClientRect();
       var top = size.top - outer.top, bot = size.bottom - outer.top;
+      if (vg) top = Math.round(top/vg)*vg, bot = Math.round(bot/vg)*vg;
       top = Math.max(top,0), bot = Math.min(bot,maxBot);
       for (var j = 0; j < vranges.length; j += 2) {
         var rtop = vranges[j], rbot = vranges[j+1];
@@ -2845,6 +2853,7 @@ window.CodeMirror = (function() {
   option("onDragEvent", null);
 
   option("lineWrapping", false, wrappingChanged, true);
+  option("verticalGrid", false);
   option("gutters", [], function(cm) {
     setGuttersForLineNumbers(cm.options);
     guttersChanged(cm);


### PR DESCRIPTION
**Not yet ready to merge!**

Open a terminal or an IDE, select something and look at the shape
of the selection. Its "top" and "bottom" lands _exactly between two lines_.
This is more easier to see if the active line is highlighted.

On a browser, this is also true... until you wrap each line in his own
block (which is what CodeMirror2 and ACE do). Then, each line's bounds
separate a bit, yielding something like this:

![That odd selection.](https://f.cloud.github.com/assets/1177304/144899/7f17377e-7442-11e2-816b-6ab0a138f091.png)

Let's look at it closer. Compare the actual line with the selection shape:

![In depth...](http://i.imgur.com/KwW5AqN.png)

This affects not only the selection, but the cursor and some other things.
**Note:** if the `line-height` of the lines is not set, nothing of this happens.
## The problem

This appears because of the one-block-per-line model, which is essential for
CodeMirror to work (with line widgets, for example).

Actually, CodeMirror **draws the selection correctly**, because if you start
your selection from outside CodeMirror, the effects are the same.

However, this is odd and we should have a way to avoid it.
## The fix

What we do is add an option `verticalGrid` that, when enabled,
causes CodeMirror to round the character measures so that **their
`top` and `bottom` coordinates are always a multiple of `line-height`**.

Everything looks good now:

![sel2](https://f.cloud.github.com/assets/1177304/144968/9fe035c4-7446-11e2-89ab-6f5d853f0652.png)
## The implementation

If the option is disabled (the default), this feature adds
one `if` for every line, and another for every character.

Some browsers may not have `getComputedStyle`, or
may return incorrect values (like `normal`). In this case,
CodeMirror ignores this option.
