### PR TITLE
CodeMirror should set spellcheck=false on the input textarea

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -97,7 +97,7 @@ window.CodeMirror = (function() {
     else input.setAttribute("wrap", "off");
     // if border: 0; -- iOS fails to open keyboard (issue #1287)
     if (ios) input.style.border = "1px solid black";
-    input.setAttribute("autocorrect", "off"); input.setAttribute("autocapitalize", "off");
+    input.setAttribute("autocorrect", "off"); input.setAttribute("autocapitalize", "off"); input.setAttribute("spellcheck", "false");
 
     // Wraps and hides input textarea
     d.inputDiv = elt("div", [input], null, "overflow: hidden; position: relative; width: 3px; height: 0px;");


### PR DESCRIPTION
WebKit on Mac does not honor autocorrect=off like WebKit on iOS, but it does honor
spellcheck=false. CodeMirror should set spellcheck=false to prevent OS X from autocorrecting while typing.
