### PR TITLE
Workaround for issue #1474

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1442,6 +1442,10 @@ window.CodeMirror = (function() {
   function readInput(cm) {
     var input = cm.display.input, prevInput = cm.display.prevInput, doc = cm.doc, sel = doc.sel;
     if (!cm.state.focused || hasSelection(input) || isReadOnly(cm) || cm.state.disableInput) return false;
+    if (cm.state.pasteIncoming && cm.state.fakedLastChar) {
+      input.value = input.value.substring(0, input.value.length - 1);
+      cm.state.fakedLastChar = false;
+    }
     var text = input.value;
     if (text == prevInput && posEq(sel.from, sel.to)) return false;
     if (ie && !ie_lt9 && cm.display.inputHasSelection === text) {
@@ -1594,6 +1598,18 @@ window.CodeMirror = (function() {
       fastPoll(cm);
     });
     on(d.input, "paste", function() {
+      // Workaround for webkit bug https://bugs.webkit.org/show_bug.cgi?id=90206
+      // Add a char to the end of textarea before paste occur so that
+      // selection doesn't span to the end of textarea.
+      if (webkit) {
+        var start = d.input.selectionStart, end = d.input.selectionEnd;
+        d.input.value += "$";
+        d.input.selectionStart = start;
+        d.input.selectionEnd = end;
+        cm.state.fakedLastChar = true;
+      } else {
+        cm.state.fakedLastChar = false;
+      }
       cm.state.pasteIncoming = true;
       fastPoll(cm);
     });


### PR DESCRIPTION
This is a workaround for the issue #1474 and underlying webkit bug.
The problem seems to be happenning in webkit if the selection spans to the very end of the textarea content, so the workaround adds a trailing character to the textarea.

P.S. This is the corrected version of the pull request https://github.com/marijnh/CodeMirror/pull/1683
