### PR TITLE
Make the continue list addon work.

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -1,28 +1,24 @@
 (function() {
+  var listRE = /^(\s*)([*+-]|(\d+)\.)(\s*)/
+    , unorderedBullets = '*+-';
+
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
-    var pos = cm.getCursor(), token = cm.getTokenAt(pos);
-    var space;
-    if (token.className == "string") {
-      var full = cm.getRange({line: pos.line, ch: 0}, {line: pos.line, ch: token.end});
-      var listStart = /\*|\d+\./, listContinue;
-      if (token.string.search(listStart) == 0) {
-        var reg = /^[\W]*(\d+)\./g;
-        var matches = reg.exec(full);
-        if(matches)
-          listContinue = (parseInt(matches[1]) + 1) + ".  ";
-        else
-          listContinue = "*   ";
-        space = full.slice(0, token.start);
-        if (!/^\s*$/.test(space)) {
-          space = "";
-          for (var i = 0; i < token.start; ++i) space += " ";
-        }
-      }
+    var pos = cm.getCursor()
+      , line = cm.getLineHandle(pos.line)
+      , line, match, indent, bullet;
+
+    if (!line.stateAfter.list || !(match = line.text.match(listRE))) {
+      cm.execCommand('newlineAndIndent');
+      return;
     }
 
-    if (space != null)
-      cm.replaceSelection("\n" + space + listContinue, "end");
-    else
-      cm.execCommand("newlineAndIndent");
+    indent = match[1];
+    after = match[4];
+    bullet = unorderedBullets.indexOf(match[2]) >= 0
+      ? match[2]
+      : (parseInt(match[3], 10) + 1) + '.';
+
+    cm.replaceSelection('\n' + indent + bullet + after, 'end');
   };
-})();
+
+}());


### PR DESCRIPTION
It had been depending on the list token being highlighted
with the class 'string', which it no longer is in the markdown
mode.

Updated to check the `list` property of the line's state.

You can see it working at the markdown example `mode/markdown/index.html`.
