### PR TITLE
[vim keymap] Treat empty line as word + clipping fixes

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1911,10 +1911,10 @@
     // caret to the first character of the next line.
     function clipToLine(cm, curStart, curEnd) {
       var selection = cm.getRange(curStart, curEnd);
-      // Only do something if the selection ends in '\n'
-      if ('\n' == selection.charAt(selection.length - 1)) {
+      // Only clip if the selection ends with trailing newline + whitespace
+      if (/\n\s*$/.test(selection)) {
         var lines = selection.split('\n');
-        // We know this one is an empty string.
+        // We know this is all whitepsace.
         lines.pop();
 
         // Cases:

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -573,6 +573,11 @@ testVim('dw_whitespace_followed_by_empty_line', function(cm, vim, helpers) {
   helpers.doKeys('d', 'w');
   eq('\n\n', cm.getValue());
 }, { value: '  \n\n' });
+testVim('dw_word_whitespace_word', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('d', 'w');
+  eq('\n   \nword2', cm.getValue());
+}, { value: 'word1\n   \nword2'})
 testVim('dw_end_of_document', function(cm, vim, helpers) {
   cm.setCursor(1, 2);
   helpers.doKeys('d', 'w');


### PR DESCRIPTION
- Refactored core `moveToWord` logic to be cleaner, and prepare to possibly move clipping logic over
- Now treating empty lines as words for word navigation motions other than `e`, matching VIM
- Modified whitespace clipping logic to properly account for multiple whitespace lines and empty lines
- Lots of unit tests
