### PR TITLE
Fixing optional parameter syntax for typescript.

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -314,7 +314,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "[") return cont(pushlex("]"), maybeexpression, expect("]"), poplex, me);
   }
   function questionMark(type, value) {
-    if (type.match(:>\)/)) return pass();
+    if (type.match(/:|>|\)/)) return pass();
   	return pass(expression, expect(":"), expression);
   }
   function maybelabel(type) {


### PR DESCRIPTION
Type this in typescript mode (http://codemirror.net/mode/javascript/typescript.html) - the indentation gets broken upon hitting Enter.

```
class Apple {
  call(arg?); <press Enter here>
```
