### PR TITLE
Fix copy/paste in IE

### DIFF
--- a/addon/runmode/runmode.js
+++ b/addon/runmode/runmode.js
@@ -1,5 +1,7 @@
 CodeMirror.runMode = function(string, modespec, callback, options) {
   var mode = CodeMirror.getMode(CodeMirror.defaults, modespec);
+  var isIe8OrEarlier = /\bMSIE\s(\d+)/.exec(navigator.userAgent);
+  isIe8OrEarlier = isIe8OrEarlier && +isIe8OrEarlier[1] <= 8;
 
   if (callback.nodeType == 1) {
     var tabSize = (options && options.tabSize) || CodeMirror.defaults.tabSize;
@@ -7,7 +9,11 @@ CodeMirror.runMode = function(string, modespec, callback, options) {
     node.innerHTML = "";
     callback = function(text, style) {
       if (text == "\n") {
-        node.appendChild(document.createElement("br"));
+        // Emitting LF or CRLF on IE8 or earlier results in an incorrect display.
+        // Emitting a carriage return makes everything ok.
+        var newLine = isIe8OrEarlier ? '\r' : text;
+        var newLineSpan = node.appendChild(document.createElement("span"));
+        newLineSpan.appendChild( document.createTextNode(newLine));
         col = 0;
         return;
       }


### PR DESCRIPTION
This fixes a problem with the rrunmode addon in which copy and paste in IE results in newlines being stripped.

A related problem with [google-code-prettify](https://code.google.com/p/google-code-prettify/) is discussed [here](http://stackoverflow.com/questions/136443/why-doesnt-ie7-copy-precode-blocks-to-the-clipboard-correctly).

The solution in this pull request is to change to using newlines instead of `<br/>`.

Plus there is some special handling for IE8 and earlier, inspired by [google-code-prettify](https://code.google.com/p/google-code-prettify/source/browse/trunk/src/prettify.js#1203)
