### PR TITLE
Double semicolon in the eclipse theme

### DIFF
--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -21,5 +21,5 @@
 
 .cm-s-eclipse .CodeMirror-matchingbracket {
 	outline:1px solid grey;
-	color:black !important;;
+	color:black !important;
 }


### PR DESCRIPTION
The double semicolon prevents LESS to compile the CSS file.
