### PR TITLE
[vim keymap] Add macro support / insert mode changes become repeatable

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -245,9 +245,10 @@
         actionArgs: { insertAt: 'charAfter' }},
     { keys: ['A'], type: 'action', action: 'enterInsertMode',
         actionArgs: { insertAt: 'eol' }},
-    { keys: ['i'], type: 'action', action: 'enterInsertMode' },
+    { keys: ['i'], type: 'action', action: 'enterInsertMode',
+        actionArgs: { insertAt: 'inplace' }},
     { keys: ['I'], type: 'action', action: 'enterInsertMode',
-        motion: 'moveToFirstNonWhiteSpaceCharacter' },
+        actionArgs: { insertAt: 'firstNonBlank' }},
     { keys: ['o'], type: 'action', action: 'newLineAndEnterInsertMode',
         actionArgs: { after: true }},
     { keys: ['O'], type: 'action', action: 'newLineAndEnterInsertMode',
@@ -261,6 +262,9 @@
     { keys: ['P'], type: 'action', action: 'paste',
         actionArgs: { after: false }},
     { keys: ['r', 'character'], type: 'action', action: 'replace' },
+    { keys: ['@', '@'], type: 'action', action: 'replayLatestMacro' },
+    { keys: ['@', 'character'], type: 'action', action: 'replayMacro' },
+    { keys: ['q', 'character'], type: 'action', action: 'enterMacroRecordMode' },
     { keys: ['R'], type: 'action', action: 'enterReplaceMode' },
     { keys: ['u'], type: 'action', action: 'undo' },
     { keys: ['Ctrl-r'], type: 'action', action: 'redo' },
@@ -327,7 +331,7 @@
     var validMarks = upperCaseAlphabet.concat(lowerCaseAlphabet).concat(
         numbers).concat(['<', '>']);
     var validRegisters = upperCaseAlphabet.concat(lowerCaseAlphabet).concat(
-        numbers).concat('-\"'.split(''));
+        numbers).concat('-\".'.split(''));
 
     function isAlphabet(k) {
       return alphabetRegex.test(k);
@@ -340,6 +344,9 @@
     }
     function isMatchableSymbol(k) {
       return '()[]{}'.indexOf(k) != -1;
+    }
+    function isSymbol(k) {
+      return (/[^\w]|_/).test(k);
     }
     function isNumber(k) {
       return numberRegex.test(k);
@@ -368,7 +375,7 @@
       return false;
     }
 
-    var circularJumpList = function() {
+    var createCircularJumpList = function() {
       var size = 100;
       var pointer = -1;
       var head = 0;
@@ -433,6 +440,41 @@
         move: move
       };
     };
+
+    var createMacroState = function() {
+      return {
+        macroKeyBuffer: [],
+        latestRegister: undefined,
+        macroKeyIndex: undefined, /* array index of 'q' in defaultKeymap */
+        alternativeCmd:{ keys: ['q'], type: 'action', action: 'exitMacroRecordMode' },
+        enteredMacroMode: undefined,
+        toggle: function(cm, registerName) {
+          if (this.enteredMacroMode) { //onExit
+            this.enteredMacroMode(); // close dialog
+            this.enteredMacroMode = undefined;
+            this.macroKeyBuffer.pop(); //discard "q" command at tail
+          } else { //onEnter
+            this.latestRegister = registerName;
+            this.enteredMacroMode = cm.openDialog(
+              '(recording)['+registerName+']', null, {bottom:true});
+          }
+          /* begin: swap macro key behavior */ {
+            var macroKeyIndex = this.macroKeyIndex;
+            if (!macroKeyIndex) {
+              defaultKeymap.some(function(keyItem, idx){
+                var keys = keyItem.keys;
+                return keys[0] === 'q' && (macroKeyIndex = idx);
+              });
+              this.macroKeyIndex = macroKeyIndex;
+            }
+            var tempQCmd = this.alternativeCmd;
+            this.alternativeCmd = defaultKeymap[macroKeyIndex];
+            defaultKeymap[macroKeyIndex] = tempQCmd;
+          } /* end */
+        }
+      }
+    }
+
     // Global Vim state. Call getVimGlobalState to get and initialize.
     var vimGlobalState;
     function getVimGlobalState() {
@@ -442,7 +484,8 @@
           searchQuery: null,
           // Whether we are searching backwards.
           searchIsReversed: false,
-          jumpList: circularJumpList(),
+          jumpList: createCircularJumpList(),
+          macroModeState: createMacroState(),
           // Recording latest f, t, F or T motion command.
           lastChararacterSearch: {increment:0, forward:true, selectedCharacter:''},
           registerController: new RegisterController({})
@@ -468,6 +511,7 @@
           lastMotion: null,
           marks: {},
           visualMode: false,
+          insertMode: false,
           // If we are in visual line mode. No effect if visualMode is false.
           visualLine: false
         };
@@ -508,6 +552,12 @@
       handleKey: function(cm, key) {
         var command;
         var vim = getVimState(cm);
+
+        var macroModeState = getVimGlobalState().macroModeState;
+        if (macroModeState.enteredMacroMode) {
+          logKey(key);
+        }
+
         if (key == 'Esc') {
           // Clear input state and get back to normal mode.
           vim.inputState = new InputState();
@@ -669,6 +719,9 @@
           register.set(text, linewise);
           this.unamedRegister.set(text, linewise);
         }
+      },
+      setRegisterText: function(name, text, linewise) {
+        this.getRegister(name).set(text, linewise);
       },
       // Gets the register named @name.  If one of @name doesn't already exist,
       // create it.  If @name is invalid, return the unamedRegister.
@@ -1099,6 +1152,7 @@
         }
       },
       recordLastEdit: function(cm, vim, inputState) {
+        if(macroPlaying)return;
         vim.lastEdit = inputState;
       }
     };
@@ -1520,16 +1574,43 @@
         // view into the right place.
         cm.scrollIntoView();
       },
+      replayLatestMacro: function(cm) {
+        var registerName = getVimGlobalState().macroModeState.latestRegister;
+        parseRegisterToKeyBuffer(registerName);
+        executeMacroKeyBuffer(cm);
+      },
+      replayMacro: function(cm, actionArgs) {
+        var registerName = actionArgs.selectedCharacter;
+        parseRegisterToKeyBuffer(registerName);
+        executeMacroKeyBuffer(cm);
+      },
+      exitMacroRecordMode: function(cm, actionArgs) {
+        var macroModeState = getVimGlobalState().macroModeState;
+        macroModeState.toggle();
+        parseKeyBufferToRegister(macroModeState.latestRegister);
+      },
+      enterMacroRecordMode: function(cm, actionArgs) {
+        var macroModeState = getVimGlobalState().macroModeState;
+        var registerName = actionArgs.selectedCharacter;
+        macroModeState.toggle(cm, registerName);
+        emptyMacroKeyBuffer();
+      },
       enterInsertMode: function(cm, actionArgs) {
+        var vim = getVimState(cm);
         var insertAt = (actionArgs) ? actionArgs.insertAt : null;
-        if (insertAt == 'eol') {
+        if (insertAt === 'eol') {
           var cursor = cm.getCursor();
           cursor = { line: cursor.line, ch: lineLength(cm, cursor.line) };
           cm.setCursor(cursor);
-        } else if (insertAt == 'charAfter') {
+        } else if (insertAt === 'charAfter') {
           cm.setCursor(offsetCursor(cm.getCursor(), 0, 1));
+        } else if (insertAt === 'firstNonBlank') {
+          cm.setCursor(motions.moveToFirstNonWhiteSpaceCharacter(cm));
         }
+        if(insertAt)commandDispatcher.recordLastEdit(cm, vim, insertAt);
         cm.setOption('keyMap', 'vim-insert');
+        vim.insertMode = true;
+        emptyMacroKeyBuffer();
       },
       toggleVisualMode: function(cm, actionArgs, vim) {
         var repeat = actionArgs.repeat;
@@ -1756,8 +1837,14 @@
         cm.setCursor({line: cur.line, ch: start + numberStr.length - 1});
       },
       repeatLastEdit: function(cm, actionArgs, vim) {
-        // TODO: Make this repeat insert mode changes.
         var lastEdit = vim.lastEdit;
+        if (typeof lastEdit === 'string') { /* A,I,a,i */
+          actions.enterInsertMode(cm, { insertAt:lastEdit });
+          parseRegisterToKeyBuffer('.');
+          executeMacroKeyBuffer(cm);
+          exitInsertMode(cm, /* retainLastCmd */true);
+          return;
+        }
         if (lastEdit) {
           if (actionArgs.repeat && actionArgs.repeatIsExplicit) {
             vim.lastEdit.repeatOverride = actionArgs.repeat;
@@ -1765,6 +1852,11 @@
           var currentInputState = vim.inputState;
           vim.inputState = vim.lastEdit;
           commandDispatcher.evalInput(cm, vim);
+          if (lastEdit.operator === 'change') {
+            parseRegisterToKeyBuffer('.');
+            executeMacroKeyBuffer(cm);
+            exitInsertMode(cm, /* retainLastCmd */true);
+          }
           vim.inputState = currentInputState;
         }
       }
@@ -1823,6 +1915,7 @@
         }
       }
     }
+
     function copyArgs(args) {
       var ret = {};
       for (var prop in args) {
@@ -3191,26 +3284,175 @@
     }
     CodeMirror.keyMap.vim = buildVimKeyMap();
 
-    function exitInsertMode(cm) {
+    function exitInsertMode(cm, retainLastCmd) {
+      var vim = getVimState(cm);
       cm.setCursor(cm.getCursor().line, cm.getCursor().ch-1, true);
       cm.setOption('keyMap', 'vim');
+      vim.insertMode = false;
+      if(!retainLastCmd)discardMacroExitCmd();
+      parseKeyBufferToRegister('.');
     }
 
-    CodeMirror.keyMap['vim-insert'] = {
-      // TODO: override navigation keys so that Esc will cancel automatic
-      // indentation from o, O, i_<CR>
-      'Esc': exitInsertMode,
-      'Ctrl-[': exitInsertMode,
-      'Ctrl-C': exitInsertMode,
-      'Ctrl-N': 'autocomplete',
-      'Ctrl-P': 'autocomplete',
-      'Enter': function(cm) {
-        var fn = CodeMirror.commands.newlineAndIndentContinueComment ||
+    function insertChar(cm, char) {
+      if(char==='Space')char=' ';
+      if (char.length === 1) {
+        var cur = cm.getCursor();
+        cm.replaceRange(char, cur, cur);
+      }
+    }
+
+    function insertModeKeyToNormalMode(insertModeKey) {
+      if(insertModeKey.length === 1)return insertModeKey.toLowerCase();/* lowercase alphabets */
+      if(insertModeKey.length === 3
+         && insertModeKey[0]==="'")return insertModeKey[1];/* symbols */
+      var combo = insertModeKey.split('-');
+      var mod = combo[0];
+      var ch = combo[1];
+      if(mod === 'Shift')return ch; /* uppercase alphabets */
+      if(ch && ch.length === 1)return mod+'-'+ch.toLowerCase(); /* modifier-keys */
+      return insertModeKey;
+    }
+
+    function normalModeKeyToTextToken(normalModeKey) {
+      if (normalModeKey.length > 1) {
+        var keyCombo = normalModeKey.split('-');
+        var modifier, key;
+        switch (keyCombo.length) {
+          case 1:
+            key = keyCombo[0];
+            var specialToken = {Space:' ',Enter:'\n',Backspace:'\b'}[key];
+            key = specialToken ? specialToken : key;
+            if(key.length===1)return key;
+            return '<'+key+'>';
+          case 2:
+            modifier = keyCombo[0];
+            key = keyCombo[1];
+            return '<'+modifier[0]+'-'+key+'>';
+          case 3: /* key == '-' */
+            modifier = keyCombo[0];
+            return '<'+modifier[0]+'-->';
+        }
+      }
+      return normalModeKey;
+    }
+
+    function parseRegisterToKeyBuffer(registerName) {
+      var match, token;
+      var register = getVimGlobalState().registerController.getRegister(registerName);
+      var text = register.toString();
+      emptyMacroKeyBuffer();
+      do {
+        match = text.match(/<\w+-.+>|<\w+>|.|\n/);
+        if(match === null)break;
+        token = match[0];
+        text = text.substring(match.index + token.length);
+        macroKeyBuffer.push(textToNormKeyLookup[token]);
+      } while (text);
+    }
+
+    function parseKeyBufferToRegister(registerName) {
+      var text = macroKeyBuffer.map(function(k){
+        return normKeyToTextLookup[k];
+      }).join('');
+      vimGlobalState.registerController.setRegisterText(registerName, text);
+    }
+
+    function buildInsertModeBehavior() {
+      var keyBehavior = {};
+      var defaultBehavior = CodeMirror.keyMap.default;
+      var basicBehavior = CodeMirror.keyMap.basic;
+      mergeArgs(keyBehavior, basicBehavior);
+      mergeArgs(keyBehavior, defaultBehavior);
+      mergeArgs(keyBehavior, {
+        // TODO: override navigation keys so that Esc will cancel automatic
+        // indentation from o, O, i_<CR>
+        'Esc': exitInsertMode,
+        'Ctrl-[': exitInsertMode,
+        'Ctrl-C': exitInsertMode,
+        'Ctrl-N': 'autocomplete',
+        'Ctrl-P': 'autocomplete',
+        'Enter': function(cm) {
+          var fn = CodeMirror.commands.newlineAndIndentContinueComment ||
             CodeMirror.commands.newlineAndIndent;
-        fn(cm);
-      },
-      fallthrough: ['default']
-    };
+          fn(cm);
+        },
+        'Backspace': function(cm) {
+          CodeMirror.commands.delCharBefore(cm);
+        }
+      });
+      return keyBehavior;
+    }
+    var insertModeBehavior = buildInsertModeBehavior();
+
+    function createInsertModeKeyHook(insertModeKey) {
+      var fn = insertModeBehavior[insertModeKey];
+      var normalModeKey = insertModeKeyToNormalMode(insertModeKey);
+      switch (typeof fn) {
+        case 'undefined':
+          return function(cm) {
+            logKey(normalModeKey);
+            insertChar(cm, normalModeKey);
+          };
+        case 'string':
+          fn = CodeMirror.commands[fn];
+        case 'function':
+          return function(cm) {
+            logKey(normalModeKey);
+            fn(cm);
+          };
+      }
+    }
+
+    var macroKeyBuffer = getVimGlobalState().macroModeState.macroKeyBuffer;
+    var macroPlaying = false;
+    function emptyMacroKeyBuffer() {
+      if(macroPlaying)return;
+      macroKeyBuffer.length = 0;
+    }
+
+    function logKey(key) {
+      if(macroPlaying)return;
+      macroKeyBuffer.push(key);
+    }
+
+    var insertModeKeymap = {};
+    var keyNormToInsLookup = {}; // normalModeKey to insertModeKey lookup
+    var textToNormKeyLookup = {}; // normalModeKey to registerText lookup
+    var normKeyToTextLookup = {}; // registerText to normalModeKey lookup
+    function buildLookups() {
+      var vimKeyMap = CodeMirror.keyMap.vim;
+      for (var insertModeKey in vimKeyMap) {
+        insertModeKeymap[insertModeKey] = createInsertModeKeyHook(insertModeKey);
+
+        var normalModeKey = insertModeKeyToNormalMode(insertModeKey);
+        keyNormToInsLookup[normalModeKey] = insertModeKey;
+
+        var text = normalModeKeyToTextToken(normalModeKey);
+        textToNormKeyLookup[text] = normalModeKey;
+        normKeyToTextLookup[normalModeKey] = text;
+      }
+    }
+    buildLookups();
+    CodeMirror.keyMap['vim-insert'] = insertModeKeymap;
+
+    function insertModeHandleNormalModeKey(cm, normalModeKey) {
+      insertModeKeymap[keyNormToInsLookup[normalModeKey]](cm);
+    }
+
+    function discardMacroExitCmd() {
+      macroKeyBuffer.pop();
+    }
+
+    function executeMacroKeyBuffer(cm) {
+      var vim = getVimState(cm);
+      macroPlaying = true;
+      macroKeyBuffer.forEach(function(k){
+        vim.insertMode
+          ? insertModeHandleNormalModeKey(cm, k)
+          : CodeMirror.Vim.handleKey(cm, k);
+      });
+      macroPlaying = false;
+    }
 
     function exitReplaceMode(cm) {
       cm.toggleOverwrite();


### PR DESCRIPTION
This chunk of code is big and messy, might took you quite some time to review.

So far, it introduces the following set of features:
- `q` keylogger
- `@` execute macro from registers
- `@@` execute latest macro
-  changes from insert mode become repeatable by register `.`
