### PR TITLE
Main class added to set authors intended FG & BG

### DIFF
--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -1,3 +1,4 @@
+.cm-s-eclipse.CodeMirror {background: #fff; color: #000;}
 .cm-s-eclipse span.cm-meta {color: #FF1717;}
 .cm-s-eclipse span.cm-keyword { line-height: 1em; font-weight: bold; color: #7F0055; }
 .cm-s-eclipse span.cm-atom {color: #219;}

--- a/theme/elegant.css
+++ b/theme/elegant.css
@@ -1,3 +1,4 @@
+.cm-s-elegant.CodeMirror {background: #fff; color: #000;}
 .cm-s-elegant span.cm-number, .cm-s-elegant span.cm-string, .cm-s-elegant span.cm-atom {color: #762;}
 .cm-s-elegant span.cm-comment {color: #262; font-style: italic; line-height: 1em;}
 .cm-s-elegant span.cm-meta {color: #555; font-style: italic; line-height: 1em;}

--- a/theme/neat.css
+++ b/theme/neat.css
@@ -1,3 +1,4 @@
+.cm-s-neat.CodeMirror { background: #fff; color: #000; }
 .cm-s-neat span.cm-comment { color: #a86; }
 .cm-s-neat span.cm-keyword { line-height: 1em; font-weight: bold; color: blue; }
 .cm-s-neat span.cm-string { color: #a22; }


### PR DESCRIPTION
Added a main class to ensure the authors intended white BG & black text foundation is used and the parent BG isn't seen. This is as per a tweak made across most themes 3 months ago, bringing these 3 themes in line with the others.
