### PR TITLE
[vim keymap] Repeat insert changes for A,I,a,i,caw,ciw

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -441,6 +441,12 @@
       return {
         macroKeyBuffer: [],
         latestRegister: undefined,
+        lastInsertModeChanages: {
+          ch: 0,
+          baseRemnantLength: 0,
+          cachedText: '',
+          text: ''
+        },
         enteredMacroMode: undefined,
         isMacroPlaying: false,
         toggle: function(cm, registerName) {
@@ -1591,6 +1597,10 @@
           cm.setCursor(motions.moveToFirstNonWhiteSpaceCharacter(cm));
         }
         cm.setOption('keyMap', 'vim-insert');
+        cm.on('change', onInsertModeTextChanges);
+        var vim = getVimState(cm);
+        if(insertAt)commandDispatcher.recordLastEdit(cm, vim, insertAt);
+        getVimGlobalState().macroModeState.lastInsertModeChanages.text = '';
       },
       toggleVisualMode: function(cm, actionArgs, vim) {
         var repeat = actionArgs.repeat;
@@ -1817,15 +1827,24 @@
         cm.setCursor({line: cur.line, ch: start + numberStr.length - 1});
       },
       repeatLastEdit: function(cm, actionArgs, vim) {
-        // TODO: Make this repeat insert mode changes.
         var lastEdit = vim.lastEdit;
-        if (lastEdit) {
+        var repeat = actionArgs.repeat;
+        var macroModeState = getVimGlobalState().macroModeState;
+        if (isInsertModeChanges(lastEdit)) { /* A,I,a,i */
+          actions.enterInsertMode(cm, { isRepeatEdit:true, insertAt:lastEdit });
+          repeatLastInsertModeChanges(cm, repeat, macroModeState);
+          return;
+        } else if (lastEdit) {
           if (actionArgs.repeat && actionArgs.repeatIsExplicit) {
             vim.lastEdit.repeatOverride = actionArgs.repeat;
           }
           var currentInputState = vim.inputState;
           vim.inputState = vim.lastEdit;
           commandDispatcher.evalInput(cm, vim);
+          if (lastEdit.operator == 'change') {
+            repeatLastInsertModeChanges(cm, repeat, macroModeState);
+            return;
+          }
           vim.inputState = currentInputState;
         }
       }
@@ -3226,9 +3245,15 @@
     }
     CodeMirror.keyMap.vim = buildVimKeyMap();
 
-    function exitInsertMode(cm) {
+    function exitInsertMode(cm, suppressChanges) {
       cm.setCursor(cm.getCursor().line, cm.getCursor().ch-1, true);
       cm.setOption('keyMap', 'vim');
+      cm.off('change', onInsertModeTextChanges);
+      logKey(getVimGlobalState().macroModeState, '<Esc>');
+      if (!suppressChanges) {
+        var lastChange = getVimGlobalState().macroModeState.lastInsertModeChanages;
+        lastChange.cachedText = lastChange.text;
+      }
     }
 
     CodeMirror.keyMap['vim-insert'] = {
@@ -3292,6 +3317,62 @@
       cm.toggleOverwrite();
       cm.setCursor(cm.getCursor().line, cm.getCursor().ch-1, true);
       cm.setOption('keyMap', 'vim');
+    }
+
+    function changeObjToString(changeObj) {
+      return changeObj.text.join('\n');
+    }
+
+    function onInsertModeTextChanges(cm, changeObj) {
+      var macroModeState = getVimGlobalState().macroModeState;
+      var keyBuffer = macroModeState.macroKeyBuffer;
+      var cur = cm.getCursor();
+      var line = cur.line;
+      var ch = cur.ch;
+      var lastChange = macroModeState.lastInsertModeChanages;
+      var remnantLength;
+      if (lastChange.text) {
+        // if current change is newline, push '\n'
+        if (changeObj.text.length > 1) {
+          lastChange.text += changeObj.text.join('\n');
+
+        // if last change was newline, update lastChange state for current line
+        } else if (lastChange.text.charAt(lastChange.text.length-1) == '\n') {
+          lastChange.baseRemnantLength = lastChange.text.length;
+          lastChange.text += changeObj.text;
+          changeObj.text = lastChange.text;
+          lastChange.ch = changeObj.from.ch;
+
+        // Merge consecutive grainy changes into one chunk
+        } else {
+          var remnantLength = lastChange.baseRemnantLength + changeObj.from.ch - lastChange.ch;
+          var lastText = lastChange.text;
+          var changeObjText = changeObjToString(changeObj);
+          var lastTextRemnant = lastText.substring(0, remnantLength);
+          lastChange.text = lastTextRemnant + changeObjText;
+        }
+      } else { // reset lastChange state
+        lastChange.ch = changeObj.from.ch;
+        lastChange.text = changeObj.text.join('\n');
+        lastChange.baseRemnantLength = 0;
+        console.log(changeObj.text);
+      }
+    }
+
+    function isInsertModeChanges(lastEdit) {
+      return (typeof lastEdit) == 'string';
+    }
+
+    function repeatLastInsertModeChanges(cm, repeat, macroModeState) {
+      var cur = cm.getCursor();
+      var lastChange = macroModeState.lastInsertModeChanages;
+      var text = '';
+      var cachedText = lastChange.cachedText;
+      while (repeat--) {
+        text += cachedText;
+      }
+      cm.replaceRange(text, cur, cur);
+      exitInsertMode(cm, /* suppressChanges */true);
     }
 
     CodeMirror.keyMap['vim-replace'] = {


### PR DESCRIPTION
This pull request is a break down from #1535.
It enables insert mode text changes to be repeated by `.`

So far it supports `A`,`I`,`a`,`i`,`caw` and `ciw`.
Support for `o` and `O` is yet to be implemented. (Should be easily done by changing some code structure)
