### PR TITLE
Vim keybindings for jump to next and prev marks.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -949,16 +949,13 @@
         return null;
       },
       jumpToMark: function(cm, motionArgs, vim) {
-        // "best" is the position of the mark closest to the cursor so far.
         var best = cm.getCursor(); 
         for (var i = 0; i < motionArgs.repeat; i++) {
-          // after each iteration we (logically) move the cursor to the next mark.
           var cursor = best;
           for (var key in vim.marks) {
             if (!isLowerCase(key)) {
               continue;
             }
-            // "mark" is the position of a mark we are comparing against best.
             var mark = vim.marks[key].find();
             var isWrongDirection = (motionArgs.forward) ?
               cursorIsBefore(mark, cursor) : cursorIsBefore(cursor, mark)
@@ -966,24 +963,26 @@
             if (isWrongDirection) {
               continue;
             }
+            if (motionArgs.linewise && (mark.line == cursor.line)) {
+              continue;
+            }
 
-            var between = (motionArgs.forward) ? cusrorIsBetween(cursor, mark, best) :
-                                                 cusrorIsBetween(best, mark, cursor);
-            var equal = (motionArgs.linewise) ? cursor.line == best.line :
-                                                cursorEqual(cursor, best);
+            var equal = cursorEqual(cursor, best);
+            var between = (motionArgs.forward) ? 
+              cusrorIsBetween(cursor, mark, best) :
+              cusrorIsBetween(best, mark, cursor);
+
             if (equal || between) {
               best = mark;
             }
           }
         }
-        
+
         if (motionArgs.linewise) {
-          // Vim places the cursor on the first non-whitespace character of the
-          // line if there is one, else it places the cursor at the end of the
-          // line, regardless of whether a mark was found.
-          var line = cm.getLine(best.line);
-          var col = findFirstNonWhiteSpaceCharacter(line);
-          best.ch = col;
+          // Vim places the cursor on the first non-whitespace character of
+          // the line if there is one, else it places the cursor at the end
+          // of the line, regardless of whether a mark was found.
+          best.ch = findFirstNonWhiteSpaceCharacter(cm.getLine(best.line));
         }
         return best;
       },

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -859,6 +859,15 @@ testVim('jumpToMark_next_nomark', function(cm, vim, helpers) {
   helpers.doKeys(']', '\'');
   helpers.assertCursorAt(2, 0);
 });
+testVim('jumpToMark_next_linewise_over', function(cm, vim, helpers) {
+  cm.setCursor(2, 2);
+  helpers.doKeys('m', 'a');
+  cm.setCursor(3, 4);
+  helpers.doKeys('m', 'b');
+  cm.setCursor(2, 1);
+  helpers.doKeys(']', '\'');
+  helpers.assertCursorAt(3, 1);
+});
 testVim('jumpToMark_next_action', function(cm, vim, helpers) {
   cm.setCursor(2, 2);
   helpers.doKeys('m', 't');
@@ -923,6 +932,15 @@ testVim('jumpToMark_prev_nomark', function(cm, vim, helpers) {
   cm.setCursor(2, 2);
   helpers.doKeys('[', '`');
   helpers.assertCursorAt(2, 2);
+  helpers.doKeys('[', '\'');
+  helpers.assertCursorAt(2, 0);
+});
+testVim('jumpToMark_prev_linewise_over', function(cm, vim, helpers) {
+  cm.setCursor(2, 2);
+  helpers.doKeys('m', 'a');
+  cm.setCursor(3, 4);
+  helpers.doKeys('m', 'b');
+  cm.setCursor(3, 6);
   helpers.doKeys('[', '\'');
   helpers.assertCursorAt(2, 0);
 });


### PR DESCRIPTION
The functionality should be identical to vim 7.
In normal mode "[`" takes you to the next lowercase mark, "]`" takes you
to the previous. "['" and "]'" work similarly but just take you to the
line of the mark, not the column.

I am not sure if the "_goTo..." functions I added to the motions object are
appropriate.  Maybe it is clearer to just duplicate the code?
