### PR TITLE
[ruby mode] Several regexp improvements

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -31,14 +31,16 @@ CodeMirror.defineMode("ruby", function(config) {
     }
     if (stream.eatSpace()) return null;
     var ch = stream.next(), m;
-    if (ch == "`" || ch == "'" || ch == '"' ||
-        (ch == "/" && !stream.eol() && stream.peek() != " ")) {
+    if (ch == "`" || ch == "'" || ch == '"') {
       return chain(readQuoted(ch, "string", ch == '"' || ch == "`"), stream, state);
+    } else if (ch == "/" && !stream.eol() && stream.peek() != " ") {
+      return chain(readQuoted(ch, "string-2", true), stream, state);
     } else if (ch == "%") {
       var style, embed = false;
       if (stream.eat("s")) style = "atom";
       else if (stream.eat(/[WQ]/)) { style = "string"; embed = true; }
-      else if (stream.eat(/[wxqr]/)) style = "string";
+      else if (stream.eat(/[r]/)) { style = "string-2"; embed = true; }
+      else if (stream.eat(/[wxq]/)) style = "string";
       var delim = stream.eat(/[^\w\s]/);
       if (!delim) return "operator";
       if (matching.propertyIsEnumerable(delim)) delim = matching[delim];


### PR DESCRIPTION
- Use the string-2 class for regexps like JS mode
- Xonsider %r as a regexp
- Handle interpolation inside regexps

It allow to colorize properly stuffs like:

``` ruby
/foo #{1 + 2}/
%r{foo #{@bar} baz}
```
