### PR TITLE
Don't try to scroll if editor isn't visible

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1432,15 +1432,17 @@ window.CodeMirror = (function() {
     if (!captureMiddleClick) on(d.scroller, "contextmenu", function(e) {onContextMenu(cm, e);});
 
     on(d.scroller, "scroll", function() {
-      setScrollTop(cm, d.scroller.scrollTop);
-      setScrollLeft(cm, d.scroller.scrollLeft, true);
-      signal(cm, "scroll", cm);
+      if (d.scroller.clientHeight) {
+        setScrollTop(cm, d.scroller.scrollTop);
+        setScrollLeft(cm, d.scroller.scrollLeft, true);
+        signal(cm, "scroll", cm);
+      }
     });
     on(d.scrollbarV, "scroll", function() {
-      setScrollTop(cm, d.scrollbarV.scrollTop);
+      if (d.scroller.clientHeight) setScrollTop(cm, d.scrollbarV.scrollTop);
     });
     on(d.scrollbarH, "scroll", function() {
-      setScrollLeft(cm, d.scrollbarH.scrollLeft);
+      if (d.scroller.clientHeight) setScrollLeft(cm, d.scrollbarH.scrollLeft);
     });
 
     on(d.scroller, "mousewheel", function(e){onScrollWheel(cm, e);});


### PR DESCRIPTION
If someone calls `scrollTo()`, and then hides the editor before the scroll event is processed, CodeMirror will try to process the scroll while it's hidden, which seems to end up scrolling to (0,0). (I didn't dig into why that happens, but it's plausible to me that the scrolling management stuff would get confused if it's called while the editor is invisible.) 

This patch makes it so CM doesn't try to process scrolls while hidden. Since the scroll position is saved in the doc state, it appears that the scroll position gets correctly reset to the `scrollTo()` position when CM becomes visible again anyway (I didn't trace through to fully verify this, but that appears to be the behavior I'm seeing).

This is somewhat similar to, but different from, the issue and fix for marijnh/CodeMirror#1236--there, the issue was that a bogus value was explicitly calculated during `endOperation()` while the editor was hidden. Here, the editor is actually still visible in the `endOperation()` of the `scrollTo()`--the problem is that it becomes hidden before the resulting scroll event is asynchronously processed.
