### PR TITLE
Check maxLineLen before trying to find matching bracket

### DIFF
--- a/addon/edit/matchbrackets.js
+++ b/addon/edit/matchbrackets.js
@@ -9,6 +9,7 @@
   var matching = {"(": ")>", ")": "(<", "[": "]>", "]": "[<", "{": "}>", "}": "{<"};
   function findMatchingBracket(cm) {
     var cur = cm.getCursor(), line = cm.getLineHandle(cur.line), pos = cur.ch - 1;
+    if (cm.getLine(cur.line).length > maxLineLen) return null;
     var match = (pos >= 0 && matching[line.text.charAt(pos)]) || matching[line.text.charAt(++pos)];
     if (!match) return null;
     var forward = match.charAt(1) == ">", d = forward ? 1 : -1;


### PR DESCRIPTION
Match Brackets code tries to find matching bracket and then checks to see if line is too long. On a minified library such as less-1.3.0.min.js (47KB) this takes ~87 sec on MacBook Pro running MacOS 10.8. And there are much larger libraries out there!

It's much faster to check the line length first. This won't fix case where code has mixed long/short lines, but that does not seem to be common.

This is to fix Brackets issue [2991](https://github.com/adobe/brackets/issues/2991) and a few others.

Not sure if this is the best fix, but it should highlight the problem and get you close :)
