### PR TITLE
Fix selecting the start of a bidi line

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5456,11 +5456,15 @@ window.CodeMirror = (function() {
 
   function iterateBidiSections(order, from, to, f) {
     if (!order) return f(from, to, "ltr");
+    var found = false;
     for (var i = 0; i < order.length; ++i) {
       var part = order[i];
-      if (part.from < to && part.to > from || from == to && part.to == from)
+      if (part.from < to && part.to > from || from == to && part.to == from) {
         f(Math.max(part.from, from), Math.min(part.to, to), part.level == 1 ? "rtl" : "ltr");
+        found = true;
+      }
     }
+    if (!found) f(from, to, "ltr");
   }
 
   function bidiLeft(part) { return part.level % 2 ? part.to : part.from; }


### PR DESCRIPTION
Hi Marijn,
To reproduce this bug, go to http://codemirror.net/demo/bidi.html and create a selection starting or ending on the left of a bidi line (e.g. from Pos(5, 8) to Pos(10, 0)). drawForLine throws an error because iterateBidiSections is never called, because the selection on that line is empty. Additionally, if the first selection you make triggers this (start on the left), the selected text is removed by readInput, because resetInput & selectInput never got called.
