### PR TITLE
Proof-of-concept: lazifying measureLineInner

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1019,8 +1019,6 @@ window.CodeMirror = (function() {
   }
 
   function measureLineInner(cm, line, from, to, oldMeasure) {
-    if (false || (from || to))
-      console.log("Count for: " + from + " -- " + to);
     var display = cm.display, measure = emptyArray(line.text.length);
     var pre = lineContent(cm, line, measure, true, from, to);
 


### PR DESCRIPTION
This is a proof-of-concept that does lazy measurement of long lines and partly addresses issue #1022. 
To be more specific, when one requests measurement information regarding char `N`, it 
measures information for characters in `[N-50, N+50]`. The rendering is done in a following fashion:
- tokens that are before `[N-50, N+50]` range are rendered as-is
- tokens that fall inside `[N-50, N+50]` range are splitted into chars

With this patch rendering a single line with 75k characters gets done in `300ms` instead of `16000ms`.

It's not a finished thing and it has couple of unhandled cases; though this effort should obsolete pull request #1609 as it works fast, doesn't require monospaced font and supports (in theory) wrapped lines.

How do you feel about it?
