### PR TITLE
Actionscript 3 Syntax Highlight mode

### DIFF
--- a/addon/edit/continuecomment.js
+++ b/addon/edit/continuecomment.js
@@ -1,5 +1,5 @@
 (function() {
-  var modes = ["clike", "css", "javascript"];
+  var modes = ["clike", "css", "javascript", "actionscript"];
   for (var i = 0; i < modes.length; ++i)
     CodeMirror.extendMode(modes[i], {blockCommentStart: "/*",
                                      blockCommentEnd: "*/",

--- a/mode/actionscript/actionscript.js
+++ b/mode/actionscript/actionscript.js
@@ -1,0 +1,233 @@
+CodeMirror.defineMode("actionscript", function(config, parserConfig) {
+  var indentUnit = config.indentUnit,
+      statementIndentUnit = parserConfig.statementIndentUnit || indentUnit,
+      dontAlignCalls = parserConfig.dontAlignCalls,
+      keywords = parserConfig.keywords || {},
+      attributes = parserConfig.attributes || {},
+      builtin = parserConfig.builtin || {},
+      blockKeywords = parserConfig.blockKeywords || {},
+      atoms = parserConfig.atoms || {},
+      hooks = parserConfig.hooks || {},
+      multiLineStrings = parserConfig.multiLineStrings;
+  var isOperatorChar = /[+\-*&%=<>!?|\/]/;
+
+  var curPunc;
+
+  function tokenBase(stream, state) {
+    var ch = stream.next();
+    if (hooks[ch]) {
+      var result = hooks[ch](stream, state);
+      if (result !== false) return result;
+    }
+    if (ch == '"' || ch == "'") {
+      state.tokenize = tokenString(ch);
+      return state.tokenize(stream, state);
+    }
+    if (/[\[\]{}\(\),;\:\.]/.test(ch)) {
+      curPunc = ch;
+      return null;
+    }
+    if (/\d/.test(ch)) {
+      stream.eatWhile(/[\w\.]/ );
+      return "number";
+    }
+    if (ch == "/") {
+      if (stream.eat("*")) {
+        state.tokenize = tokenComment;
+        return tokenComment(stream, state);
+      }
+      if (stream.eat("/")) {
+        stream.skipToEnd();
+        return "comment";
+      }
+      if (state.lastStyle == "operator" || state.lastStyle == "keyword" || /^[\[{}\(,;:]$/.test(state.lastStyle)) {
+        nextUntilUnescaped(stream, "/");
+        stream.eatWhile(/[gixsm]/); 
+        return "string-2";
+      }
+    }
+    if (isOperatorChar.test(ch)) {
+      stream.eatWhile(isOperatorChar);
+      return "operator";
+    }
+    stream.eatWhile(/[\w\$_]/);
+    var cur = stream.current();
+    if (keywords.propertyIsEnumerable(cur)) {
+      if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
+      return "keyword";
+    }
+    if (attributes.propertyIsEnumerable(cur)) {
+      if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
+      return "attribute";
+    }
+    if (builtin.propertyIsEnumerable(cur)) {
+      if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
+      return "builtin";
+    }
+    if (atoms.propertyIsEnumerable(cur)) return "atom";
+    return "variable";
+  }
+
+  function tokenString(quote) {
+    return function(stream, state) {
+      var escaped = false, next, end = false;
+      while ((next = stream.next()) != null) {
+        if (next == quote && !escaped) {end = true; break;}
+        escaped = !escaped && next == "\\";
+      }
+      if (end || !(escaped || multiLineStrings))
+        state.tokenize = null;
+      return "string";
+    };
+  }
+
+  function tokenComment(stream, state) {
+    var maybeEnd = false, ch;
+    while (ch = stream.next()) {
+      if (ch == "/" && maybeEnd) {
+        state.tokenize = null;
+        break;
+      }
+      maybeEnd = (ch == "*");
+    }
+    return "comment";
+  }
+    
+  function nextUntilUnescaped(stream, end) {
+    var escaped = false, next;
+    while ((next = stream.next()) != null) {
+      if (next == end && !escaped)
+        return false;
+      escaped = !escaped && next == "\\";
+    }
+    return escaped;
+  }
+
+  function Context(indented, column, type, align, prev) {
+    this.indented = indented;
+    this.column = column;
+    this.type = type;
+    this.align = align;
+    this.prev = prev;
+  }
+  function pushContext(state, col, type) {
+    var indent = state.indented;
+    if (state.context && state.context.type == "statement")
+      indent = state.context.indented;
+    return state.context = new Context(indent, col, type, null, state.context);
+  }
+  function popContext(state) {
+    var t = state.context.type;
+    if (t == ")" || t == "]" || t == "}")
+      state.indented = state.context.indented;
+    return state.context = state.context.prev;
+  }
+
+  // Interface
+
+  return {
+    startState: function(basecolumn) {
+      return {
+        tokenize: null,
+        context: new Context((basecolumn || 0) - indentUnit, 0, "top", false),
+        indented: 0,
+        startOfLine: true
+      };
+    },
+
+    token: function(stream, state) {
+      var ctx = state.context;
+      if (stream.sol()) {
+        if (ctx.align == null) ctx.align = false;
+        state.indented = stream.indentation();
+        state.startOfLine = true;
+      }
+      if (stream.eatSpace()) return null;
+      curPunc = null;
+      var style = (state.tokenize || tokenBase)(stream, state);
+      state.lastStyle = style || curPunc;
+      if (style == "comment" || style == "meta") return style;
+      if (ctx.align == null) ctx.align = true;
+      if ((curPunc == ";" || curPunc == ":" || curPunc == ",") && ctx.type == "statement") popContext(state);
+      else if (curPunc == "{") pushContext(state, stream.column(), "}");
+      else if (curPunc == "[") pushContext(state, stream.column(), "]");
+      else if (curPunc == "(") pushContext(state, stream.column(), ")");
+      else if (curPunc == "}") {
+        while (ctx.type == "statement") ctx = popContext(state);
+        if (ctx.type == "}") ctx = popContext(state);
+        while (ctx.type == "statement") ctx = popContext(state);
+      }
+      else if (curPunc == ctx.type) popContext(state);
+      else if (((ctx.type == "}" || ctx.type == "top") && curPunc != ';') || (ctx.type == "statement" && curPunc == "newstatement"))
+        pushContext(state, stream.column(), "statement");
+      state.startOfLine = false;
+      return style;
+    },
+
+    indent: function(state, textAfter) {
+      if (state.tokenize != tokenBase && state.tokenize != null) return CodeMirror.Pass;
+      var ctx = state.context, firstChar = textAfter && textAfter.charAt(0);
+      if (ctx.type == "statement" && firstChar == "}") ctx = ctx.prev;
+      var closing = firstChar == ctx.type;
+      if (ctx.type == "statement") return ctx.indented + (firstChar == "{" ? 0 : statementIndentUnit);
+      else if (dontAlignCalls && ctx.type == ")" && !closing) return ctx.indented + statementIndentUnit;
+      else if (ctx.align) return ctx.column + (closing ? 0 : 1);
+      else return ctx.indented + (closing ? 0 : indentUnit);
+    },
+
+    electricChars: "{}"
+  };
+});
+
+(function() {
+  function words(str) {
+    var obj = {}, words = str.split(" ");
+    for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
+    return obj;
+  }
+  var cKeywords = "auto if break int case long char register continue return default short do sizeof " +
+    "double static else struct entry switch extern typedef float union for unsigned " +
+    "goto while enum void const signed volatile";
+
+  function cppHook(stream, state) {
+    if (!state.startOfLine) return false;
+    for (;;) {
+      if (stream.skipTo("\\")) {
+        stream.next();
+        if (stream.eol()) {
+          state.tokenize = cppHook;
+          break;
+        }
+      } else {
+        stream.skipToEnd();
+        state.tokenize = null;
+        break;
+      }
+    }
+    return "meta";
+  }
+
+  // C#-style strings where "" escapes a quote.
+  function tokenAtString(stream, state) {
+    var next;
+    while ((next = stream.next()) != null) {
+      if (next == '"' && !stream.eat('"')) {
+        state.tokenize = null;
+        break;
+      }
+    }
+    return "string";
+  }
+
+  
+  CodeMirror.defineMIME("text/x-actionscript", {
+    name: "actionscript",
+    keywords: words("if while with else do try finally return break continue new delete throw var const catch" +
+                     " for each in switch case default label super this typeof instanceof as is" +
+                     " class const extends function get set implements interface namespace package import include"),
+    attributes: words("public internal protected private static override native final dynamic"),
+    blockKeywords: words("catch class do else finally for foreach if switch try while"),
+    builtin: words("int uint Number String void Null Boolean Object trace"),
+    atoms: words("true false null undefined NaN Infinity"),
+  });
+}());

--- a/mode/actionscript/index.html
+++ b/mode/actionscript/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CodeMirror: ActionScript mode</title>
+    <link rel="stylesheet" href="../../lib/codemirror.css">
+    <script src="../../lib/codemirror.js"></script>
+    <script src="actionscript.js"></script>
+    <link rel="stylesheet" href="../../doc/docs.css">
+    <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+  </head>
+  <body>
+    <h1>CodeMirror: Actionscript mode</h1>
+
+<div><textarea id="code" name="code">
+packake com.example.Tests
+{    
+    import one.two.Three;
+    import one.two.IInterface;
+    
+    [SWF(width="1024", height="768", frameRate="60", backgroundColor="#FFFFFF")]]
+    public class Foo extends Sprite implements IInterface
+    {
+        public static const EVT_NAME:String = "myEventName";
+        
+        [Inject (id="Test")]
+        public var injectedVar;
+        
+        public var myPublicStr:String = new String("init");
+        private var _myPrivateStr:String = "Private var";
+        private var _myPrivateBool:Bool = true;
+        
+        var obj:Object = { foo:val1, "bar":"value" };
+        var arr:Array = [ 0,1,2,3,4]
+        var vector:Vector.<int> = Vector.<int> ( [0, 1, 2, 3] );
+        
+        public function Foo()
+        {
+            myPublicStr = "assigned in function scope";
+            
+            _myPrivateString = _myPrivateBool ? "Ternary" : "Operator";
+            
+            if(_myPrivateBool)
+                _myPrivateString = "test1";
+            else if (false)
+                _myPrivateString = "test2";
+            else 
+                _myPrivateString = "test3";
+                
+        }
+        
+        public static function doFoo(obj:{k:int, l:Number}):int
+        {
+            for(i in arr)
+            {
+                obj.k++;
+                trace(i);
+                var var1 = new Array();
+                if(var1.length > 1)
+                    throw  new Error("Error");
+            }
+            // The following line should not be colored, the variable is scoped out
+            var1;
+            /* Multi line
+             * Comment test
+             */
+            return obj.k;
+        }
+        private function bar():void
+        {
+            
+            var t1:String = "1.21";
+            
+            try 
+            {
+                doFoo({k:3, l:1.2});
+            }
+            catch (e : String) 
+            {
+                trace(e);
+            }
+            finally 
+            {
+                trace("do nothing");
+            }
+            var t2:Number = "3.2".ToString();
+            var t5 = /^(\(?(\d{3})\)?\s?-?\s?(\d{3})\s?-?\s?(\d{4}))$/gixsm;
+            doFoo(t4);
+            var t3:* = 4;
+            var t4 = 8 << 2;
+        }
+        public var okFoo:Function = function():void 
+        {
+            switch (_myPrivateStr)
+            {
+                case "string":
+                    break;
+                case "otherstring":
+                    break;
+                default:
+                    break;
+            }
+        }
+       
+        
+        public var three:uint;
+    }
+}
+</textarea></div>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        lineNumbers: true,
+        indentUnit: 4,
+        indentWithTabs: true,
+        mode:"text/x-actionscript",
+      });
+    </script>
+
+    <p><strong>MIME types defined:</strong> <code>text/x-actionscript</code>.</p>
+  </body>
+</html>

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -1,4 +1,5 @@
 CodeMirror.modeInfo = [
+  {name: 'Actionscript', mime: 'text/x-actionscript', mode: 'actionscript'},
   {name: 'APL', mime: 'text/apl', mode: 'apl'},
   {name: 'Asterisk', mime: 'text/x-asterisk', mode: 'asterisk'},
   {name: 'C', mime: 'text/x-csrc', mode: 'clike'},


### PR DESCRIPTION
Added actionscript 3 syntax highlighting mode based on the clike.js mode with slight modifications for things like reg ex. 

Wasn't sure about specifying keywords etc as part of the mime type spec, as people then have to be diligent about setting ""text/x-actionscript"" as the mode. However i guess this would make it possible to add an actionscript 2 implementation for any brave souls. 

Also unsure as to the need for the amendment to addon/edit/continuecomment.js 
