### PR TITLE
Fix linenumbers when undoing multiple changes

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -453,7 +453,7 @@ window.CodeMirror = (function() {
     var positionsChangedFrom = Infinity;
     if (cm.options.lineNumbers)
       for (var i = 0; i < changes.length; ++i)
-        if (changes[i].diff) { positionsChangedFrom = changes[i].from; break; }
+        if (changes[i].diff && changes[i].from < positionsChangedFrom) { positionsChangedFrom = changes[i].from; }
 
     var end = doc.first + doc.size;
     var from = Math.max(visible.from - cm.options.viewportMargin, doc.first);


### PR DESCRIPTION
To reproduce, for example create two selections on different lines, press enter twice and undo once.
