### PR TITLE
Update xml-hint.js to support multi-line tags

### DIFF
--- a/addon/hint/xml-hint.js
+++ b/addon/hint/xml-hint.js
@@ -50,7 +50,7 @@
 
         if(text.length >= 0) {
 
-            var regex = new RegExp('<([^!?][^\\s/>]*).*?>', 'g');
+            var regex = new RegExp('<([^!?][^\\s/>]*)[\\s\\S]*?>', 'g');
 
             var matches = [];
             var match;


### PR DESCRIPTION
Allows correct hinting even when the tag is multi-line by achieving a dot matches all effect by using [\s\S] instead.
