### PR TITLE
Markdown list fixes

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -106,6 +106,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
   function blockNormal(stream, state) {
     
+    var prevLineIsList = (state.list !== false);
     if (state.list !== false && state.indentationDiff >= 0) { // Continued list
       if (state.indentationDiff < 4) { // Only adjust indentation if *not* a code block
         state.indentation -= state.indentationDiff;
@@ -114,7 +115,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     } else if (state.list !== false && state.indentation > 0) {
       state.list = null;
       state.listDepth = Math.floor(state.indentation / 4);
-    } else { // No longer a list
+    } else if (state.list !== false) { // No longer a list
       state.list = false;
       state.listDepth = 0;
     }
@@ -139,7 +140,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return switchInline(stream, state, footnoteLink);
     } else if (stream.match(hrRE, true)) {
       return hr;
-    } else if (stream.match(ulRE, true) || stream.match(olRE, true)) {
+    } else if ((!prevLineHasContent || prevLineIsList) && (stream.match(ulRE, true) || stream.match(olRE, true))) {
       state.indentation += 4;
       state.list = true;
       state.listDepth++;

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -130,6 +130,11 @@
   MT("blockquoteNoSpace",
      "[atom >foo]");
 
+  // No blank line before blockquote
+  MT("blockquoteNoBlankLine",
+     "foo",
+     "[atom > bar]");
+
   // Nested blockquote
   MT("blockquoteSpace",
      "[atom > foo]",
@@ -183,6 +188,12 @@
   MT("listNumber",
      "[variable-2 1. foo]",
      "[variable-2 2. bar]");
+
+  // Lists require a preceding blank line (per Dingus)
+  MT("listBogus",
+     "foo",
+     "1. bar",
+     "2. hello");
 
   // Formatting in lists (*)
   MT("listAsteriskFormatting",


### PR DESCRIPTION
I kept the commits (outlined below) related to different problems separated in case you didn't want to pull all of them in.
### [markdown] Improve highlighting of lists.

This fixes #1276. It also improves highlighting of nested list items. It uses multiple classes to differentiate between nesting levels. It uses 3 classes instead of 2 in order to avoid confusion between 3rd and 1st level (which is quite possible, due to Markdown's silly handling of indentation). Using 3 classes also brought a couple bugs from the original implementation to my attention (which are fixed as well).

_If you want this to only use 2 classes, let me know, and I'll take care of it. I'd really prefer to use 3 though._
### [markdown] Fix test that was changed in a2ad87f.

When the tests were changed to the new format (which I love, btw), an extra new line was lost in translation. This just adds it back in.
### [markdown] Improve highlighting of blockquotes.

Blockquotes suffered from many of the issues lists had. For example, code highlighting was hidden, due to CSS specificity, and nested comments had the same highlighting. This commit fixes the issues.
### [markdown] Remove `emstrong` entirely.

Removing `emstrong` entirely, since it isn't necessary (glad to see this removed--only left it in there for backward-compatibility).
### [markdown] Only match list items that follow a blank line.

Small fix for list items without a blank line preceding it (per [Dingus](http://daringfireball.net/projects/markdown/dingus)). Also added a test to make sure a blank line _isn't_ required for Blockquotes (also per Dingus).
