### PR TITLE
Smalltalk mode: add support for extended symbol syntax

### DIFF
--- a/mode/smalltalk/smalltalk.js
+++ b/mode/smalltalk/smalltalk.js
@@ -36,8 +36,13 @@ CodeMirror.defineMode('smalltalk', function(config) {
       token = nextString(stream, new Context(nextString, context));
 
     } else if (aChar === '#') {
-      stream.eatWhile(/[^ .\[\]()]/);
-      token.name = 'string-2';
+      if (stream.peek() === '\'') {
+        stream.next();
+        token = nextSymbol(stream, new Context(nextSymbol, context));
+      } else {
+        stream.eatWhile(/[^ .\[\]()]/);
+        token.name = 'string-2';
+      }
 
     } else if (aChar === '$') {
       if (stream.next() === '<') {
@@ -87,6 +92,11 @@ CodeMirror.defineMode('smalltalk', function(config) {
   var nextString = function(stream, context) {
     stream.eatWhile(/[^']/);
     return new Token('string', stream.eat('\'') ? context.parent : context, false);
+  };
+
+  var nextSymbol = function(stream, context) {
+    stream.eatWhile(/[^']/);
+    return new Token('string-2', stream.eat('\'') ? context.parent : context, false);
   };
 
   var nextTemporaries = function(stream, context) {


### PR DESCRIPTION
As noted in fca338be9dd62db07f154277c7b3bd0ade6788c7 by @frankshearar Smalltalk allows convert string to symbol by adding `#` prefix to `'string'` -> `#'string'`.
