### PR TITLE
[rst-mode] LaTex/Python inner mode glitches

### DIFF
--- a/mode/rst/rst.js
+++ b/mode/rst/rst.js
@@ -441,13 +441,7 @@ CodeMirror.defineMode('rst-base', function (config) {
                 return null;
             }
 
-            try {
-                return state.ctx.mode.token(stream, state.ctx.local);
-            } catch (ex) {
-                change(state, to_normal);
-                console.error (ex);
-                return null;
-            }
+            return state.ctx.mode.token(stream, state.ctx.local);
         }
 
         change(state, to_normal);


### PR DESCRIPTION
The were some minor issues w.r.t. where exactly an `stex` or `python` inner mode starts and where the outer `rst` mode resumes; fixed.
