### PR TITLE
Update search.js

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -55,7 +55,7 @@
         if (!query || state.query) return;
         state.query = parseQuery(query);
         cm.removeOverlay(state.overlay);
-        state.overlay = searchOverlay(query);
+        state.overlay = searchOverlay(state.query);
         cm.addOverlay(state.overlay);
         state.posFrom = state.posTo = cm.getCursor();
         findNext(cm, rev);


### PR DESCRIPTION
The variable "query" only contains the string version of the query, even if a regex has been submitted. "state.query" contains either a regex object or a string, depending on the input.
The function searchOverlay contains the neccessary logic to differientiate between these two types, indicating that the original purpose of it was that regexes should be highlighted accordingly.
Passing the "query" variable to searchOverlay fails to highlight regexes, for example case insensitive searches, and thus isn't in sync with the find next / find previous commands.
