### PR TITLE
Multiple bookmarks at a point location hides all but the last

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4438,7 +4438,7 @@ window.CodeMirror = (function() {
       if (nextChange == pos) { // Update current marker set
         spanStyle = spanEndStyle = spanStartStyle = title = "";
         collapsed = null; nextChange = Infinity;
-        var foundBookmark = null;
+        var foundBookmarks = [];
         for (var j = 0; j < spans.length; ++j) {
           var sp = spans[j], m = sp.marker;
           if (sp.from <= pos && (sp.to == null || sp.to > pos)) {
@@ -4452,14 +4452,18 @@ window.CodeMirror = (function() {
           } else if (sp.from > pos && nextChange > sp.from) {
             nextChange = sp.from;
           }
-          if (m.type == "bookmark" && sp.from == pos && m.replacedWith) foundBookmark = m;
+          if (m.type == "bookmark" && sp.from == pos && m.replacedWith) foundBookmarks.push(m);
         }
         if (collapsed && (collapsed.from || 0) == pos) {
           buildCollapsedSpan(builder, (collapsed.to == null ? len : collapsed.to) - pos,
                              collapsed.marker, collapsed.from == null);
           if (collapsed.to == null) return collapsed.marker.find();
         }
-        if (foundBookmark && !collapsed) buildCollapsedSpan(builder, 0, foundBookmark);
+        if (foundBookmarks.length && !collapsed) {
+          for(var i in foundBookmarks){
+            buildCollapsedSpan(builder, 0, foundBookmarks[i]);
+          }
+        }
       }
       if (pos >= len) break;
 


### PR DESCRIPTION
Since bookmarks are point based and do not replace any text, they cannot technically overlap eachother and there's no reason multiple can't be shown at a point location. The current implementation of insertLineContent prevents them from being shown by assuming there's only ever one. This is another naive solution that has one problem: when there are two (or more) bookmarks the cursor is positioned in between them (as opposed to before all of them) when the insertLeft option is set true.
