### PR TITLE
Add beforeHistoryChange event

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -418,12 +418,13 @@
       the CodeMirror implementation, probably cause the editor to
       become corrupted.</dd>
 
-      <dt id="event_beforeHistoryChange"><code><strong>"beforeHistoryChange"</strong> (instance: CodeMirror, changes: array)</code></dt>
+      <dt id="event_beforeHistoryChange"><code><strong>"beforeHistoryChange"</strong> (instance: CodeMirror, changeObj: object)</code></dt>
       <dd>This event is fired before the <code>undo</code> or <code>redo</code> command is applied.
-      The <code>changes</code>
-      argument is an array of <code>{from, to, text}</code> objects, each describing a change to be applied.
-      <code>from</code> and <code>to</code> properties are <code>CodeMirror.Pos</code> objects, and <code>text</code>
-      property is an array of lines that will be paste into the range. <strong>Note:</strong> You may not change <code>changes</code> object in any way as it will break history behaviour, and you may not change Codstrongirror's document as it will result in 
+      The <code>changeObj</code>
+      argument is an object with <code>{from, to, text, origin}</code> properties.
+      <code>from</code> and <code>to</code> properties are <code>CodeMirror.Pos</code> objects, <code>text</code>
+      property is an array of lines wich will substitute the range, and <code>origin</code> is either <code>"undo"</code> or
+      <code>"redo"</code>. <strong>Note:</strong> You may not change <code>changeObj</code> object in any way as it will break history processing, and you may not change CodeMirror's document as it will result in 
       unpredictable behaviour. The purpose of this event is to notify clients about the future changes of the document
       and show what kind of changes at which locations will be done.
       </dd>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2261,12 +2261,12 @@ window.CodeMirror = (function() {
                 anchorAfter: event.anchorBefore, headAfter: event.headBefore};
     (type == "undo" ? hist.undone : hist.done).push(anti);
 
-    signal(doc.cm, "beforeHistoryChange", event.changes);
 
     for (var i = event.changes.length - 1; i >= 0; --i) {
       var change = event.changes[i];
       change.origin = type;
       anti.changes.push(historyChangeFromChange(doc, change));
+      signal(doc.cm, "beforeHistoryChange", doc.cm, change);
 
       var after = i ? computeSelAfterChange(doc, change, null)
                     : {anchor: event.anchorBefore, head: event.headBefore};


### PR DESCRIPTION
Intent: the event is useful to get notifications about
future changes of the document so that one might be able
to update his own external document representation on an incremental
basis. This event is complimentary to the "beforeChange" event which
may be used for this purpose but which doesn't fire for the undo/redo
commands.
