### PR TITLE
Fix 1-2 pixel jumps when brackets are highlighted

### DIFF
--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -20,6 +20,6 @@
 .cm-s-eclipse span.cm-link {color: #219;}
 
 .cm-s-eclipse .CodeMirror-matchingbracket {
-	border:1px solid grey;
+	outline:1px solid grey;
 	color:black !important;;
 }


### PR DESCRIPTION
With the eclipse theme, if you move your cursor on a bracket and have the matching bracket option enabled, spans with borders are inserted. They push the rest of the line to the right by the amount of the border width, which looks very crappy. Using outline instead of border fixes this
