### PR TITLE
clike dependency missing for php.

### DIFF
--- a/mode/php/php.js
+++ b/mode/php/php.js
@@ -121,7 +121,7 @@
 
       innerMode: function(state) { return {state: state.curState, mode: state.curMode}; }
     };
-  }, "htmlmixed");
+  }, "htmlmixed", "clike");
 
   CodeMirror.defineMIME("application/x-httpd-php", "php");
   CodeMirror.defineMIME("application/x-httpd-php-open", {name: "php", startOpen: true});


### PR DESCRIPTION
the 'clike' mode was missing as a php dependency, but is a required dependency.  You can see the JS errors that get thrown [here](http://codemirror.net/demo/loadmode.html) by adding the <?php tag and adding some newlines.

I'm not super familiar with this library, but I think I fixed it properly.
