### PR TITLE
Update to support SPARQL 1.1

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -9,7 +9,9 @@ CodeMirror.defineMode("sparql", function(config) {
                         "isblank", "isliteral", "union", "a"]);
   var keywords = wordRegexp(["base", "prefix", "select", "distinct", "reduced", "construct", "describe",
                              "ask", "from", "named", "where", "order", "limit", "offset", "filter", "optional",
-                             "graph", "by", "asc", "desc"]);
+                             "graph", "by", "asc", "desc", "as", "having", "undef", "values", "group",
+                             "minus", "in", "not", "service", "silent", "using", "insert", "delete",
+                             "data", "copy", "to", "move", "add", "create", "drop", "clear", "load"]);
   var operatorChars = /[*+\-<>=&|]/;
 
   function tokenBase(stream, state) {


### PR DESCRIPTION
SPARQL 1.1 became a W3C recommendation recently, and adds a number of new keywords to the language. The rest of the language is broadly similar, so the only changes necessary to the syntax highlighting tokenizer are the addition of the new keywords.

http://www.w3.org/TR/sparql11-query/
