### PR TITLE
[rst mode] Fixed minor bug: HTTP path with commas now properly highlighted

### DIFF
--- a/mode/rst/rst.js
+++ b/mode/rst/rst.js
@@ -496,7 +496,7 @@ CodeMirror.defineMode('rst', function (config, options) {
 
     var rx_uri_protocol = "[Hh][Tt][Tt][Pp][Ss]?://";
     var rx_uri_domain = "(?:[\\d\\w.-]+)\\.(?:\\w{2,6})";
-    var rx_uri_path = "(?:/[\\d\\w\\#\\%\\&\\-\\.\\/\\:\\=\\?\\~]+)*";
+    var rx_uri_path = "(?:/[\\d\\w\\#\\%\\&\\-\\.\\,\\/\\:\\=\\?\\~]+)*";
     var rx_uri = new RegExp("^" +
         rx_uri_protocol + rx_uri_domain + rx_uri_path
     );


### PR DESCRIPTION
Hi marijnh,

I've discovered a minor bug in link highlighting w.r.t. rST : Apparently it is possible to have links with a comma inside (at least in the path portion). Had missed that in the previous commit; fixed now.
