### PR TITLE
Remove font-size

### DIFF
--- a/theme/rubyblue.css
+++ b/theme/rubyblue.css
@@ -1,4 +1,4 @@
-.cm-s-rubyblue { font:13px/1.4em Trebuchet, Verdana, sans-serif; }	/* - customized editor font - */
+.cm-s-rubyblue { font-family: Trebuchet, Verdana, sans-serif; }	/* - customized editor font - */
 
 .cm-s-rubyblue.CodeMirror { background: #112435; color: white; }
 .cm-s-rubyblue div.CodeMirror-selected { background: #38566F !important; }


### PR DESCRIPTION
Rubyblue is the only theme that sets a font size, which makes it trickier to a apply new size. ie, .CodeMirror {font-size: 20px} has no effect. Removed this to bring in line with other themes.
