### PR TITLE
Numbers are being parsed slightly incorrectly.

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -27,7 +27,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       return null;
     }
     if (/\d/.test(ch)) {
-      stream.eatWhile(/[\w\.]/);
+      stream.eatWhile(/[\d\.]/);
       return "number";
     }
     if (ch == "/") {


### PR DESCRIPTION
because in given code number is anything that start with a number (0-9) and then continues with any alphanumeric character or dot (a-zA-z0-9_.). I.e. 6542zvasdfxzcv would be treated as a number though it certainly is not a number.
