### PR TITLE
Fixed Fold Marker click not changing folding gutter marker status.

### DIFF
--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -32,7 +32,7 @@
     if (!range || range.cleared) return;
 
     var myWidget = makeWidget(options);
-    CodeMirror.on(myWidget, "mousedown", function() {myRange.clear();});
+    CodeMirror.on(myWidget, "mousedown", function() {myRange.doc.cm.foldCode(myRange.find().from);});
     var myRange = cm.markText(range.from, range.to, {
       replacedWith: myWidget,
       clearOnEnter: true,


### PR DESCRIPTION
Fix for the issue "Clicking CodeMirror-foldmarker does not toggle CodeMirror-foldgutter-folded".
