### PR TITLE
Improve performance of StringStream with long lines (match)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3394,7 +3394,8 @@ window.CodeMirror = (function() {
     match: function(pattern, consume, caseInsensitive) {
       if (typeof pattern == "string") {
         var cased = function(str) {return caseInsensitive ? str.toLowerCase() : str;};
-        if (cased(this.string).indexOf(cased(pattern), this.pos) == this.pos) {
+        var substr = this.string.substr(this.pos, pattern.length);
+        if (cased(substr) == cased(pattern)) {
           if (consume !== false) this.pos += pattern.length;
           return true;
         }


### PR DESCRIPTION
StringString.prototype.match(<string>) may do a lot of unnecessary work:
- If it is caseInsensitive it was calling toLowerCase on the entire string.
- It did an indexOf search through the string for a pattern, but only cared
  if the string started with that pattern.

Because a string pattern has a fixed length, we only need to run toLowerCase
on a small substring of the stream, and we only compare this small substring
to the pattern.
