### PR TITLE
SQL Mode: enhancements to specific dialects

### DIFF
--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -294,3 +294,30 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     support:    set("nCharCast zerolessFloat")
   });
 }());
+
+/*
+  How Properties of Mime Types are used by SQL Mode
+  =================================================
+
+  keywords:
+    A list of keywords you want to be highlighted.
+  functions:
+    A list of function names you want to be highlighted.
+  builtin:
+    A list of builtin types you want to be highlighted (if you want types to be of class "builtin" instead of "keyword").
+  operatorChars:
+    All characters that must be handled as operators.
+  client:
+    Commands parsed and executed by the client (not the server).
+  support:
+    A list of supported syntaxes which are not common, but are supported by more than 1 DBMS.
+    * ODBCdotTable: .tableName
+    * zerolessFloat: .1
+    * nCharCast: N'string'
+    * charsetCast: _utf8'string'
+  atoms:
+    Keywords that must be highlighted as atoms,. Some DBMS's support more atoms than others:
+    UNKNOWN, INFINITY, UNDERFLOW, NaN...
+  dateSQL:
+    Used for date/time SQL standard syntax, because not all DBMS's support same temporal types.
+*/


### PR DESCRIPTION
Changes summary:
- separate support.nCharCast from support.charsetCast
- MySQL/MariaDB: \N as synonym of NULL
- Oracle supports zerolessFloat, nCharCast
- add a comment which explains all Mime Types properties used by SQL Mode
