### PR TITLE
Fix windows detection

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -24,7 +24,7 @@ window.CodeMirror = (function() {
   // This is woefully incomplete. Suggestions for alternative methods welcome.
   var mobile = ios || /Android|webOS|BlackBerry|Opera Mini|Opera Mobi|IEMobile/i.test(navigator.userAgent);
   var mac = ios || /Mac/.test(navigator.platform);
-  var windows = /windows/i.test(navigator.platform);
+  var windows = /win/i.test(navigator.platform);
 
   var opera_version = opera && navigator.userAgent.match(/Version\/(\d*\.\d*)/);
   if (opera_version) opera_version = Number(opera_version[1]);


### PR DESCRIPTION
This changes the default of `rtlMoveVisually` to false on windows. I don't know if that's a good thing, but at least it's consistent :)
