### PR TITLE
[vim] Initial implementation of .

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -243,6 +243,7 @@
     { keys: ['z', 'b'], type: 'action', action: 'scrollToCursor',
         actionArgs: { position: 'bottom' },
         motion: 'moveToFirstNonWhiteSpaceCharacter' },
+    { keys: ['.'], type: 'action', action: 'repeatLastEdit' },
     // Text object motions
     { keys: ['a', 'character'], type: 'motion',
         motion: 'textObjectManipulation' },
@@ -399,7 +400,7 @@
         var vim = getVimState(cm);
         if (key == 'Esc') {
           // Clear input state and get back to normal mode.
-          vim.inputState.reset();
+          vim.inputState = new InputState();
           if (vim.visualMode) {
             exitVisualMode(cm, vim);
           }
@@ -439,9 +440,6 @@
 
     // Represents the current input state.
     function InputState() {
-      this.reset();
-    }
-    InputState.prototype.reset = function() {
       this.prefixRepeat = [];
       this.motionRepeat = [];
 
@@ -451,7 +449,7 @@
       this.motionArgs = null;
       this.keyBuffer = []; // For matching multi-key commands.
       this.registerName = null; // Defaults to the unamed register.
-    };
+    }
     InputState.prototype.pushRepeatDigit = function(n) {
       if (!this.operator) {
         this.prefixRepeat = this.prefixRepeat.concat(n);
@@ -629,6 +627,7 @@
         return null;
       },
       processCommand: function(cm, vim, command) {
+        vim.inputState.repeatOverride = command.repeatOverride;
         switch (command.type) {
           case 'motion':
             this.processMotion(cm, vim, command);
@@ -670,7 +669,7 @@
             return;
           } else {
             // 2 different operators in a row doesn't make sense.
-            inputState.reset();
+            vim.inputState = new InputState();
           }
         }
         inputState.operator = command.operator;
@@ -715,7 +714,7 @@
         actionArgs.repeat = repeat || 1;
         actionArgs.repeatIsExplicit = repeatIsExplicit;
         actionArgs.registerName = inputState.registerName;
-        inputState.reset();
+        vim.inputState = new InputState();
         vim.lastMotion = null,
         actions[command.action](cm, actionArgs, vim);
       },
@@ -799,10 +798,13 @@
         var curOriginal = copyCursor(curStart);
         var curEnd;
         var repeat;
-        if (motionArgs.repeat !== undefined) {
-          // If motionArgs specifies a repeat, that takes precedence over the
+        if (operator) {
+          this.recordLastEdit(cm, vim, inputState);
+        }
+        if (inputState.repeatOverride !== undefined) {
+          // If repeatOverride is specified, that takes precedence over the
           // input state's repeat. Used by Ex mode and can be user defined.
-          repeat = inputState.motionArgs.repeat;
+          repeat = inputState.repeatOverride;
         } else {
           repeat = inputState.getRepeat();
         }
@@ -819,7 +821,7 @@
               inputState.selectedCharacter;
         }
         motionArgs.repeat = repeat;
-        inputState.reset();
+        vim.inputState = new InputState();
         if (motion) {
           var motionResult = motions[motion](cm, motionArgs, vim);
           vim.lastMotion = motions[motion];
@@ -916,6 +918,9 @@
             actions.enterInsertMode(cm);
           }
         }
+      },
+      recordLastEdit: function(cm, vim, inputState) {
+        vim.lastEdit = inputState;
       }
     };
 
@@ -1400,6 +1405,19 @@
           }else{
             cm.setCursor(offsetCursor(curEnd, 0, -1));
           }
+        }
+      },
+      repeatLastEdit: function(cm, actionArgs, vim) {
+        // TODO: Make this repeat insert mode changes.
+        var lastEdit = vim.lastEdit;
+        if (lastEdit) {
+          if (actionArgs.repeat && actionArgs.repeatIsExplicit) {
+            vim.lastEdit.repeatOverride = actionArgs.repeat;
+          }
+          var currentInputState = vim.inputState;
+          vim.inputState = vim.lastEdit;
+          commandDispatcher.evalInput(cm, vim);
+          vim.inputState = currentInputState;
         }
       }
     };
@@ -2459,7 +2477,8 @@
         commandDispatcher.processMotion(cm, getVimState(cm), {
             motion: 'moveToLineOrEdgeOfDocument',
             motionArgs: { forward: false, explicitRepeat: true,
-              linewise: true, repeat: params.line+1 }});
+              linewise: true },
+            repeatOverride: params.line+1});
       },
       substitute: function(cm, params) {
         var argString = params.argString;

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -54,7 +54,8 @@ var bigWord3 = {
 var bigWord4 = {
   start: { line: bigWordLine.line, ch: bigWord1.end.ch + 3 },
   end: { line: bigWordLine.line, ch: bigWord1.end.ch + 7 }
-}
+};
+
 var oChars = [ { line: charLine.line, ch: 1 },
     { line: charLine.line, ch: 3 },
     { line: charLine.line, ch: 7 } ];
@@ -971,15 +972,6 @@ testVim('? and n/N', function(cm, vim, helpers) {
   helpers.doKeys('2', '?');
   helpers.assertCursorAt(0, 11);
 }, { value: 'match nope match \n nope Match' });
-//:noh should clear highlighting of search-results but allow to resume search through n
-testVim('noh_clearSearchHighlight', function(cm, vim, helpers) {
-  cm.openDialog = helpers.fakeOpenDialog('match');
-  helpers.doKeys('?');
-  helpers.doEx('noh');
-  eq(vim.searchState_.getOverlay(),null,'match-highlighting wasn\'t cleared');
-  helpers.doKeys('n');
-  helpers.assertCursorAt(0, 11,'can\'t resume search after clearing highlighting');
-}, { value: 'match nope match \n nope Match' });
 testVim('*', function(cm, vim, helpers) {
   cm.setCursor(0, 9);
   helpers.doKeys('*');
@@ -1020,6 +1012,20 @@ testVim('#', function(cm, vim, helpers) {
   helpers.doKeys('#');
   helpers.assertCursorAt(1, 8);
 }, { value: '    :=  match nomatch match \nnomatch Match' });
+testVim('.', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('2', 'd', 'w');
+  helpers.doKeys('.');
+  eq('5 6', cm.getValue());
+}, { value: '1 2 3 4 5 6'});
+testVim('._repeat', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('2', 'd', 'w');
+  helpers.doKeys('3', '.');
+  eq('6', cm.getValue());
+}, { value: '1 2 3 4 5 6'});
+
+// Ex mode tests
 testVim('ex_write', function(cm, vim, helpers) {
   var tmp = CodeMirror.commands.save;
   var written;
@@ -1084,6 +1090,15 @@ testVim('ex_substitute_count_with_range', function(cm, vim, helpers) {
   helpers.doEx('1,3s/\\d/0/ 3');
   eq('1\n2\n0\n0', cm.getValue());
 }, { value: '1\n2\n3\n4' });
+//:noh should clear highlighting of search-results but allow to resume search through n
+testVim('ex_noh_clearSearchHighlight', function(cm, vim, helpers) {
+  cm.openDialog = helpers.fakeOpenDialog('match');
+  helpers.doKeys('?');
+  helpers.doEx('noh');
+  eq(vim.searchState_.getOverlay(),null,'match-highlighting wasn\'t cleared');
+  helpers.doKeys('n');
+  helpers.assertCursorAt(0, 11,'can\'t resume search after clearing highlighting');
+}, { value: 'match nope match \n nope Match' });
 // TODO: Reset key maps after each test.
 testVim('ex_map_key2key', function(cm, vim, helpers) {
   helpers.doEx('map a x');


### PR DESCRIPTION
`.` repeats the last change made. It doesn't currently support changes made in insert mode.

I would like to record and repeat changes made in insert mode, basically when the user is typing into the document. I can't figure out a good way to do so. I only want to record changes up until the user moves the cursor. The `change` event that CodeMirror provides doesn't really specify how granular the change is and it seems like attempting to record all change events and merging them together would be quite a mess.
