### PR TITLE
[vim] Fix for ~ movement

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -233,7 +233,8 @@
         operator: 'change',
         motion: 'moveToEol', motionArgs: { inclusive: true },
         operatorMotionArgs: { visualLine: true }},
-    { keys: ['~'], type: 'operatorMotion', operator: 'swapcase',
+    { keys: ['~'], type: 'operatorMotion',
+        operator: 'swapcase', operatorArgs: { shouldMoveCursor: true },
         motion: 'moveByCharacters', motionArgs: { forward: true }},
     // Actions
     { keys: ['<C-i>'], type: 'action', action: 'jumpListWalk',
@@ -1551,7 +1552,7 @@
         cm.setCursor(curStart);
         cm.setCursor(motions.moveToFirstNonWhiteSpaceCharacter(cm));
       },
-      swapcase: function(cm, _operatorArgs, _vim, curStart, curEnd, curOriginal) {
+      swapcase: function(cm, operatorArgs, _vim, curStart, curEnd, curOriginal) {
         var toSwap = cm.getRange(curStart, curEnd);
         var swapped = '';
         for (var i = 0; i < toSwap.length; i++) {
@@ -1560,7 +1561,9 @@
               character.toUpperCase();
         }
         cm.replaceRange(swapped, curStart, curEnd);
-        cm.setCursor(curOriginal);
+        if (!operatorArgs.shouldMoveCursor) {
+          cm.setCursor(curOriginal);
+        }
       },
       yank: function(cm, operatorArgs, _vim, curStart, curEnd, curOriginal) {
         vimGlobalState.registerController.pushText(

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1023,6 +1023,11 @@ testVim('Y', function(cm, vim, helpers) {
   is(!register.linewise);
   helpers.assertCursorAt(0, 3);
 }, { value: ' word1\nword2\n word3' });
+testVim('~', function(cm, vim, helpers) {
+  helpers.doKeys('3', '~');
+  eq('ABCdefg', cm.getValue());
+  helpers.assertCursorAt(0, 3);
+}, { value: 'abcdefg' });
 
 // Action tests
 testVim('ctrl-a', function(cm, vim, helpers) {


### PR DESCRIPTION
Fix for https://github.com/marijnh/CodeMirror/issues/1685.

~ will now move the cursor forward. @misterbeegee let me know if the fix suffices.
