### PR TITLE
[vim keymap] 'dd' now handles last line corretly.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -663,6 +663,9 @@
     }
     RegisterController.prototype = {
       pushText: function(registerName, operator, text, linewise) {
+        if (linewise && text.charAt(0) == '\n') {
+          text = text.slice(1) + '\n';
+        }
         // Lowercase and uppercase registers refer to the same register.
         // Uppercase just means append.
         var register = this.isValidRegister(registerName) ?
@@ -1476,6 +1479,13 @@
       },
       // delete is a javascript keyword.
       'delete': function(cm, operatorArgs, vim, curStart, curEnd) {
+        // If the ending line is past the last line, inclusive, instead of
+        // including the trailing \n, include the \n before the starting line
+        if (operatorArgs.linewise &&
+            curEnd.line > cm.lastLine() && curStart.line > cm.firstLine()) {
+          curStart.line--;
+          curStart.ch = lineLength(cm, curStart.line);
+        }
         getVimGlobalState().registerController.pushText(
             operatorArgs.registerName, 'delete', cm.getRange(curStart, curEnd),
             operatorArgs.linewise);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -782,6 +782,13 @@ testVim('dd_multiply_repeat', function(cm, vim, helpers) {
   is(register.linewise);
   helpers.assertCursorAt(0, lines[6].textStart);
 });
+testVim('dd_lastline', function(cm, vim, helpers) {
+  cm.setCursor(cm.lineCount(), 0);
+  var expectedLineCount = cm.lineCount() - 1;
+  helpers.doKeys('d', 'd');
+  eq(expectedLineCount, cm.lineCount());
+  helpers.assertCursorAt(cm.lineCount() - 1, 0);
+});
 // Yank commands should behave the exact same as d commands, expect that nothing
 // gets deleted.
 testVim('yw_repeat', function(cm, vim, helpers) {


### PR DESCRIPTION
Current behavior:

```
word1
word2

```

If the cursor is on the last line and 'dd' is executed, the buffer does
not change.

Expected behavior:

```
word1
word2
```
