### PR TITLE
Fix shell hyphenation

### DIFF
--- a/mode/shell/shell.js
+++ b/mode/shell/shell.js
@@ -57,7 +57,7 @@ CodeMirror.defineMode('shell', function() {
         return 'number';
       }
     }
-    stream.eatWhile(/\w/);
+    stream.eatWhile(/[\w-]/);
     var cur = stream.current();
     if (stream.peek() === '=' && /\w+/.test(cur)) return 'def';
     return words.hasOwnProperty(cur) ? words[cur] : null;


### PR DESCRIPTION
Prevent the latter part of hyphenated shell terms from being identified as attributes. See, e.g., adobe/brackets#3348. (Notice "cef-clean" and "brackets-shell".) With the fix it looks like this: 

![Brackets](http://f.cl.ly/items/0A1f1T3w243p1v2r3A1G/Screen%20Shot%202013-04-04%20at%205.01.39%20PM.png)
