### PR TITLE
added css class to div containing the actual code

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -106,7 +106,7 @@ window.CodeMirror = (function() {
     d.scrollbarV = elt("div", [elt("div", null, null, "width: 1px")], "CodeMirror-vscrollbar");
     d.scrollbarFiller = elt("div", null, "CodeMirror-scrollbar-filler");
     // DIVs containing the selection and the actual code
-    d.lineDiv = elt("div");
+    d.lineDiv = elt("div", null, "CodeMirror-line");
     d.selectionDiv = elt("div", null, null, "position: relative; z-index: 1");
     // Blinky cursor, and element used to ensure cursor fits at the end of a line
     d.cursor = elt("div", "\u00a0", "CodeMirror-cursor");


### PR DESCRIPTION
Added a 'CodeMirror-code' css class to the div containing the pre elements with the code. I found this useful to differentiate the pre elements from the ones present in CodeMirror-measure div when doing some specific DOM manipulations.  
