### PR TITLE
Fix race condition with text pasting

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1601,14 +1601,12 @@ window.CodeMirror = (function() {
       // Workaround for webkit bug https://bugs.webkit.org/show_bug.cgi?id=90206
       // Add a char to the end of textarea before paste occur so that
       // selection doesn't span to the end of textarea.
-      if (webkit) {
+      if (webkit && !cm.state.fakedLastChar) {
         var start = d.input.selectionStart, end = d.input.selectionEnd;
         d.input.value += "$";
         d.input.selectionStart = start;
         d.input.selectionEnd = end;
         cm.state.fakedLastChar = true;
-      } else {
-        cm.state.fakedLastChar = false;
       }
       cm.state.pasteIncoming = true;
       fastPoll(cm);


### PR DESCRIPTION
This patch fixes race condition with text pasting:
- Copy single word
- Press Ctrl-V and keep it pressed for some time; you'll see $ signs popping here and there

The issue was introduces by https://github.com/marijnh/CodeMirror/pull/1708
