### PR TITLE
Hi, I'm new.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -131,6 +131,10 @@
         motion: 'moveByPage', motionArgs: { forward: true }},
     { keys: ['Ctrl-b'], type: 'motion',
         motion: 'moveByPage', motionArgs: { forward: false }},
+    { keys: ['Ctrl-u'], type: 'motion',
+        motion: 'moveByPage', motionArgs: { forward: false, custom: true }},
+    { keys: ['Ctrl-d'], type: 'motion',
+        motion: 'moveByPage', motionArgs: { forward: true, custom: true }},
     { keys: ['g', 'g'], type: 'motion',
         motion: 'moveToLineOrEdgeOfDocument',
         motionArgs: { forward: false, explicitRepeat: true, linewise: true }},
@@ -337,7 +341,8 @@
           searchQuery: null,
           // Whether we are searching backwards.
           searchIsReversed: false,
-          registerController: new RegisterController({})
+          registerController: new RegisterController({}),
+          scrollCustom: 0
         };
       }
       return vimGlobalState;
@@ -1057,7 +1062,13 @@
         // will move the cursor to where it should be in the end.
         var curStart = cm.getCursor();
         var repeat = motionArgs.repeat;
-        cm.moveV((motionArgs.forward ? repeat : -repeat), 'page');
+        // if scroll count not defined, default to half page scroll
+        var movementType = (
+            motionArgs.custom
+                ? ( getVimGlobalState().scrollCustom ? getVimGlobalState().scrollCustom : 'halfPage' )
+                : 'page'
+        );
+        cm.moveV((motionArgs.forward ? repeat : -repeat), movementType);
         var curEnd = cm.getCursor();
         cm.setCursor(curStart);
         return curEnd;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2590,11 +2590,16 @@ window.CodeMirror = (function() {
 
   function findPosV(cm, pos, dir, unit) {
     var doc = cm.doc, x = pos.left, y;
-    if (unit == "page") {
+
+    if (unit == "page" || unit == "halfPage") {
       var pageSize = Math.min(cm.display.wrapper.clientHeight, window.innerHeight || document.documentElement.clientHeight);
+      if (unit == "halfPage")
+          pageSize /= 2;
       y = pos.top + dir * (pageSize - (dir < 0 ? 1.5 : .5) * textHeight(cm.display));
     } else if (unit == "line") {
       y = dir > 0 ? pos.bottom + 3 : pos.top - 3;
+    } else if ( ! isNan(unit) ) {
+      y = dir > 0 ? pos.bottom + unit : pos.top - unit;
     }
     for (;;) {
       var target = coordsChar(cm, x, y);
@@ -2885,7 +2890,13 @@ window.CodeMirror = (function() {
       if (sel.goalColumn != null) pos.left = sel.goalColumn;
       var target = findPosV(this, pos, dir, unit);
 
-      if (unit == "page") addToScrollPos(this, 0, charCoords(this, target, "div").top - pos.top);
+      var scrollBarMove = charCoords(this, target, "div").top - pos.top;
+      if (unit == "page" || unit == "halfPage" ) {
+        if (unit == "halfPage")
+          scrollBarMove /= 2;
+        addToScrollPos(this, 0, scrollBarMove);
+      }
+
       extendSelection(this.doc, target, target, dir);
       sel.goalColumn = pos.left;
     }),


### PR DESCRIPTION
So, I'm not really a javascript programmer.  I downloaded light table, and saw they had vim bindings.  I've been using vim/screen for like 15 years and thought it'd be nice to try something new.  First thing I did was open a file and hit ctrl-d to skip through it.  Nothing.  I monkeypatched the code locally so I could test out functionality.  I let Chris Granger know and he advised me to clone Codemirror and apply my patch.

He is using a slightly older version, so I had to patch my code slightly to make it work with your latest.  Thanks for implementing ".".  That was driving me nuts too, and I was going to fix that next.  

Anyway, ctrl-u/d are both custom commands, you should be able to specify the number of lines you want to scroll, but if it's not set it defaults to a half page.  I set it up that way, storing the custom value in the global configuration.  I did overload your concept of "unit" which you may not like for findPosV.  

So, first use of github, first clone, first checkin and first pull request, let me know if it looks ok.  Oh and all the existing tests passed, if you want me to write a test, I will.
