### PR TITLE
Adding slightly nicer auto-indentation in xml/html mode

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -134,28 +134,6 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
     return closure;
   }
 
-  function inSingleQuoteAttribute(stream, state) {
-    while (!stream.eol()) {
-      if (stream.next() == "\'") {
-        state.tokenize = inTag;
-        delete state.stringStartCol;
-        break;
-      }
-    }
-    return "string";
-  }
-
-  function inDoubleQuoteAttribute(stream, state) {
-    while (!stream.eol()) {
-      if (stream.next() == "\"") {
-        state.tokenize = inTag;
-        delete state.stringStartCol;
-        break;
-      }
-    }
-    return "string";
-  }
-
   function inBlock(style, terminator) {
     return function(stream, state) {
       while (!stream.eol()) {


### PR DESCRIPTION
These are two changes to how html and xml get indented. The first is that attribute names on a new line will get indented to be in a line with the first attribute. For example, if you start out with this

``` html
<div class="..."
```

then press enter at the end and type 'style="...">' to get

``` html
<div class="..."
     style="...">
```

The option added controls whether to use the new attr name indentation algorithm or the old one, defaulting to the new.

The second change indents multi-line string attr values. For example, if you start with

``` html
<div style="height: 10px;
```

then press enter at the end and type 'width: 10px">' you'll get

``` html
<div style="height: 10px;
            width: 10px">
```

This seems like a generally nicer way of doing things, so I didn't put in an option for disabling it.

Two tests fail with these changes, but I checked and they seem to also be failing at your head. I'm pretty new to working with github, so maybe I didn't check it properly and my change did cause the failures. Hope you can let me know if there are problems! Thanks :)
