### PR TITLE
FullScreen Addon

### DIFF
--- a/addon/display/fullscreen.css
+++ b/addon/display/fullscreen.css
@@ -1,0 +1,7 @@
+.CodeMirror-fullscreen {
+  display: block;
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  z-index: 9;
+}

--- a/addon/display/fullscreen.js
+++ b/addon/display/fullscreen.js
@@ -1,0 +1,36 @@
+(function() {
+
+  CodeMirror.isFullScreen = function(cm) {
+    return /\bCodeMirror-fullscreen\b/.test(cm.getWrapperElement().className);
+  }
+
+  CodeMirror.setFullScreen = function(cm, full) {
+    var wrap = cm.getWrapperElement();
+    if (full) {
+      wrap.className += " CodeMirror-fullscreen";
+      wrap.style.height = winHeight() + "px";
+      document.documentElement.style.overflow = "hidden";
+    } else {
+      wrap.className = wrap.className.replace(" CodeMirror-fullscreen", "");
+      wrap.style.height = "";
+      document.documentElement.style.overflow = "";
+    }
+    cm.refresh();
+  }
+
+  function winHeight() {
+    return window.innerHeight
+        || (document.documentElement || document.body).clientHeight;
+  }
+
+  CodeMirror.on(window, "resize", function() {
+    var showing = document.body.getElementsByClassName("CodeMirror-fullscreen")[0];
+    if (!showing) return;
+    showing.CodeMirror.getWrapperElement().style.height = winHeight() + "px";
+  });
+  
+  CodeMirror.defineOption("fullScreen", false, function(cm, val, old) {
+    CodeMirror.setFullScreen(cm, val);    
+  });
+
+})();

--- a/demo/fullscreen.html
+++ b/demo/fullscreen.html
@@ -8,16 +8,10 @@
     <link rel="stylesheet" href="../theme/night.css">
     <script src="../mode/xml/xml.js"></script>
     <link rel="stylesheet" href="../doc/docs.css">
-
-    <style type="text/css">
-      .CodeMirror-fullscreen {
-        display: block;
-        position: absolute;
-        top: 0; left: 0;
-        width: 100%;
-        z-index: 9999;
-      }
-    </style>
+    
+    <script src="../addon/display/fullscreen.js"></script>
+    <link rel="stylesheet" href="../addon/display/fullscreen.css">
+    
   </head>
   <body>
     <h1>CodeMirror: Full Screen Editing</h1>
@@ -103,40 +97,17 @@
     </dl></dd>
 
 </textarea></form>
-  <script>
-    function isFullScreen(cm) {
-      return /\bCodeMirror-fullscreen\b/.test(cm.getWrapperElement().className);
-    }
-    function winHeight() {
-      return window.innerHeight || (document.documentElement || document.body).clientHeight;
-    }
-    function setFullScreen(cm, full) {
-      var wrap = cm.getWrapperElement();
-      if (full) {
-        wrap.className += " CodeMirror-fullscreen";
-        wrap.style.height = winHeight() + "px";
-        document.documentElement.style.overflow = "hidden";
-      } else {
-        wrap.className = wrap.className.replace(" CodeMirror-fullscreen", "");
-        wrap.style.height = "";
-        document.documentElement.style.overflow = "";
-      }
-      cm.refresh();
-    }
-    CodeMirror.on(window, "resize", function() {
-      var showing = document.body.getElementsByClassName("CodeMirror-fullscreen")[0];
-      if (!showing) return;
-      showing.CodeMirror.getWrapperElement().style.height = winHeight() + "px";
-    });
+  <script>    
     var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
       lineNumbers: true,
       theme: "night",
+      fullScreen: true,
       extraKeys: {
         "F11": function(cm) {
-          setFullScreen(cm, !isFullScreen(cm));
+          CodeMirror.setFullScreen(cm, !CodeMirror.isFullScreen(cm));
         },
         "Esc": function(cm) {
-          if (isFullScreen(cm)) setFullScreen(cm, false);
+          if (CodeMirror.isFullScreen(cm)) CodeMirror.setFullScreen(cm, false);
         }
       }
     });


### PR DESCRIPTION
Hi Marijn,

I have created the fullscreen addon for my CodeMirror-Eclipse (https://github.com/angelozerr/CodeMirror-Eclipse) because I embed CM in a Eclipse EditorPart with fullscreen mode.

This addon is just a copy/paste of the javascript of your demo/fullscreen.html. Here the benefit with this addon : 

1) avoid copying/pasting the fullscreen javascript of demo/fullscreen.html to manage fullscreen (just include the addon/display/fullscreen.js
2) can initialize the fullscreen with options : 

---

var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
  ...
  fullScreen:true
## }

I have created too a fullscreen.css (copy/paste the style included in the demo/fullscreen.html. I have just modified the z-index because my completion is not displayed.

I have modified the fullscreen demo with this new addon.

Hope you will like it.

Regards Angelo
