### PR TITLE
Introduce CoffeeScript Lint addon

### DIFF
--- a/addon/lint/coffeescript-lint.js
+++ b/addon/lint/coffeescript-lint.js
@@ -1,0 +1,24 @@
+// Depends on coffeelint.js from http://www.coffeelint.org/js/coffeelint.js
+
+CodeMirror.coffeeValidator = function(text) {
+  var found = [];
+  var parseError = function(err) {
+    var loc = err.lineNumber;
+    found.push({from: CodeMirror.Pos(loc-1, 0),
+                to: CodeMirror.Pos(loc, 0),
+                severity: err.level,
+                message: err.message});
+  };
+  try {
+    var res = coffeelint.lint(text);
+    for(var i = 0; i < res.length; i++) {
+      parseError(res[i]);
+    }
+  } catch(e) {
+    found.push({from: CodeMirror.Pos(e.location.first_line, 0),
+                to: CodeMirror.Pos(e.location.last_line, e.location.last_column),
+                severity: 'error',
+                message: e.message});
+  }
+  return found;
+};


### PR DESCRIPTION
A simple lint checker for CoffeeScript. Checked with `bin/lint`, no warnings.

![preview](https://dl.dropboxusercontent.com/u/176100/opensource/coffeescript-lint.png)
