### PR TITLE
Do not call startWorker every 100ms on typing

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -512,7 +512,10 @@ window.CodeMirror = (function() {
       display.lastSizeC != display.wrapper.clientHeight;
     // This is just a bogus formula that detects when the editor is
     // resized or the font size changes.
-    if (different) display.lastSizeC = display.wrapper.clientHeight;
+    if (different) {
+      display.lastSizeC = display.wrapper.clientHeight;
+      startWorker(cm, 400);
+    }
     display.showingFrom = from; display.showingTo = to;
 
     var prevBottom = display.lineDiv.offsetTop;


### PR DESCRIPTION
When smth is typed into the CodeMirror editor
it schedules a job to rehighlight the next 500 lines of the document. This job
is intended to be executed in a `400ms` time (as hardcoded in
`makeChangeSingleDocInEditor` method), but actually
400ms delay gets overwritten with `100ms` delay which is set
from `updateDisplayInner` method.
The problem with this is that people hardly ever type 10 chars/second,
so the highlighter gets its time to rehighlight 500 lines of the
document while keydown events get postponed and user might feel some
slowleness.
