### PR TITLE
Avoid scrolling to cursor position in a non-visible editor

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1241,7 +1241,7 @@ window.CodeMirror = (function() {
     var newScrollPos, updated;
     if (op.updateScrollPos) {
       newScrollPos = op.updateScrollPos;
-    } else if (op.selectionChanged) {
+    } else if (op.selectionChanged && display.scroller.clientHeight) { // don't rescroll if not visible
       var coords = cursorCoords(cm, doc.sel.head);
       newScrollPos = calculateScrollPos(cm, coords.left, coords.top, coords.left, coords.bottom);
     }


### PR DESCRIPTION
Simple fix for #1236.
