### PR TITLE
[javascript mode] Recognize bitwise operators '~' and '^'

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -52,7 +52,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     return jsKeywords;
   }();
 
-  var isOperatorChar = /[+\-*&%=<>!?|]/;
+  var isOperatorChar = /[+\-*&%=<>!?|~^]/;
 
   function chain(stream, state, f) {
     state.tokenize = f;


### PR DESCRIPTION
This was causing `1^2` to tokenize as: `(number, "1")`, `(variable, "^2)`. By
tokenizing these bitwise operators as operators CodeMirror can correctly
syntax highlight the 2 as a number. Likewise the number in `~0`.
