### PR TITLE
[vim keymap] Minor fixup for normalMode macro

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -536,6 +536,7 @@
         if (macroModeState.enteredMacroMode) {
           if (key == 'q') {
             actions.exitMacroRecordMode();
+            vim.inputState = new InputState();
             return;
           }
         }


### PR DESCRIPTION
The current patch fixes two issues with normalMode macro:
1. Eliminate the risk of wrongly matching `<C-[>ada<C-[>` instead of  `<C-[>`.
2. Avoid logging `keyToKey` twice.
