### PR TITLE
Fix binding with shift to go- command not passing shift

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1975,6 +1975,10 @@ window.CodeMirror = (function() {
     return maps;
   }
 
+  function isGoBinding(b) {
+    return (typeof b == "string" && /^go[A-Z]/.test(b));
+  }
+
   var maybeTransition;
   function handleKeyBinding(cm, e) {
     // Handle auto keymap transitions
@@ -1993,9 +1997,12 @@ window.CodeMirror = (function() {
       // First try to resolve full name (including 'Shift-'). Failing
       // that, see if there is a cursor-motion command (starting with
       // 'go') bound to the keyname without 'Shift-'.
-      handled = lookupKey("Shift-" + name, keymaps, function(b) {return doHandleBinding(cm, b, true);})
+      handled = lookupKey("Shift-" + name, keymaps, function(b) {
+                  var dropShift = !isGoBinding(b);
+                  return doHandleBinding(cm, b, dropShift);
+                })
              || lookupKey(name, keymaps, function(b) {
-                  if (typeof b == "string" && /^go[A-Z]/.test(b)) return doHandleBinding(cm, b);
+                  if (isGoBinding(b)) return doHandleBinding(cm, b);
                 });
     } else {
       handled = lookupKey(name, keymaps, function(b) { return doHandleBinding(cm, b); });

--- a/test/test.js
+++ b/test/test.js
@@ -882,11 +882,14 @@ testCM("extraKeys", function(cm) {
   }
   CodeMirror.commands.testCommand = function() {outcome = "tc";};
   CodeMirror.commands.goTestCommand = function() {outcome = "gtc";};
+  CodeMirror.commands.goTestShiftCommand = function(cm) {outcome = "gtsc" + !!cm.doc.sel.shift;};
   cm.setOption("extraKeys", {"Shift-X": function() {outcome = "sx";},
                              "X": function() {outcome = "x";},
                              "Ctrl-Alt-U": function() {outcome = "cau";},
                              "End": "testCommand",
                              "Home": "goTestCommand",
+                             "Shift-Delete": "goTestShiftCommand",
+                             "Delete": "goTestShiftCommand",
                              "Tab": false});
   fakeKey(null, "U");
   fakeKey("cau", "U", {ctrlKey: true, altKey: true});
@@ -897,6 +900,8 @@ testCM("extraKeys", function(cm) {
   fakeKey(null, 35, {shiftKey: true});
   fakeKey("gtc", 36);
   fakeKey("gtc", 36, {shiftKey: true});
+  fakeKey("gtscfalse", 46);
+  fakeKey("gtsctrue", 46, {shiftKey: true});
   fakeKey(null, 9);
 }, null, window.opera && mac);
 


### PR DESCRIPTION
Our codebase contained something like:

```
CodeMirror.keyMap.basic["Up"] = moveUpAcrossRegions;
```

Where `moveUpAcrossRegions` used `moveV` internally. Shift-selections
weren't working. Documentation stated that shift is passed through for
"go" prefixed commands, so assumed this would work:

```
CodeMirror.keyMap.basic["Shift-Up"] = "goLineDown";
CodeMirror.keyMap.basic["Up"] = moveUpAcrossRegions;
```

But the shift was still being dropped. This commit makes the key event
handling properly passes it through.
