### PR TITLE
[show-hint addon] Let default keymap resuable by custom keymap

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -106,7 +106,7 @@ CodeMirror.showHint = function(cm, getHints, options) {
     };
     if (options.customKeys) for (var key in options.customKeys) if (options.customKeys.hasOwnProperty(key)) {
       var val = options.customKeys[key];
-      if (/^(Up|Down|Enter|Esc)$/.test(key)) val = ourMap[val];
+      if (/^(Up|Down|Enter|Esc|Home|End|PageUp|PageDown)$/.test(val)) val = ourMap[val];
       ourMap[key] = val;
     }
 


### PR DESCRIPTION
The code /^(Up|Down|Enter|Esc)$/.test(`key`) only prevents users from overwriting the default keymap, I believe this was not your true intention. By changing `key` to `val`, the default keymap now becomes rebind-able to the custom keymap.
