### PR TITLE
fix .changed() for bookmarks

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3745,6 +3745,7 @@ window.CodeMirror = (function() {
   TextMarker.prototype.changed = function() {
     var pos = this.find(), cm = this.doc.cm;
     if (!pos || !cm) return;
+    if (this.type == "bookmark") pos = {from: pos, to: pos};
     var line = getLine(this.doc, pos.from.line);
     clearCachedMeasurement(cm, line);
     if (pos.from.line >= cm.display.showingFrom && pos.from.line < cm.display.showingTo) {


### PR DESCRIPTION
Calling .changed() on a bookmark throws because bookmarks do not have from and to. This is a naive solution, but it seems like a better solution would be to have bookmarks return their position in the same way that all other textmarkers do. That would definitely be an end-user breaking change, though.
