### PR TITLE
[javascript mode] Force expecting semicolons in forspec tokenization

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -242,10 +242,10 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   poplex.lex = true;
 
-  function expect(wanted) {
+  function expect(wanted, matchRequired) {
     return function(type) {
       if (type == wanted) return cont();
-      else if (wanted == ";") return pass();
+      else if (wanted == ";" && !matchRequired) return pass();
       else return cont(arguments.callee);
     };
   }
@@ -358,7 +358,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "var") return cont(vardef1, expect(";"), forspec2);
     if (type == ";") return cont(forspec2);
     if (type == "variable") return cont(formaybein);
-    return pass(expression, expect(";"), forspec2);
+    return pass(expression, expect(";", true), forspec2);
   }
   function formaybein(_type, value) {
     if (value == "in") return cont(expression);
@@ -367,7 +367,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function forspec2(type, value) {
     if (type == ";") return cont(forspec3);
     if (value == "in") return cont(expression);
-    return pass(expression, expect(";"), forspec3);
+    return pass(expression, expect(";", true), forspec3);
   }
   function forspec3(type) {
     if (type != ")") cont(expression);


### PR DESCRIPTION
At CodeMirror: 1520c65

I was seeing unexpected JavaScript tokenization of:

``` javascript
for (1,1,(1);;) break;
```

The lexical scope inside the for loop declaration `")"` was dropping before the for loop declaration was finished. This was because the `expect(";")` calls were allowing skipping tokens if it wasn't a semicolon. This change forces a semicolon in the fall through cases in forspec1 and forspec2. I believe this should be safe with `for in` because `for in` requires either a LeftHandSideExpression (sounds like a reference) or a var declaration, both of which CodeMirror seems to handle well (vardecl explicitly allows comma lists, and a LHSE would likely be a "variable" in this context, I couldn't break it with valid code).

This style of code can be seen in minified versions of jquery.js, which we would like to pretty print accurately.

Reduction:

``` html
<textarea id="code"></textarea>
<pre id="output"></pre>

<script>
// Create editor and initialize with test string.
var cm = CodeMirror.fromTextArea(document.getElementById('code'));
var str = ['for ((1);;;) break;', '// ----', 'for (1,1,(1);;) break;'].join("\n");
cm.setValue(str);
cm.refresh();

// Tokenize and dump some output into pre#output.
function refresh() {
    if (timer)
        clearTimeout(timer);

    var output = "";
    var from = {line:0, ch:0}, to = {line:cm.lineCount()-1};

    function pad(str, x, doNotQuote) {
        var result = doNotQuote ? str : "'" + str + "'";
        for (var toPad = x - result.length; toPad > 0; --toPad) result += " ";
        return result;
    }

    function debugToken(mode, token, state, stream) {
        output += "Token: " + pad(token ? String(token) : "-", 12);
        output += "Lexical: " + pad(String(state.lexical.type), 10); // JavaScript
        output += "String: '" + stream.current() + "'\n";
    }

    var outerMode = cm.getMode();
    var content = cm.getRange(from, to);
    var state = CodeMirror.copyState(outerMode, cm.getTokenAt(from).state);
    var lineOffset = 0;
    var lines = content.split("\n");
    for (var i = 0; i < lines.length; ++i) {
        var line = lines[i];
        var stream = new CodeMirror.StringStream(line);
        while (!stream.eol()) {
            var innerMode = CodeMirror.innerMode(outerMode, state);
            var token = outerMode.token(stream, state);
            debugToken(innerMode.mode, token, state, stream);
            stream.start = stream.pos;
        }
    }

    document.getElementById("output").textContent = output;
}

// Refresh after changes after a short delay.
var timer = null;
cm.on("change", function(codeMirror, change) {
    if (timer)
        clearTimeout(timer)
    timer = setTimeout(function() {
        clearTimeout(timer);
        timer = null;
        refresh();
    }, 500);
});

setTimeout(refresh);
</script>
```

Before fix:

![Screen Shot 2013-04-06 at 2 26 30 AM](https://f.cloud.github.com/assets/11351/347140/da96f728-9ea0-11e2-93ba-75b13d2f4246.png)

After fix:

![Screen Shot 2013-04-06 at 2 28 58 AM](https://f.cloud.github.com/assets/11351/347142/e37620d0-9ea0-11e2-8782-62b51c77426d.png)
