### PR TITLE
Added note about !doctype

### DIFF
--- a/demo/resize.html
+++ b/demo/resize.html
@@ -36,7 +36,7 @@
 <p>By setting a few CSS properties, and giving
 the <a href="../doc/manual.html#option_viewportMargin"><code>viewportMargin</code></a>
 a value of <code>Infinity</code>, CodeMirror can be made to
-automatically resize to fit its content.</p>
+automatically resize to fit its content. Also note, an HTML document type <code>&lt;!doctype html&lt;</code> is required.</p>
 
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {


### PR DESCRIPTION
Does not work in Chrome without doctype set. This is what made it work for me, though there may be a more precise reason ?
