### PR TITLE
Add 'removedText' to change event object.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -353,15 +353,16 @@
       <dt id="event_change"><code>"change" (instance, changeObj)</code></dt>
       <dd>Fires every time the content of the editor is changed.
       The <code>changeObj</code> is a <code>{from, to, text,
-      next}</code> object containing information about the changes
-      that occurred as second argument. <code>from</code>
+      removedText, next}</code> object containing information about the changes
+      that occurred. <code>from</code>
       and <code>to</code> are the positions (in the pre-change
       coordinate system) where the change started and ended (for
       example, it might be <code>{ch:0, line:18}</code> if the
       position is at the beginning of line #19). <code>text</code> is
       an array of strings representing the text that replaced the
-      changed range (split by line). If multiple changes happened
-      during a single operation, the object will have
+      changed range (split by line) and <code>removedText</code> is
+      an array of strings representing the text that was replaced.
+      If multiple changes happened during a single operation, the object will have
       a <code>next</code> property pointing to another change object
       (which may point to another, etc).</dd>
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2159,6 +2159,8 @@ window.CodeMirror = (function() {
   }
 
   function makeChangeNoReadonly(doc, change, selUpdate) {
+    change.removedText = getBetween(doc, change.from, change.to);
+    
     var selAfter = computeSelAfterChange(doc, change, selUpdate);
     addToHistory(doc, change, selAfter, doc.cm ? doc.cm.curOp.id : NaN);
 
@@ -2187,6 +2189,7 @@ window.CodeMirror = (function() {
     for (var i = event.changes.length - 1; i >= 0; --i) {
       var change = event.changes[i];
       change.origin = type;
+      change.removedText = getBetween(doc, change.from, change.to);
       anti.changes.push(historyChangeFromChange(doc, change));
 
       var after = i ? computeSelAfterChange(doc, change, null)
@@ -2277,7 +2280,8 @@ window.CodeMirror = (function() {
     // Remember that these lines changed, for updating the display
     regChange(cm, from.line, to.line + 1, lendiff);
     if (hasHandler(cm, "change")) {
-      var changeObj = {from: from, to: to, text: change.text, origin: change.origin};
+      var changeObj = {from: from, to: to, text: change.text, removedText: change.removedText, 
+                       origin: change.origin};
       if (cm.curOp.textChanged) {
         for (var cur = cm.curOp.textChanged; cur.next; cur = cur.next) {}
         cur.next = changeObj;
@@ -4745,7 +4749,7 @@ window.CodeMirror = (function() {
   }
 
   function historyChangeFromChange(doc, change) {
-    var histChange = {from: change.from, to: changeEnd(change), text: getBetween(doc, change.from, change.to)};
+    var histChange = {from: change.from, to: changeEnd(change), text: change.removedText};
     attachLocalSpans(doc, histChange, change.from.line, change.to.line + 1);
     linkedDocs(doc, function(doc) {attachLocalSpans(doc, histChange, change.from.line, change.to.line + 1);}, true);
     return histChange;

--- a/test/test.js
+++ b/test/test.js
@@ -1345,3 +1345,28 @@ testCM("beforeSelectionChange", function(cm) {
   eqPos(cm.getCursor("start"), Pos(0, 0));
   eqPos(cm.getCursor("end"), Pos(9, 9));
 });
+
+testCM("change_removedText", function(cm) {
+  cm.setValue("abc\ndef");
+  
+  var removedText;
+  cm.on("change", function(cm, change) { 
+    removedText = [change.removedText, change.next && change.next.removedText];
+  });
+
+  cm.operation(function() {
+    cm.replaceRange("xyz", Pos(0, 0), Pos(1,1));
+    cm.replaceRange("123", Pos(0,0));
+  });
+
+  eq(removedText[0].join("\n"), "abc\nd");
+  eq(removedText[1].join("\n"), "");
+
+  cm.undo();
+  eq(removedText[0].join("\n"), "123");
+  eq(removedText[1].join("\n"), "xyz");
+
+  cm.redo();
+  eq(removedText[0].join("\n"), "abc\nd");
+  eq(removedText[1].join("\n"), "");
+});


### PR DESCRIPTION
If you're amenable, this is what I had in mind for adding 'removedText' to the change object. I'm happy to make any tweaks if this isn't suitable as-is.

In particular, if you'd prefer a name other than 'removedText', let me know (I thought about oldText, replacedText, and deletedText as alternatives).

Also, I am /not/ currently including it in the beforeChange event object.  I figure it's not necessary since you can easily calculate it yourself, and omitting it is a slight optimization, since we'd have to recalculate it in the case that the beforeChange handler calls .update() or if the change is split by readonly regions.  But if you'd prefer beforeChange include it, it shouldn't be hard.
