### PR TITLE
Fix visual mode downwards movement bug

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1105,9 +1105,9 @@
               if (cursorIsBefore(selectionStart, selectionEnd)) {
                 selectionStart.ch = 0;
 
-                var lineCount = cm.lineCount();
-                if (selectionEnd.line >= lineCount) {
-                  selectionEnd.line = lineCount - 1;
+                var lastLine = cm.lastLine();
+                if (selectionEnd.line > lastLine) {
+                  selectionEnd.line = lastLine;
                 }
                 selectionEnd.ch = lineLength(cm, selectionEnd.line);
               } else {


### PR DESCRIPTION
Previously, if you tried to move further down the document than exist
the cursor would not move down.  This sets selectionEnd.line to be
no greater than the total length of the document.
