### PR TITLE
forgive one pixel before drawing scrollbars

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -323,8 +323,8 @@ window.CodeMirror = (function() {
     d.sizer.style.minHeight = d.heightForcer.style.top = totalHeight + "px";
     d.gutters.style.height = Math.max(totalHeight, d.scroller.clientHeight - scrollerCutOff) + "px";
     var scrollHeight = Math.max(totalHeight, d.scroller.scrollHeight);
-    var needsH = d.scroller.scrollWidth > d.scroller.clientWidth;
-    var needsV = scrollHeight > d.scroller.clientHeight;
+    var needsH = d.scroller.scrollWidth > (d.scroller.clientWidth + 1);
+    var needsV = scrollHeight > (d.scroller.clientHeight + 1);
     if (needsV) {
       d.scrollbarV.style.display = "block";
       d.scrollbarV.style.bottom = needsH ? scrollbarWidth(d.measure) + "px" : "0";


### PR DESCRIPTION
Sometimes I find that CodeMirror adds scrollbars inappropriately (most often due to browser zoom). Digging around suggested that it is some non-integers resulting in rounding up the measured size, and I haven't been able to find a case where the two values differ by more than one pixel, so simply setting the threshold one pixel higher seems to address the issue.

This PR forgives one pixel in the size comparison before drawing the scrollbars.
