### PR TITLE
[rst-mode] Fixed strong, emphasis & literal rST

### DIFF
--- a/mode/rst/rst.js
+++ b/mode/rst/rst.js
@@ -501,9 +501,9 @@ CodeMirror.defineMode('rst', function (config, options) {
         rx_uri_protocol + rx_uri_domain + rx_uri_path
     );
 
-    var rx_strong = /^\*\*[^\*\s](?:[^\*]*[^\*\s])?\*\*/;
-    var rx_emphasis = /^\*[^\*\s](?:[^\*]*[^\*\s])?\*/;
-    var rx_literal = /^``[^`\s](?:[^`]*[^`\s])``/;
+    var rx_strong = /^\*\*[^\*\s](?:[^\*]*[^\*\s])?\*\*(\s+|$)/;
+    var rx_emphasis = /^[^\*]\*[^\*\s](?:[^\*]*[^\*\s])?\*(\s+|$)/;
+    var rx_literal = /^``[^`\s](?:[^`]*[^`\s])``(\s+|$)/;
 
     var rx_number = /^(?:[\d]+(?:[\.,]\d+)*)/;
     var rx_positive = /^(?:\s\+[\d]+(?:[\.,]\d+)*)/;


### PR DESCRIPTION
rST does not allow mixing strong with simple emphasis, further it
requires the stars to have a preceding and trailing whitespaces. Same
for literal text; e.g.

 **strong** is correct, but **strong\* is not, or
 _emphasis_ is correct, but *emphasis** is not.
