### PR TITLE
New Mime Type "x-cassandra" (SQL Mode)

### DIFF
--- a/mode/sql/index.html
+++ b/mode/sql/index.html
@@ -56,6 +56,7 @@ SELECT SQL_NO_CACHE DISTINCT
             <code><a href="?mime=text/x-sql">text/x-sql</a></code>,
             <code><a href="?mime=text/x-mysql">text/x-mysql</a></code>,
             <code><a href="?mime=text/x-mariadb">text/x-mariadb</a></code>,
+            <code><a href="?mime=text/x-cassandra">text/x-cassandra</a></code>,
             <code><a href="?mime=text/x-plsql">text/x-plsql</a></code>.
         </p>
         <p>


### PR DESCRIPTION
Support for Cassandra's CQL (which is a subset of SQL).
More support elements, so mime types can customize their syntaxes.
My/Maria: support ! \? etc
Oracle: --comments without space
