### PR TITLE
Suggestion for option to `getTokenAt()/getStateBefore()` to improve precision after edits

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1382,7 +1382,7 @@
       the mode specification, rather than the resolved, instantiated
       <a href="#defineMode">mode object</a>.</dd>
 
-      <dt id="getTokenAt"><code><strong>cm.getTokenAt</strong>(pos: {line, ch}) → object</code></dt>
+      <dt id="getTokenAt"><code><strong>cm.getTokenAt</strong>(pos: {line, ch}, ?precise: boolean) → object</code></dt>
       <dd>Retrieves information about the token the current mode found
       before the given position (a <code>{line, ch}</code> object). The
       returned object has the following properties:
@@ -1394,14 +1394,19 @@
         to the token, such as <code>"keyword"</code>
         or <code>"comment"</code> (may also be null).</dd>
         <dt><code><strong>state</strong></code></dt><dd>The mode's state at the end of this token.</dd>
-      </dl></dd>
+      </dl>
+      If <code>precise</code> is true, the token will be guaranteed to be accurate based on recent edits. If false or
+      not specified, the token will use cached state information, which will be faster but might not be accurate if
+      edits were recently made and highlighting has not yet completed.
+      </dd>
 
-      <dt id="getStateAfter"><code><strong>cm.getStateAfter</strong>(?line: integer) → object</code></dt>
+      <dt id="getStateAfter"><code><strong>cm.getStateAfter</strong>(?line: integer, ?precise: boolean) → object</code></dt>
       <dd>Returns the mode's parser state, if any, at the end of the
       given line number. If no line number is given, the state at the
       end of the document is returned. This can be useful for storing
       parsing errors in the state, or getting other kinds of
-      contextual information for a line.</dd>
+      contextual information for a line. <code>precise</code> is defined
+      as in <code>getTokenAt()</code>.</dd>
     </dl>
 
     <h3 id="api_misc">Miscellaneous methods</h3>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -917,12 +917,12 @@ window.CodeMirror = (function() {
   // valid state. If that fails, it returns the line with the
   // smallest indentation, which tends to need the least context to
   // parse correctly.
-  function findStartLine(cm, n) {
+  function findStartLine(cm, n, precise) {
     var minindent, minline, doc = cm.doc;
     for (var search = n, lim = n - 100; search > lim; --search) {
       if (search <= doc.first) return doc.first;
       var line = getLine(doc, search - 1);
-      if (line.stateAfter) return search;
+      if (line.stateAfter && (!precise || search <= doc.frontier)) return search;
       var indented = countColumn(line.text, null, cm.options.tabSize);
       if (minline == null || minindent > indented) {
         minline = search - 1;
@@ -932,10 +932,10 @@ window.CodeMirror = (function() {
     return minline;
   }
 
-  function getStateBefore(cm, n) {
+  function getStateBefore(cm, n, precise) {
     var doc = cm.doc, display = cm.display;
       if (!doc.mode.startState) return true;
-    var pos = findStartLine(cm, n), state = pos > doc.first && getLine(doc, pos-1).stateAfter;
+    var pos = findStartLine(cm, n, precise), state = pos > doc.first && getLine(doc, pos-1).stateAfter;
     if (!state) state = startState(doc.mode);
     else state = copyState(doc.mode, state);
     doc.iter(pos, n, function(line) {
@@ -2837,10 +2837,10 @@ window.CodeMirror = (function() {
 
     // Fetch the parser token for a given character. Useful for hacks
     // that want to inspect the mode state (say, for completion).
-    getTokenAt: function(pos) {
+    getTokenAt: function(pos, precise) {
       var doc = this.doc;
       pos = clipPos(doc, pos);
-      var state = getStateBefore(this, pos.line), mode = this.doc.mode;
+      var state = getStateBefore(this, pos.line, precise), mode = this.doc.mode;
       var line = getLine(doc, pos.line);
       var stream = new StringStream(line.text, this.options.tabSize);
       while (stream.pos < pos.ch && !stream.eol()) {
@@ -2855,10 +2855,10 @@ window.CodeMirror = (function() {
               state: state};
     },
 
-    getStateAfter: function(line) {
+    getStateAfter: function(line, precise) {
       var doc = this.doc;
       line = clipLine(doc, line == null ? doc.first + doc.size - 1: line);
-      return getStateBefore(this, line + 1);
+      return getStateBefore(this, line + 1, precise);
     },
 
     cursorCoords: function(start, mode) {


### PR DESCRIPTION
Because re-highlighting is delayed after an edit, the cached mode state for lines after `doc.frontier` can be invalid. This proposal adds a `precise` option to `getTokenAt()` and `getStateBefore()` that makes them ignore line states after the frontier when trying to find the first valid line.

This doesn't guarantee total accuracy since it will still cut off the search at 100 lines, but it will be at least as accurate as the case where no highlighting had previously been run. (And, in most cases, the thing we're trying to get the token for will be near the last edit point, so it will usually hit the frontier.)

I'm open to other approaches to dealing with this issue, but this seemed the least invasive to me.
