### PR TITLE
[addon continuelist.js] Make the listiness check

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -6,7 +6,7 @@
 
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
     var pos = cm.getCursor(),
-        inList = cm.getStateAfter(pos.line),
+        inList = cm.getStateAfter(pos.line).list,
         match;
 
     if (!inList || !(match = cm.getLine(pos.line).match(listRE))) {


### PR DESCRIPTION
Just a small nit. Without the list check, `getStateAfter`
looks like it will always be true.
