### PR TITLE
Change disableInput behavior to allow programmatic edits but not inputs to the hidden textfield

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -239,8 +239,7 @@ window.CodeMirror = (function() {
     var map = keyMap[cm.options.keyMap], style = map.style;
     cm.display.wrapper.className = cm.display.wrapper.className.replace(/\s*cm-keymap-\S+/g, "") +
       (style ? " cm-keymap-" + style : "");
-    if (map.disableInput) cm.doc.cantEdit |= cantEdit_keymap;
-    else cm.doc.cantEdit &= ~cantEdit_keymap;
+    cm.doc.disableInput = !!map.disableInput;
   }
 
   function themeChanged(cm) {
@@ -1423,7 +1422,7 @@ window.CodeMirror = (function() {
     if (!cm.state.focused || hasSelection(input) || isReadOnly(cm)) return false;
     var text = input.value;
     if (text == prevInput && posEq(sel.from, sel.to)) return false;
-    if (ie && !ie_lt9 && cm.display.inputHasSelection === text) {
+    if (cm.doc.disableInput || ie && !ie_lt9 && cm.display.inputHasSelection === text) {
       resetInput(cm, true);
       return false;
     }
@@ -2486,7 +2485,7 @@ window.CodeMirror = (function() {
   function skipAtomic(doc, pos, bias, mayClear) {
     var flipped = false, curPos = pos;
     var dir = bias || 1;
-    doc.cantEdit &= ~cantEdit_inatomic;
+    doc.cantEdit = false;
     search: for (;;) {
       var line = getLine(doc, curPos.line);
       if (line.markedSpans) {
@@ -2518,7 +2517,7 @@ window.CodeMirror = (function() {
                   // -- try again *with* clearing, if we didn't already
                   if (!mayClear) return skipAtomic(doc, pos, bias, true);
                   // Otherwise, turn off editing until further notice, and return the start of the doc
-                  doc.cantEdit |= cantEdit_inatomic;
+                  doc.cantEdit = true;
                   return Pos(doc.first, 0);
                 }
                 flipped = true; newPos = pos; dir = -dir;
@@ -3611,8 +3610,8 @@ window.CodeMirror = (function() {
     if (min != null && cm) regChange(cm, min, max + 1);
     this.lines.length = 0;
     this.explicitlyCleared = true;
-    if (this.atomic && (this.doc.cantEdit & cantEdit_inatomic)) {
-      this.doc.cantEdit &= ~cantEdit_inatomic;
+    if (this.atomic && this.doc.cantEdit) {
+      this.doc.cantEdit = false;
       if (cm) reCheckSelection(cm);
     }
     if (withOp) endOperation(cm);
@@ -4528,8 +4527,6 @@ window.CodeMirror = (function() {
     }
   };
 
-  var cantEdit_inatomic = 1, cantEdit_keymap = 2;
-
   var nextDocId = 0;
   var Doc = CodeMirror.Doc = function(text, mode, firstLine) {
     if (!(this instanceof Doc)) return new Doc(text, mode, firstLine);
@@ -4538,7 +4535,7 @@ window.CodeMirror = (function() {
     BranchChunk.call(this, [new LeafChunk([makeLine("", null)])]);
     this.first = firstLine;
     this.scrollTop = this.scrollLeft = 0;
-    this.cantEdit = 0;
+    this.cantEdit = false;
     this.history = makeHistory();
     this.frontier = firstLine;
     var start = Pos(firstLine, 0);
@@ -4786,8 +4783,7 @@ window.CodeMirror = (function() {
     loadMode(cm);
     if (!cm.options.lineWrapping) computeMaxLength(cm);
     cm.options.mode = doc.modeOption;
-    if (keyMap[cm.options.keyMap].disableInput) doc.cantEdit |= cantEdit_keymap;
-    else doc.cantEdit &= ~cantEdit_keymap;
+    doc.disableInput = !!keyMap[cm.options.keyMap].disableInput;
     regChange(cm);
   }
 


### PR DESCRIPTION
I'm not exactly sure if I modified `readInput` correctly, but as far as I can tell it results in the desired behavior in vim mode, and doesn't seem to break anything with the default codemirror keymap.

The change is that key events are now able to trigger edits to the document, while direct character insertions are ignored.
