### PR TITLE
Signal "change" event before clearing current op

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1219,6 +1219,7 @@ window.CodeMirror = (function() {
 
   function endOperation(cm) {
     var op = cm.curOp, doc = cm.doc, display = cm.display;
+    if (op.textChanged) signal(cm, "change", cm, op.textChanged);
     cm.curOp = null;
 
     if (op.updateMaxLine) computeMaxLength(cm);
@@ -1263,8 +1264,6 @@ window.CodeMirror = (function() {
       delayed = delayedCallbacks;
       delayedCallbacks = null;
     }
-    if (op.textChanged)
-      signal(cm, "change", cm, op.textChanged);
     if (op.selectionChanged) signal(cm, "cursorActivity", cm);
     if (delayed) for (var i = 0; i < delayed.length; ++i) delayed[i]();
   }


### PR DESCRIPTION
Groups changes made by `on("change")` with the current operation so undo/redo treats it as a single change. This is especially useful when `on("change")` automatically fixes input (such as normalizing indentation).

I'm not sure if this breaks anything---the tests seem to pass and the modes I tried still worked. If this pull request can't be accepted, perhaps a "changeWithOp" event? Or a way to group the change in `on("change")` with the previous operation? (I couldn't find a way to do this, and don't remember this being a possibility.)
