### PR TITLE
Workaround for the issue #1474

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1588,11 +1588,14 @@ window.CodeMirror = (function() {
       fastPoll(cm);
     });
     on(d.input, "paste", function() {
-      // add some value to the textarea before paste occur
-      // to workaround webkit bug https://bugs.webkit.org/show_bug.cgi?id=90206
-      if (!d.input.value.length) {
-        d.input.value = "$";
-        d.input.selectionStart = d.input.selectionEnd = 0;
+      // Workaround for webkit bug https://bugs.webkit.org/show_bug.cgi?id=90206
+      // Add a char to the end of textarea before paste occur so that
+      // selection doesn't span to the end of textarea.
+      if (webkit) {
+        var start = d.input.selectionStart, end = d.input.selectionEnd;
+        d.input.value += "$";
+        d.input.selectionStart = start;
+        d.input.selectionEnd = end;
         cm.state.fakedLastChar = true;
       } else {
         cm.state.fakedLastChar = false;


### PR DESCRIPTION
This is a workaround for the issue #1474 and underlying [webkit bug](https://bugs.webkit.org/show_bug.cgi?id=90206).
The problem seems to be happenning in webkit if the selection spans to the very end of the textarea content, so the workaround adds a trailing character to the textarea.
