### PR TITLE
Faster removeChildren

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5131,7 +5131,7 @@ window.CodeMirror = (function() {
 
   function removeChildren(e) {
     // IE will break all parent-child relations in subnodes when setting innerHTML
-    if (!ie) e.innerHTML = "";
+    if (!ie) e.textContent = "";
     else while (e.firstChild) e.removeChild(e.firstChild);
     return e;
   }


### PR DESCRIPTION
Use `textContent = ""` instead of `innerHTML = ""` in `!IE` browsers. 
This will avoid html parser creation (at least in webkit).
FYI: 
Testing results: http://jsperf.com/removechildren/8
Browser compatability: http://www.quirksmode.org/dom/w3c_html.html
Spec: https://developer.mozilla.org/ru/docs/DOM/Node.textContent
