### PR TITLE
Adding markers while composing text

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -226,6 +226,10 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-selected { background: #d9d9d9; }
 .CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
 
+.CodeMirror-composing {
+  border-bottom: 3px solid black;
+}
+
 .cm-searching {
   background: #ffa;
   background: rgba(255, 255, 0, .4);

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1375,6 +1375,7 @@ window.CodeMirror = (function() {
       if (!changed && !missed) {missed = true; cm.display.poll.set(60, p);}
       else {cm.display.pollingFast = false; slowPoll(cm);}
     }
+    if (cm.state.composing) p();
     cm.display.poll.set(20, p);
   }
 
@@ -1405,6 +1406,7 @@ window.CodeMirror = (function() {
       from = Pos(from.line, from.ch - (prevInput.length - same));
     else if (cm.state.overwrite && posEq(from, to) && !cm.state.pasteIncoming)
       to = Pos(to.line, Math.min(getLine(doc, to.line).text.length, to.ch + (text.length - same)));
+    
     var updateInput = cm.curOp.updateInput;
     makeChange(cm.doc, {from: from, to: to, text: splitLines(text.slice(same)),
                         origin: cm.state.pasteIncoming ? "paste" : "+input"}, "end");
@@ -1414,6 +1416,15 @@ window.CodeMirror = (function() {
     else cm.display.prevInput = text;
     if (withOp) endOperation(cm);
     cm.state.pasteIncoming = false;
+
+    if (cm.state.composing) {
+      if (!cm.state.lastComposeMark) {
+        cm.state.lastComposeMark = cm.doc.markText(cm.state.composeStart, {line: cm.state.composeStart.line, ch: cm.state.composeStart.ch + cm.state.lastCompositionEventData.length}, {className: 'CodeMirror-composing'});
+      } else {
+        cm.state.lastComposeMark.clear();
+        cm.state.lastComposeMark = cm.doc.markText(cm.state.composeStart, {line: cm.state.composeStart.line, ch: cm.state.composeStart.ch + cm.state.lastCompositionEventData.length}, {className: 'CodeMirror-composing'});
+      }
+    }
     return true;
   }
 
@@ -1502,6 +1513,9 @@ window.CodeMirror = (function() {
     on(d.input, "keypress", operation(cm, onKeyPress));
     on(d.input, "focus", bind(onFocus, cm));
     on(d.input, "blur", bind(onBlur, cm));
+    on(d.input, "compositionstart", function(e) { onCompositionEvent(cm, e); });
+    on(d.input, "compositionupdate", function(e) { onCompositionEvent(cm, e); });
+    on(d.input, "compositionend", function(e) { onCompositionEvent(cm, e); });
 
     function drag_(e) {
       if (cm.options.onDragEvent && cm.options.onDragEvent(cm, addStop(e))) return;
@@ -2029,6 +2043,26 @@ window.CodeMirror = (function() {
     }
     clearInterval(cm.display.blinker);
     setTimeout(function() {if (!cm.state.focused) cm.doc.sel.shift = false;}, 150);
+  }
+  function onCompositionEvent(cm, e) {
+    switch(e.type) {
+    case "compositionstart":
+      cm.state.composing = true;
+      cm.state.composeStart = cm.getCursor();
+      break;
+    case "compositionupdate":
+      cm.state.lastCompositionEventData = e.data;
+      fastPoll(cm);
+      break;
+    case "compositionend":
+      cm.state.composing = false;
+      if (cm.state.lastComposeMark) {
+        cm.state.lastComposeMark.clear();
+        cm.state.lastComposeMark = null;
+      }
+      cm.state.composeStart = null;
+      break;
+    }
   }
 
   var detectingSelectAll;


### PR DESCRIPTION
This is my first pull request here, so please bear with me.

In Mac OSX, during composing IME characters, there is a visual marker that is shown for the character / series of characters that will be affected by further input.

The submitted code enables this feature, however uses composition events to make this work.

Please find attached below an image of how this looks like currently:

![Screen Shot 2013-03-20 at 5 26 06 PM](https://f.cloud.github.com/assets/573531/279920/3e2d6c72-9140-11e2-888d-efe83ead1196.png)

Please let me know if there are further improvements required, or whether there's a better way to add the markers. I'm unfortunately a little new with the CodeMirror codebase.

Thanks
Mutahhir
