### PR TITLE
Placing the cursor above the text ( <pre> )

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -221,6 +221,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   visibility: hidden;
   border-right: none;
   width: 0;
+  z-index: 3;
 }
 .CodeMirror-focused div.CodeMirror-cursor {
   visibility: visible;


### PR DESCRIPTION
The cursor needs to be put on a higher z-index than the text ( z-index:
2 ) otherwise any kind of full background highlighting will hide the
cursor.
