### PR TITLE
[vim] Fix :num and add unit test

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2543,7 +2543,8 @@
         exCommandDispatcher.map(mapArgs[0], mapArgs[1], cm);
       },
       move: function(cm, params) {
-        commandDispatcher.processMotion(cm, getVimState(cm), {
+        commandDispatcher.processCommand(cm, getVimState(cm), {
+            type: 'motion',
             motion: 'moveToLineOrEdgeOfDocument',
             motionArgs: { forward: false, explicitRepeat: true,
               linewise: true },

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1158,6 +1158,11 @@ testVim('._repeat', function(cm, vim, helpers) {
 }, { value: '1 2 3 4 5 6'});
 
 // Ex mode tests
+testVim('ex_go_to_line', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doEx('4');
+  helpers.assertCursorAt(3, 0);
+}, { value: 'a\nb\nc\nd\ne\n'});
 testVim('ex_write', function(cm, vim, helpers) {
   var tmp = CodeMirror.commands.save;
   var written;


### PR DESCRIPTION
`:num` broke some time ago, my mistake completely. Added unit test to prevent future regression.
