### PR TITLE
Fix multiplex close on blank line.

### DIFF
--- a/addon/mode/multiplex.js
+++ b/addon/mode/multiplex.js
@@ -81,7 +81,7 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
             state.inner = CodeMirror.startState(other.mode, mode.indent ? mode.indent(state.outer, "") : 0);
           }
         }
-      } else if (mode.close === "\n") {
+      } else if (state.innerActive.close === "\n") {
         state.innerActive = state.inner = null;
       }
     },


### PR DESCRIPTION
The multiplex mode was checking whether an empty line should close the active mode by checking the active mode object instead of the active multiplex configuration object. As a consequence, the active mode was never closed.
