### PR TITLE
Improve ruby variables and symbols parsing rules

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -84,13 +84,18 @@ CodeMirror.defineMode("ruby", function(config) {
         return "atom";
       }
       return "operator";
-    } else if (ch == "@") {
+    } else if (ch == "@" && stream.match(/^@?[a-zA-Z_]/)) {
       stream.eat("@");
       stream.eatWhile(/[\w]/);
       return "variable-2";
     } else if (ch == "$") {
-      stream.next();
-      stream.eatWhile(/[\w]/);
+      if (stream.eat(/[a-zA-Z_]/)) {
+        stream.eatWhile(/[\w]/);
+      } else if (stream.eat(/\d/)) {
+        stream.eat(/\d/);
+      } else {
+        stream.next(); // Must be a special global like $: or $!
+      }
       return "variable-3";
     } else if (/[a-zA-Z_]/.test(ch)) {
       stream.eatWhile(/[\w]/);


### PR DESCRIPTION
For local variables, instance variables and classe variables:
- can't include a `?` nor a `!`
- can't start by a digit

For global variables:
- can't include a `?` nor a `!`
- can't start by a digit
- except for match variables (e.g. `$1`, `$2`, `$42`) which are full digits
- expect for some special variables (e.g. `$$`, `$!`, `$,`)

For symbols:
- can be operators (e.g `:+`, `:/`, `:-`, `:>>`)
- start with `@` or `$`
- end with `!`, `?` or `=`
- can't start by a digit

For symbols defined in reverse as hash keys (e.g {foo: 'bar'}):
- can only start with `[a-zA-Z\_]`
- can't end with `=`
