### PR TITLE
[vim keymap] Add actionArgs for command 'i' 'I'

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1523,13 +1523,13 @@
       },
       enterInsertMode: function(cm, actionArgs) {
         var insertAt = (actionArgs) ? actionArgs.insertAt : null;
-        if (insertAt === 'eol') {
+        if (insertAt == 'eol') {
           var cursor = cm.getCursor();
           cursor = { line: cursor.line, ch: lineLength(cm, cursor.line) };
           cm.setCursor(cursor);
-        } else if (insertAt === 'charAfter') {
+        } else if (insertAt == 'charAfter') {
           cm.setCursor(offsetCursor(cm.getCursor(), 0, 1));
-        } else if (insertAt === 'firstNonBlank') {
+        } else if (insertAt == 'firstNonBlank') {
 +         cm.setCursor(motions.moveToFirstNonWhiteSpaceCharacter(cm));
         }
         cm.setOption('keyMap', 'vim-insert');


### PR DESCRIPTION
This pull request is responding to the received suggestions from #1521.

`actionArgs.insertAt` can be later used for recording cursor behaviors for latest `enterInsertMode` commands.
