### PR TITLE
Make isClean() return true after clearHistory()

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4668,7 +4668,10 @@ window.CodeMirror = (function() {
       var hist = this.history;
       return {undo: hist.done.length, redo: hist.undone.length};
     },
-    clearHistory: function() {this.history = makeHistory(this.history.maxGeneration);},
+    clearHistory: function() {
+      this.cleanGeneration = this.history.maxGeneration;
+      this.history = makeHistory(this.history.maxGeneration);
+    },
 
     markClean: function() {
       this.cleanGeneration = this.changeGeneration();

--- a/test/test.js
+++ b/test/test.js
@@ -1351,6 +1351,9 @@ testCM("dirtyBit", function(cm) {
   eq(cm.isClean(), false);
   cm.redo();
   eq(cm.isClean(), true);
+  cm.replaceSelection("clearme");
+  cm.clearHistory();
+  eq(cm.isClean(), true);
 });
 
 testCM("addKeyMap", function(cm) {


### PR DESCRIPTION
Fixes a bug in fec397d70d62925a3fe32e4662c3536cfa012d4d - if I understand the code correctly, we should reset `cleanGeneration` to the same generation as the new history is starting from. (Alternatively, we could just call `markClean()` from `clearHistory()`, but I wasn't sure if that made sense.)
