### PR TITLE
[ruby mode] Add some missin keywords

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -10,7 +10,7 @@ CodeMirror.defineMode("ruby", function(config) {
     "redo", "rescue", "retry", "return", "self", "super", "then", "true", "undef", "unless",
     "until", "when", "while", "yield", "nil", "raise", "throw", "catch", "fail", "loop", "callcc",
     "caller", "lambda", "proc", "public", "protected", "private", "require", "load",
-    "require_relative", "extend", "autoload"
+    "require_relative", "extend", "autoload", "__END__", "__FILE__", "__LINE__", "__dir__"
   ]);
   var indentWords = wordObj(["def", "class", "case", "for", "while", "do", "module", "then",
                              "catch", "loop", "proc", "begin"]);


### PR DESCRIPTION
Actually only `__END__` is really a keyword.
But `__FILE__`, `__LINE__` and `__dir__` are special variables that you can't assign so most editors highlight them as keywords.
