### PR TITLE
Proof-of-concept: char dictionary in measureLineInner

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1059,7 +1059,7 @@ window.CodeMirror = (function() {
       vranges.push(top, bot);
       return j;
     }
-
+    var cumulativeLeft = -1;
     for (var i = 0, cur; i < measure.length; ++i) if (cur = measure[i]) {
       var size, elt = cur;
       // A widget might wrap, needs special care
@@ -1074,11 +1074,15 @@ window.CodeMirror = (function() {
           continue;
         }
       }
-      size = getRect(elt);
+      if (!elt._cachedSize)
+        elt._cachedSize = getRect(elt);
+      size = elt._cachedSize;
+      if (cumulativeLeft === -1) cumulativeLeft = size.left - outer.left;
       var vCat = categorizeVSpan(size.top - outer.top, size.bottom - outer.top);
       var right = size.right;
       if (cur.measureRight) right = getRect(cur.measureRight).left;
-      data[i] = {left: size.left - outer.left, right: right - outer.left, top: vCat};
+      data[i] = {left: cumulativeLeft, right: cumulativeLeft + size.width, top: vCat};
+      cumulativeLeft += size.width;
     }
     for (var i = 0, cur; i < data.length; ++i) if (cur = data[i]) {
       var vr = cur.top, vrRight = cur.topRight;
@@ -4191,7 +4195,7 @@ window.CodeMirror = (function() {
       line = getLine(cm.doc, merged.find().from.line);
 
     var builder = {pre: elt("pre"), col: 0, pos: 0, display: !measure,
-                   measure: null, measuredSomething: false, cm: cm};
+                   measure: null, measuredSomething: false, cm: cm, styleDict: {}};
     if (line.textClass) builder.pre.className = line.textClass;
 
     do {
@@ -4283,6 +4287,7 @@ window.CodeMirror = (function() {
         builder.pre.appendChild(elt("wbr"));
       }
       var span = builder.measure[builder.pos] =
+        (builder.styleDict[ch] && builder.styleDict[ch][style || "raw"]) ||
         buildToken(builder, ch, style,
                    start && startStyle, i == text.length - 1 && endStyle);
       // In IE single-space nodes wrap differently than spaces
@@ -4292,6 +4297,8 @@ window.CodeMirror = (function() {
           i < text.length - 1 && !/\s/.test(text.charAt(i + 1)))
         span.style.whiteSpace = "normal";
       builder.pos += ch.length;
+      builder.styleDict[ch] = builder.styleDict[ch] || {};
+      builder.styleDict[ch][style || "raw"] = span;
     }
     if (text.length) builder.measuredSomething = true;
   }


### PR DESCRIPTION
Hi Marijnh,

I'm trying to adapt CodeMirror for displaying/editing minified js files, which usually contain couple of very long lines. Currently it takes far too long to initially render a line which consists of 75k characters. The vast majority of time is spent in `measureLineInner` method, which forces layout for many one-character spans. 

One of the possible solutions would be a character metrics dictionary. The idea is to 
construct a dictionary that would contain a metric for every `char` X `class` occurrence. This drastically reduces the amount of layouted nodes.

The downside is that the approach won't work in case of lineWraping option on, but speeding up a non-line-wrapping mode is a great achievement as well. 

I attach a proof-of-concept patch that does the trick (in a dirty non-finished way) and which works for me in Chrome. The speedup is about 27 times: 75k file without highlighter gets opened in about 580ms instead of 16000ms.

What is your opinion about it?
