### PR TITLE
Use empty changes array when calling updateDisplayInner() subsequent times

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -411,6 +411,7 @@ window.CodeMirror = (function() {
       var newVisible = visibleLines(cm.display, cm.doc, viewPort);
       if (newVisible.from >= cm.display.showingFrom && newVisible.to <= cm.display.showingTo)
         break;
+      changes = [];
     }
 
     return updated;


### PR DESCRIPTION
The change in https://github.com/marijnh/CodeMirror/commit/d155c412be65acb31c6605f65b407f47408778ba broke several Brackets unit tests due to a crash in `getLine()` during `updateDisplayInner()`. The issue seemed to be that the `intact` array was getting bogus values past the end of the document, so the code in the `if (sawCollapsedSpans)` block was failing.

It looks like the above-mentioned patch introduced a subtle logic change: in the original version, subsequent recursive calls to `updateDisplayInner()` would pass `[]` for the `changes` argument instead of the original changes list, but when this was hoisted out to the outer loop, the original `changes` array would get passed in each time, causing `computeIntact()` to work with stale data.

This pull request seems to fix our unit tests, but I don't understand this code well enough to know if this is the right fix or not.
