### PR TITLE
Add Cmd+Delete and Cmd+Backspace shortcuts on Mac

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3275,6 +3275,25 @@ window.CodeMirror = (function() {
         cm.replaceRange("", from, Pos(from.line + 1, 0), "+delete");
       else cm.replaceRange("", from, sel ? to : Pos(from.line), "+delete");
     },
+    killLineSmartStart: function(cm) {
+      var from = cm.getCursor(true), to = cm.getCursor(false), sel = !posEq(from, to);
+      if (sel) {
+        cm.replaceRange("", from, to, "+delete");
+      }
+      else if (from.ch == 0) {
+        cm.replaceRange("", from, Pos(from.line - 1, cm.getLine(from.line - 1).length), "+delete");
+      }
+      else {
+        var start = lineStart(cm, from.line);
+        var line = cm.getLineHandle(start.line);
+        var order = getOrder(line);
+        if (!order || order[0].level == 0) {
+          var firstNonWS = Math.max(0, line.text.search(/\S/));
+          var inWS = from.line == start.line && from.ch <= firstNonWS && from.ch;
+          cm.replaceRange("", from, Pos(from.line, inWS ? 0 : firstNonWS), "+delete");
+        } else cm.replaceRange("", from, start, "+delete");
+      }
+    },
     deleteLine: function(cm) {
       var l = cm.getCursor().line;
       cm.replaceRange("", Pos(l, 0), Pos(l), "+delete");
@@ -3371,8 +3390,9 @@ window.CodeMirror = (function() {
   keyMap.macDefault = {
     "Cmd-A": "selectAll", "Cmd-D": "deleteLine", "Cmd-Z": "undo", "Shift-Cmd-Z": "redo", "Cmd-Y": "redo",
     "Cmd-Up": "goDocStart", "Cmd-End": "goDocEnd", "Cmd-Down": "goDocEnd", "Alt-Left": "goGroupLeft",
-    "Alt-Right": "goGroupRight", "Cmd-Left": "goLineStart", "Cmd-Right": "goLineEnd", "Alt-Backspace": "delGroupBefore",
-    "Ctrl-Alt-Backspace": "delGroupAfter", "Alt-Delete": "delGroupAfter", "Cmd-S": "save", "Cmd-F": "find",
+    "Alt-Right": "goGroupRight", "Cmd-Left": "goLineStart", "Cmd-Right": "goLineEnd",
+    "Alt-Backspace": "delGroupBefore", "Ctrl-Alt-Backspace": "delGroupAfter", "Alt-Delete": "delGroupAfter",
+    "Cmd-Backspace": "killLineSmartStart", "Cmd-Delete": "killLine", "Cmd-S": "save", "Cmd-F": "find",
     "Cmd-G": "findNext", "Shift-Cmd-G": "findPrev", "Cmd-Alt-F": "replace", "Shift-Cmd-Alt-F": "replaceAll",
     "Cmd-[": "indentLess", "Cmd-]": "indentMore",
     fallthrough: ["basic", "emacsy"]


### PR DESCRIPTION
Adds two shortcuts as defaults on the Mac:
- Cmd + Delete triggers killLine(), which deletes the text on a line after the cursor.
- Cmd + Backspace triggers a new killLineSmartStart() function, which deletes the text on the line before the cursor (but preserves leading whitespace on the line)

These are common shortcuts in code editors (and many other text-content editors), such as:
- Sublime Text 2
- TextEdit
- Eclipse
- Chrome (url bar, dev tools)
- and even Microsoft Outlook

I only added these as defaults to the Mac shortcuts because I'm not sure what the equivalents are on Windows and other configurations (or if there even is a common equivalent).

As mentioned above, part of this change involved creating a new function killLineSmartStart(). It is basically a mashup between killLine() and goLineSmartStart(). There is probably some room for removing code duplication between those functions and the new one, but I didn't want to go that far in modifying the library.
