### PR TITLE
Make setSize faster

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3115,14 +3115,15 @@ window.CodeMirror = (function() {
       updateScrollPos(this, sPos.scrollLeft, sPos.scrollTop);
     }),
 
-    setSize: function(width, height) {
+    setSize: operation(null, function(width, height) {
       function interpret(val) {
         return typeof val == "number" || /^\d+$/.test(String(val)) ? val + "px" : val;
       }
       if (width != null) this.display.wrapper.style.width = interpret(width);
       if (height != null) this.display.wrapper.style.height = interpret(height);
-      this.refresh();
-    },
+      updateScrollPos(this, this.doc.scrollLeft, this.doc.scrollTop);
+      regChange(this, this.display.showingFrom, this.display.showingFrom + 1);
+    }),
 
     operation: function(f){return runInOp(this, f);},
 


### PR DESCRIPTION
In Chrome Developer Tools we have animations for console opening.
During this animation we need to resize code mirror editor instance.
Trying to do that shows that setSize is unacceptably slow for our scenario.

It seems to me that calling refresh() on resize is an overkill.

Right now refresh does 3 things:
1. Clear caches: this should not be needed as the content and the way it is represented did not change. At most we need to reset some flags like maxLineChanged but I am not familiar with the code enough to say for sure.
2. Update scroll position: this is still needed for resize handling
3. regChange call.

It's not clear to me what regChange is supposed to do. 
I understand that we need to make sure sizer has the correct size. Apparently it is enough to call regChange for a single line for that. Is there any problem this might cause?
