### PR TITLE
[vim] Make vim dialog work correctly

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2369,7 +2369,7 @@
             onKeyDown: options.onKeyDown, onKeyUp: options.onKeyUp });
       }
       else {
-        callback(prompt(shortText, ""));
+        onClose(prompt(shortText, ""));
       }
     }
     function findUnescapedSlashes(str) {


### PR DESCRIPTION
Currently, running a vim command like `:w` doesn't work--it throws an exception when closing the dialog because it tries to call `callback`, which doesn't exist. If I'm understanding the code correctly, it should call `onClose` instead.

(It looks like this code has been in there for a long time, so I'm not sure why this hasn't caused a problem before--maybe no one is using the default implementation of `openDialog()`.)
