### PR TITLE
[vim keymap] Add Ctrl-o/Ctrl-i jumplist motions

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -405,7 +405,7 @@
         return buffer[(size + pointer) % size];
       }
       return {
-        cachedCursor: undefined,
+        cachedCursor: undefined, //used for # and * jumps
         add: add,
         move: move
       };
@@ -891,6 +891,9 @@
               query = escapeRegex(query);
             }
 
+            // cachedCursor is used to save the old position of the cursor
+            // when * or # causes vim to seek for the nearest word and shift
+            // the cursor before entering the motion.
             getVimGlobalState().jumpList.cachedCursor = cm.getCursor();
             cm.setCursor(word.start);
 
@@ -972,6 +975,7 @@
           }
           if (motionArgs.toJumplist) {
             var jumpList = getVimGlobalState().jumpList;
+            // if the current motion is # or *, use cachedCursor
             var cachedCursor = jumpList.cachedCursor;
             if (cachedCursor) {
               recordJumpPosition(cm, cachedCursor, motionResult);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -158,6 +158,47 @@ function testVim(name, run, opts, expectedFail) {
     }
   }, expectedFail);
 };
+var jumplistScene = ''+
+  'word\n'+
+  '(word)\n'+
+  '{word\n'+
+  'word.\n'+
+  '\n'+
+  'word search\n'+
+  '}word\n'+
+  'word\n'+
+  'word\n';
+function testJumplist(name, keys, endPos, startPos, dialog) {
+  endPos = makeCursor(endPos[0], endPos[1]);
+  startPos = makeCursor(startPos[0], startPos[1]);
+  testVim(name, function(cm, vim, helpers) {
+    if(dialog)cm.openDialog = helpers.fakeOpenDialog('word');
+    cm.setCursor(startPos);
+    helpers.doKeys.apply(null, keys);
+    helpers.assertCursorAt(endPos);
+  }, {value: jumplistScene});
+};
+testJumplist('jumplist_H', ['H', 'Ctrl-o'], [5,2], [5,2]);
+testJumplist('jumplist_M', ['M', 'Ctrl-o'], [2,2], [2,2]);
+testJumplist('jumplist_L', ['L', 'Ctrl-o'], [2,2], [2,2]);
+testJumplist('jumplist_[[', ['[', '[', 'Ctrl-o'], [5,2], [5,2]);
+testJumplist('jumplist_]]', [']', ']', 'Ctrl-o'], [2,2], [2,2]);
+testJumplist('jumplist_G', ['G', 'Ctrl-o'], [5,2], [5,2]);
+testJumplist('jumplist_gg', ['g', 'g', 'Ctrl-o'], [5,2], [5,2]);
+testJumplist('jumplist_%', ['%', 'Ctrl-o'], [1,5], [1,5]);
+testJumplist('jumplist_{', ['{', 'Ctrl-o'], [1,5], [1,5]);
+testJumplist('jumplist_}', ['}', 'Ctrl-o'], [1,5], [1,5]);
+testJumplist('jumplist_\'', ['m', 'a', 'h', '\'', 'a', 'h', 'Ctrl-i'], [1,5], [1,5]);
+testJumplist('jumplist_`', ['m', 'a', 'h', '`', 'a', 'h', 'Ctrl-i'], [1,5], [1,5]);
+testJumplist('jumplist_*_cachedCursor', ['*', 'Ctrl-o'], [1,3], [1,3]);
+testJumplist('jumplist_#_cachedCursor', ['#', 'Ctrl-o'], [1,3], [1,3]);
+testJumplist('jumplist_n', ['#', 'n', 'Ctrl-o'], [1,1], [2,3]);
+testJumplist('jumplist_N', ['#', 'N', 'Ctrl-o'], [1,1], [2,3]);
+testJumplist('jumplist_repeat_<c-o>', ['*', '*', '*', '3', 'Ctrl-o'], [2,3], [2,3]);
+testJumplist('jumplist_repeat_<c-i>', ['*', '*', '*', '3', 'Ctrl-o', '2', 'Ctrl-i'], [5,0], [2,3]);
+testJumplist('jumplist_repeated_motion', ['3', '*', 'Ctrl-o'], [2,3], [2,3]);
+testJumplist('jumplist_/', ['/', 'Ctrl-o'], [2,3], [2,3], 'dialog');
+testJumplist('jumplist_?', ['?', 'Ctrl-o'], [2,3], [2,3], 'dialog');
 
 /**
  * @param name Name of the test


### PR DESCRIPTION
One of the killer features in Vim, which allows user to jump around previous cursor positions.

Here's how vimdoc defines a jump:

> A "jump" is one of the following commands:  `'`, `backtick`, `G`, `/`, `?`, `n`,
> `N`, `%`, `(`, `)`, `[[`, `]]`, `{`, `}`, `:s`, `:tag`, `L`, `M`, `H`  and
> the commands that start editing a new file.  If you make the cursor "jump"
> with one of these commands, the position of the cursor before the jump is
> remembered.  You can return to that position with the "''" and "``" command,
> unless the line containing that position was changed or deleted.

I tried to make it match the original as much as I could,
however there's still something **missing** in my implementation:
1. recording postion for `(` `)`  _(depending on sentence motions which is not yet implemented)_
2. cross-file jumps _(depending on native file buffer support)_
