### PR TITLE
Patch to allow multi-line tags to have correct indentation

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -77,6 +77,7 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
         if (!tagName) return "error";
         type = isClose ? "closeTag" : "openTag";
         state.tokenize = inTag;
+        state.tagIndent = state.indented;
         return "tag";
       }
     }
@@ -180,6 +181,7 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
       prev: curState.context,
       tagName: tagName,
       indent: curState.indented,
+      tagIndent: curState.tagIndent,
       startOfLine: startOfLine,
       noIndent: noIndent
     };
@@ -300,6 +302,10 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
 
     indent: function(state, textAfter, fullLine) {
       var context = state.context;
+      if (state.cc.length > 0) {
+        return state.tagIndent + indentUnit * 2;
+      }
+
       if ((state.tokenize != inTag && state.tokenize != inText) ||
           context && context.noIndent)
         return fullLine ? fullLine.match(/^(\s*)/)[0].length : 0;
@@ -308,7 +314,8 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
         context = context.prev;
       while (context && !context.startOfLine)
         context = context.prev;
-      if (context) return context.indent + indentUnit;
+      if (context)
+        return ((context.tagIndent !== undefined) ? context.tagIndent : context.indent) + indentUnit;
       else return 0;
     },
 


### PR DESCRIPTION
You might have a better way of solving this problem than I have chosen!  In particular, I don't like checking state.cc.length > 0 to know that I am in a tag definition, but it does seem rather reliable!

I added state.tagIdent that gets set when the tokenizer goes into inTag.
In turn this is added onto the context when pushContext is called.

This is then used as the reference for subsequent tags' indenting rather than context.indent which can be set incorrectly if a multi-line tag's attributes are indented further than the first line of the tag.

Imagine if you have indentUnit:4 and your XML style is that if you continue a tag across multiple lines, you indent the subsequent lines by two indentUnits (until the tag is closed).  When you then press ENTER after closing your tag1, context.indent would be 8 and therefore the new tag starts indented at 12.

``` xml
<tag1 attr1="foo"
        attr2="bar"
        attr3="bat">
            <tag_starts_too_far_idented_at_12>
```

Whereas using the tagIndent as the base, that was set at 0 when <tag1 was encountered, you get the correct indentation:

``` xml
<tag1 attr1="foo"
        attr2="bar"
        attr3="bat">
    <tag_starts_idented_at_4>
```
