### PR TITLE
[vim] Add support for :sort

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -11,7 +11,7 @@ var code = '' +
 '    bufp = buf;\n' +
 '  }\n' +
 '\n' +
-'  return (--n >= 0) ? (unsigned char) *bufp++ : EOF;\n' + 
+'  return (--n >= 0) ? (unsigned char) *bufp++ : EOF;\n' +
 ' \n' +
 '}\n';
 
@@ -1940,6 +1940,59 @@ testVim('ex_write', function(cm, vim, helpers) {
   }
   CodeMirror.commands.save = tmp;
 });
+testVim('ex_sort', function(cm, vim, helpers) {
+  helpers.doEx('sort');
+  eq('Z\na\nb\nc\nd', cm.getValue());
+}, { value: 'b\nZ\nd\nc\na'});
+testVim('ex_sort_reverse', function(cm, vim, helpers) {
+  helpers.doEx('sort!');
+  eq('d\nc\nb\na', cm.getValue());
+}, { value: 'b\nd\nc\na'});
+testVim('ex_sort_range', function(cm, vim, helpers) {
+  helpers.doEx('2,3sort');
+  eq('b\nc\nd\na', cm.getValue());
+}, { value: 'b\nd\nc\na'});
+testVim('ex_sort_oneline', function(cm, vim, helpers) {
+  helpers.doEx('2sort');
+  // Expect no change.
+  eq('b\nd\nc\na', cm.getValue());
+}, { value: 'b\nd\nc\na'});
+testVim('ex_sort_ignoreCase', function(cm, vim, helpers) {
+  helpers.doEx('sort i');
+  eq('a\nb\nc\nd\nZ', cm.getValue());
+}, { value: 'b\nZ\nd\nc\na'});
+testVim('ex_sort_unique', function(cm, vim, helpers) {
+  helpers.doEx('sort u');
+  eq('Z\na\nb\nc\nd', cm.getValue());
+}, { value: 'b\nZ\na\na\nd\na\nc\na'});
+testVim('ex_sort_decimal', function(cm, vim, helpers) {
+  helpers.doEx('sort d');
+  eq('d3\n s5\n6\n.9', cm.getValue());
+}, { value: '6\nd3\n s5\n.9'});
+testVim('ex_sort_decimal_negative', function(cm, vim, helpers) {
+  helpers.doEx('sort d');
+  eq('z-9\nd3\n s5\n6\n.9', cm.getValue());
+}, { value: '6\nd3\n s5\n.9\nz-9'});
+testVim('ex_sort_decimal_reverse', function(cm, vim, helpers) {
+  helpers.doEx('sort! d');
+  eq('.9\n6\n s5\nd3', cm.getValue());
+}, { value: '6\nd3\n s5\n.9'});
+testVim('ex_sort_hex', function(cm, vim, helpers) {
+  helpers.doEx('sort x');
+  eq(' s5\n6\n.9\n&0xB\nd3', cm.getValue());
+}, { value: '6\nd3\n s5\n&0xB\n.9'});
+testVim('ex_sort_octal', function(cm, vim, helpers) {
+  helpers.doEx('sort o');
+  eq('.8\n.9\nd3\n s5\n6', cm.getValue());
+}, { value: '6\nd3\n s5\n.9\n.8'});
+testVim('ex_sort_decimal_mixed', function(cm, vim, helpers) {
+  helpers.doEx('sort d');
+  eq('y\nz\nc1\nb2\na3', cm.getValue());
+}, { value: 'a3\nz\nc1\ny\nb2'});
+testVim('ex_sort_decimal_mixed_reverse', function(cm, vim, helpers) {
+  helpers.doEx('sort! d');
+  eq('a3\nb2\nc1\nz\ny', cm.getValue());
+}, { value: 'a3\nz\nc1\ny\nb2'});
 testVim('ex_substitute_same_line', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('s/one/two');


### PR DESCRIPTION
Supports all options except [r] and [/pattern}/].

Vim documentation:

```
                            *:sor* *:sort*
:[range]sor[t][!] [i][u][r][n][x][o] [/{pattern}/]
            Sort lines in [range].  When no range is given all
            lines are sorted.

            With [!] the order is reversed.

            With [i] case is ignored.

            With [n] sorting is done on the first decimal number
            in the line (after or inside a {pattern} match).
            One leading '-' is included in the number.

            With [x] sorting is done on the first hexadecimal
            number in the line (after or inside a {pattern}
            match).  A leading "0x" or "0X" is ignored.
            One leading '-' is included in the number.

            With [o] sorting is done on the first octal number in
            the line (after or inside a {pattern} match).

            With [u] only keep the first of a sequence of
            identical lines (ignoring case when [i] is used).
            Without this flag, a sequence of identical lines
            will be kept in their original order.
            Note that leading and trailing white space may cause
            lines to be different.

            When /{pattern}/ is specified and there is no [r] flag
            the text matched with {pattern} is skipped, so that
            you sort on what comes after the match.
            Instead of the slash any non-letter can be used.
            For example, to sort on the second comma-separated
            field:
                :sort /[^,]*,/
            To sort on the text at virtual column 10 (thus
            ignoring the difference between tabs and spaces):
                :sort /.*\%10v/
            To sort on the first number in the line, no matter
            what is in front of it:
                :sort /.\{-}\ze\d/
            (Explanation: ".\{-}" matches any text, "\ze" sets the
            end of the match and \d matches a digit.)
            With [r] sorting is done on the matching {pattern}
            instead of skipping past it as described above.
            For example, to sort on only the first three letters
            of each line:
                :sort /\a\a\a/ r

            If a {pattern} is used, any lines which don't have a
            match for {pattern} are kept in their current order,
            but separate from the lines which do match {pattern}.
            If you sorted in reverse, they will be in reverse
            order after the sorted lines, otherwise they will be
            in their original order, right before the sorted
            lines.

            If {pattern} is empty (e.g. // is specified), the
            last search pattern is used.  This allows trying out
            a pattern first.
```
