### PR TITLE
Preserve constructor property on the editor instance.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2733,6 +2733,7 @@ window.CodeMirror = (function() {
   // 'wrap f in an operation, performed on its `this` parameter'
 
   CodeMirror.prototype = {
+    constructor: CodeMirror,
     focus: function(){window.focus(); focusInput(this); onFocus(this); fastPoll(this);},
 
     setOption: function(option, value) {


### PR DESCRIPTION
In some cases it's more convenient to access `CodeMirror`
from the instance itself, but the way prototype was defined
made `editor.codemirror` be an `Object` instead.
