### PR TITLE
Support scrolling beyond last line as an option.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -119,8 +119,10 @@ window.CodeMirror = (function() {
     // Wraps everything that needs to exist inside the vertically-padded coordinate system
     d.lineSpace = elt("div", [d.measure, d.selectionDiv, d.lineDiv, d.cursor, d.otherCursor],
                          null, "position: relative; outline: none");
+    // Adds bottom padding for scrolling beyond document end.
+    d.lines = elt("div", [d.lineSpace], "CodeMirror-lines");
     // Moved around its parent to cover visible view
-    d.mover = elt("div", [elt("div", [d.lineSpace], "CodeMirror-lines")], null, "position: relative");
+    d.mover = elt("div", [d.lines], null, "position: relative");
     // Set to the height of the text, causes scrolling
     d.sizer = elt("div", [d.mover], "CodeMirror-sizer");
     // D is needed because behavior of elts with overflow: auto and padding is inconsistent across browsers
@@ -321,6 +323,18 @@ window.CodeMirror = (function() {
   // content. Optionally force a scrollTop.
   function updateScrollbars(cm) {
     var d = cm.display, docHeight = cm.doc.height;
+    if (cm.options.scrollBeyondLastLine) {
+      var forceV = cm.doc.size > 1;
+      if (!forceV) d.lines.style.paddingBottom = "";  
+      else {
+        // Force vertical scrollbar first to update scroller's clientHeight in case horizontal scrollbar is needed.
+        var scrollBarShown = d.scroller.scrollHeight > (d.scroller.clientHeight + 1);
+        if (!scrollBarShown)
+          d.lines.style.paddingBottom = d.scroller.clientHeight + "px";
+        var paddingBottom = d.scroller.clientHeight - scrollerCutOff - (docHeight - heightAtLine(cm, getLine(cm.doc, cm.doc.size - 1)));
+        d.lines.style.paddingBottom = paddingBottom + "px";
+      }
+    }
     var totalHeight = docHeight + paddingVert(d);
     d.sizer.style.minHeight = d.heightForcer.style.top = totalHeight + "px";
     d.gutters.style.height = Math.max(totalHeight, d.scroller.clientHeight - scrollerCutOff) + "px";
@@ -3129,6 +3143,7 @@ window.CodeMirror = (function() {
       }
       if (width != null) this.display.wrapper.style.width = interpret(width);
       if (height != null) this.display.wrapper.style.height = interpret(height);
+      updateScrollPos(this, this.doc.scrollLeft, this.doc.scrollTop);
       if (this.options.lineWrapping)
         this.display.measureLineCache.length = this.display.measureLineCachePos = 0;
       this.curOp.forceUpdate = true;


### PR DESCRIPTION
This is an implementation of scrolling beyond last line based on setting padding-bottom for CodeMirror-lines element as was suggested in https://groups.google.com/forum/#!searchin/codemirror/CodeMirror-lines/codemirror/oAbm-FQtKv4/im8xpwysFhsJ

Padding bottom is always added if there is more than one line in the document.
Adding scroll in case of only one line seems awkward and the separate code path is needed to workaround padding-top set for the CodeMirror-lines element.
