### PR TITLE
Add space character and class cm-space to special character token list

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4006,7 +4006,7 @@ window.CodeMirror = (function() {
     return builder.pre;
   }
 
-  var tokenSpecialChars = /[\t\u0000-\u0019\u200b\u2028\u2029\uFEFF]/g;
+  var tokenSpecialChars = /[ \t\u0000-\u0019\u200b\u2028\u2029\uFEFF]/g;
   function buildToken(builder, text, style, startStyle, endStyle) {
     if (!text) return;
     if (!tokenSpecialChars.test(text)) {
@@ -4024,7 +4024,10 @@ window.CodeMirror = (function() {
         }
         if (!m) break;
         pos += skipped + 1;
-        if (m[0] == "\t") {
+        if (m[0] == " ") {
+          content.appendChild(elt("span", " ", "cm-space"));
+          builder.col += 1;
+        } else if (m[0] == "\t") {
           var tabSize = builder.cm.options.tabSize, tabWidth = tabSize - builder.col % tabSize;
           content.appendChild(elt("span", spaceStr(tabWidth), "cm-tab"));
           builder.col += tabWidth;


### PR DESCRIPTION
This change associates class cm-space to all space characters in the editor.

I am requesting this addition to make it easier to identify and show all white space in a text file.

Specifically, this is the first step toward fixing the functionality of the Show Whitespace extension for Adobe Brackets, but it should be generally useful for any developer who wants to toggle white space visibility in their editor.
