### PR TITLE
[vim] Incremental search

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -25,7 +25,7 @@
     var inp = dialog.getElementsByTagName("input")[0], button;
     if (inp) {
       CodeMirror.on(inp, "keydown", function(e) {
-        if (options && options.onKeyDown && options.onKeyDown(e, inp.value)) { return; }
+        if (options && options.onKeyDown && options.onKeyDown(e, inp.value, close)) { return; }
         if (e.keyCode == 13 || e.keyCode == 27) {
           CodeMirror.e_stop(e);
           close();
@@ -34,7 +34,7 @@
         }
       });
       if (options && options.onKeyUp) {
-        CodeMirror.on(inp, "keyup", function(e) {options.onKeyUp(e, inp.value);});
+        CodeMirror.on(inp, "keyup", function(e) {options.onKeyUp(e, inp.value, close);});
       }
       if (options && options.value) inp.value = options.value;
       inp.focus();

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -752,11 +752,16 @@
             cm.scrollIntoView(originalPos);
           }
         }
-        function onPromptKeyDown(e, query) {
-          if (CodeMirror.keyName(e) == 'Esc') {
+        function onPromptKeyDown(e, query, close) {
+          var keyName = CodeMirror.keyName(e);
+          if (keyName == 'Esc' || keyName == 'Ctrl-C' || keyName == 'Ctrl-[') {
             updateSearchQuery(cm, originalQuery);
             clearSearchHighlight(cm);
             cm.scrollIntoView(originalPos);
+
+            CodeMirror.e_stop(e);
+            close();
+            cm.focus();
           }
         }
         switch (command.searchArgs.querySrc) {
@@ -799,14 +804,24 @@
         function onPromptClose(input) {
           exCommandDispatcher.processCommand(cm, input);
         }
+        function onPromptKeyDown(e, input, close) {
+          var keyName = CodeMirror.keyName(e);
+          if (keyName == 'Esc' || keyName == 'Ctrl-C' || keyName == 'Ctrl-[') {
+            CodeMirror.e_stop(e);
+            close();
+            cm.focus();
+          }
+        }
         if (command.type == 'keyToEx') {
           // Handle user defined Ex to Ex mappings
           exCommandDispatcher.processCommand(cm, command.exArgs.input);
         } else {
           if (vim.visualMode) {
-            showPrompt(cm, { onClose: onPromptClose, prefix: ':', value: '\'<,\'>' });
+            showPrompt(cm, { onClose: onPromptClose, prefix: ':', value: '\'<,\'>',
+                onKeyDown: onPromptKeyDown});
           } else {
-            showPrompt(cm, { onClose: onPromptClose, prefix: ':' });
+            showPrompt(cm, { onClose: onPromptClose, prefix: ':',
+                onKeyDown: onPromptKeyDown});
           }
         }
       },


### PR DESCRIPTION
Added some handlers to dialog.js to enable key events callbacks that pass along the value of the input.

Vim will now perform incremental search: scrolling to and highlighting the search result as you type.

`Ctrl-C` and `Ctrl-[` will now exit prompts now that we have key handlers. https://github.com/marijnh/CodeMirror/issues/1076

I wanted to split up unrelated commits into separate pull requests. Let me know if you prefer just one big one.
