### PR TITLE
Add "index" parameter to addLineWidget() to support finer control on the ordering of line widgets.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2952,8 +2952,8 @@ window.CodeMirror = (function() {
       });
     }),
 
-    addLineWidget: operation(null, function(handle, node, options) {
-      return addLineWidget(this, handle, node, options);
+    addLineWidget: operation(null, function(handle, node, options, index) {
+      return addLineWidget(this, handle, node, options, index);
     }),
 
     removeLineWidget: function(widget) { widget.clear(); },
@@ -4074,11 +4074,17 @@ window.CodeMirror = (function() {
     return widget.height = widget.node.offsetHeight;
   }
 
-  function addLineWidget(cm, handle, node, options) {
+  function addLineWidget(cm, handle, node, options, index) {
     var widget = new LineWidget(cm, node, options);
     if (widget.noHScroll) cm.display.alignWidgets = true;
     changeLine(cm, handle, function(line) {
-      (line.widgets || (line.widgets = [])).push(widget);
+      var currWidgets = line.widgets || (line.widgets = []);
+      if (typeof index == 'undefined' || index >= line.widgets.length)
+        currWidgets.push(widget);
+      else if (index == 0)
+        currWidgets.unshift(widget);
+      else
+        currWidgets.splice(index, 0, widget);
       widget.line = line;
       if (!lineIsHidden(cm.doc, line) || widget.showIfHidden) {
         var aboveVisible = heightAtLine(cm, line) < cm.display.scroller.scrollTop;


### PR DESCRIPTION
Previously, addLineWidget() only appends to the end of existing widgets. This change enables splicing line widgets at any specified index.
