### PR TITLE
Colorize instance variable interpolation in double quoted strings

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -117,9 +117,14 @@ CodeMirror.defineMode("ruby", function(config) {
           state.tokenize.pop();
           break;
         }
-        if (embed && ch == "#" && !escaped && stream.eat("{")) {
-          state.tokenize.push(tokenBaseUntilBrace(arguments.callee));
-          break;
+        if (embed && ch == "#" && !escaped) {
+          if (stream.eat("{")) {
+            state.tokenize.push(tokenBaseUntilBrace(arguments.callee));
+            break;
+          } else if (stream.eat("@")) {
+            stream.eatWhile(/[\w\?]/);
+            return "variable-2";
+          }
         }
         escaped = !escaped && ch == "\\";
       }


### PR DESCRIPTION
This change add support for a not very well known feature of ruby:

``` ruby
"hello #@foo" == "hello #{@foo}"
```

It seems that even pygment isn't aware of this syntax (but textmate is).

Regards.
