### PR TITLE
Updated sql's hookIdentifier to properly match escaped `

### DIFF
--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -166,10 +166,9 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
 
   // `identifier`
   function hookIdentifier(stream) {
-    var escaped = false, ch;
+    var ch;
     while ((ch = stream.next()) != null) {
-      if (ch == "`" && !escaped) return "variable-2";
-      escaped = !escaped && ch == "`";
+      if (ch == "`" && !stream.eat("`")) return "variable-2";
     }
     return null;
   }


### PR DESCRIPTION
Possible solution for the issue https://github.com/marijnh/CodeMirror/issues/1481
