### PR TITLE
Handle default string % literal for Ruby

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -35,7 +35,7 @@ CodeMirror.defineMode("ruby", function(config) {
         (ch == "/" && !stream.eol() && stream.peek() != " ")) {
       return chain(readQuoted(ch, "string", ch == '"' || ch == "`"), stream, state);
     } else if (ch == "%") {
-      var style, embed = false;
+      var style = "string", embed = false;
       if (stream.eat("s")) style = "atom";
       else if (stream.eat(/[WQ]/)) { style = "string"; embed = true; }
       else if (stream.eat(/[wxqr]/)) style = "string";


### PR DESCRIPTION
Another ruby syntax thing

``` ruby
  %{Hello World} == %q{Hello World}
```

One gotcha though:

``` ruby
  5%(2) == 5 % 2
```

Will be seen as a string, but it will be interpreted as the modulo operator by ruby.
But It's not easy to fix it, and as far as I know, there is no editor that handle that edge case.
