### PR TITLE
Correct path of package from codemirror.js to lib/codemirror.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "codemirror",
     "version":"3.10.01",
-    "main": "codemirror.js",
+    "main": "lib/codemirror.js",
     "description": "In-browser code editing made bearable",
     "licenses": [{"type": "MIT",
                   "url": "http://codemirror.net/LICENSE"}],


### PR DESCRIPTION
Ran into this when trying to include CodeMirror from Browserify - the
path of `codemirror.js` doesn't point to the necessary
`lib/codemirror.js` file. Simply changes one line in `package.json`
