### PR TITLE
Added transparent gif datauri to setDragImage for safari

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1749,9 +1749,10 @@ window.CodeMirror = (function() {
     e.dataTransfer.setData("Text", txt);
 
     // Use dummy image instead of default browsers image.
-    // Recent Safari (~6.0.2) have a tendency to segfault when this happens, so we don't do it there.
-    if (e.dataTransfer.setDragImage && !safari) {
+    if (e.dataTransfer.setDragImage) {
       var img = elt("img", null, null, "position: fixed; left: 0; top: 0;");
+      //  safari seems to choke when an img with no src is used for setDragImage, so using smallest transperant gif
+      if (safari) img.src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
       if (opera) {
         img.width = img.height = 1;
         cm.display.wrapper.appendChild(img);


### PR DESCRIPTION
setDragImage was disabled for safari to aviod crashing browser. By
setting datauri of a transparent gif as src for the img, the problem is
avoided and user no longer sees entire editor being dragged instead of
text selection. Now there is no indication of something being dragged,
but still an improvement.
fixes #1279
