### PR TITLE
highlighting both tags

### DIFF
--- a/addon/edit/matchtags.js
+++ b/addon/edit/matchtags.js
@@ -15,10 +15,9 @@
   });
 
   function clear(cm) {
-    if (cm.state.matchedTag) {
-      cm.state.matchedTag.clear();
-      cm.state.matchedTag = null;
-    }
+    if (cm.state.tagHit) cm.state.tagHit.clear();
+    if (cm.state.tagOther) cm.state.tagOther.clear();
+    cm.state.tagHit = null; cm.state.tagOther = null;    
   }
 
   function doMatchTags(cm) {
@@ -27,14 +26,24 @@
       var cur = cm.getCursor(), range = cm.getViewport();
       range.from = Math.min(range.from, cur.line); range.to = Math.max(cur.line + 1, range.to);
       var match = CodeMirror.findMatchingTag(cm, cur, range);
-      if (cm.state.failedTagMatch = !match) return;
-      var other = match.at == "close" ? match.open : match.close;
-      cm.state.matchedTag = cm.markText(other.from, other.to, {className: "CodeMirror-matchingtag"});
+
+      if(match)
+      {
+        var hit = match.at == "open" ? match.open : match.close;
+        if(hit)cm.state.tagHit = cm.markText(hit.from, hit.to, {className: "CodeMirror-matchingtag"});
+
+        var other = match.at == "close" ? match.open : match.close;
+        if (cm.state.findOtherTag = !other) return;
+        cm.state.tagOther = cm.markText(other.from, other.to, {className: "CodeMirror-matchingtag"});
+      } else {
+        cm.state.findOtherTag = false;
+      }
+
     });
   }
 
   function maybeUpdateMatch(cm) {
-    if (cm.state.failedTagMatch) doMatchTags(cm);
+    if (cm.state.findOtherTag) doMatchTags(cm);
   }
 
   CodeMirror.commands.toMatchingTag = function(cm) {

--- a/addon/fold/xml-fold.js
+++ b/addon/fold/xml-fold.js
@@ -146,11 +146,11 @@
 
     if (start[1]) { // closing tag
       var open = findMatchingOpen(iter, start[2]);
-      return open && {open: open, close: here, at: "close"};
+      return {open: open, close: here, at: "close"};
     } else { // opening tag
       iter = new Iter(cm, to.line, to.ch, range);
       var close = findMatchingClose(iter, start[2]);
-      return close && {open: here, close: close, at: "open"};
+      return {open: here, close: close, at: "open"};
     }
   };
 


### PR DESCRIPTION
Some code changes to highlight both tags. I felt highlighting both tags are necessary when tags needs to be find by scrolling. What do you think ?
