### PR TITLE
fix stex mode handling of line break with optional argument

### DIFF
--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -95,7 +95,7 @@ CodeMirror.defineMode("stex", function() {
         }
 
         // white space control characters
-        if (source.match(/^\\[,;!\/]/)) {
+        if (source.match(/^\\[,;!\/\\]/)) {
           return "tag";
         }
 

--- a/mode/stex/test.js
+++ b/mode/stex/test.js
@@ -114,4 +114,7 @@
   MT("mathWithComment",
      "[keyword $][variable-2 x] [comment % $]",
      "[variable-2 y][keyword $] other text");
+
+  MT("lineBreakArgument",
+    "[tag \\\\][bracket [[][atom 1cm][bracket ]]]");
 })();


### PR DESCRIPTION
A line break with dimension (e.g. "\\[1cm]") was being parsed as the start of an equation ("\[...\]").

Fix: "\\" is now matched before "\[".

Test added.
