### PR TITLE
Export visibleLines to public api

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1319,6 +1319,12 @@
       the <a href="#event_viewportChange"><code>viewportChange</code></a>
       event.</dd>
 
+      <dt id="getVisibleLines"><code><strong>cm.getVisibleLines</strong>() → {from: number, to: number}</code></dt>
+      <dd>Returns a <code>{from, to}</code> object indicating the
+      start (inclusive) and end (inclusive) of the currently visible
+      part of the document. It differs from <code>cm.getViewport</code> method
+      in that it doesn't include margin around it.</dd>
+
       <dt id="refresh"><code><strong>cm.refresh</strong>()</code></dt>
       <dd>If your code does something to change the size of the editor
       element (window resizes are already listened for), or unhides

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2921,6 +2921,8 @@ window.CodeMirror = (function() {
 
     getViewport: function() { return {from: this.display.showingFrom, to: this.display.showingTo};},
 
+    getVisibleLines: function() { return visibleLines(this.display, this.doc);},
+
     addWidget: function(pos, node, scroll, vert, horiz) {
       var display = this.display;
       pos = cursorCoords(this, clipPos(this.doc, pos));


### PR DESCRIPTION
#### Problem

The only way to figure out a first visible line number (or a bottom visible line number)
is to call `codeMirror.coordsChar({left: 0, top: 0}, "local")`. (please correct me if I'm wrong).
The problem is, however, that this method is pretty expensive because of a `measureLineInner` call, so in case of calling it multiple times in a `scroll` event handler on a file with multiple long lines - scrolling gets laggy.

The `visibleLines` method seems to be a natural solution for the problem.
