### PR TITLE
Propagate StringStream's match() fixes to runmode

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -43,12 +43,14 @@ StringStream.prototype = {
   match: function(pattern, consume, caseInsensitive) {
     if (typeof pattern == "string") {
       var cased = function(str) {return caseInsensitive ? str.toLowerCase() : str;};
-      if (cased(this.string).indexOf(cased(pattern), this.pos) == this.pos) {
+      var substr = this.string.substr(this.pos, pattern.length);
+      if (cased(substr) == cased(pattern)) {
         if (consume !== false) this.pos += pattern.length;
         return true;
       }
     } else {
       var match = this.string.slice(this.pos).match(pattern);
+      if (match && match.index > 0) return null;
       if (match && consume !== false) this.pos += match[0].length;
       return match;
     }

--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -41,12 +41,14 @@ StringStream.prototype = {
   match: function(pattern, consume, caseInsensitive) {
     if (typeof pattern == "string") {
       var cased = function(str) {return caseInsensitive ? str.toLowerCase() : str;};
-      if (cased(this.string).indexOf(cased(pattern), this.pos) == this.pos) {
+      var substr = this.string.substr(this.pos, pattern.length);
+      if (cased(substr) == cased(pattern)) {
         if (consume !== false) this.pos += pattern.length;
         return true;
       }
     } else {
       var match = this.string.slice(this.pos).match(pattern);
+      if (match && match.index > 0) return null;
       if (match && consume !== false) this.pos += match[0].length;
       return match;
     }


### PR DESCRIPTION
Currently, `runMode()` behavior is not consistent across CodeMirror and the runmode addon
