### PR TITLE
Check if "cur" is null in patchDisplay()

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -618,7 +618,7 @@ window.CodeMirror = (function() {
       if (nextIntact && nextIntact.to == lineN) nextIntact = intact.shift();
       if (lineIsHidden(cm.doc, line)) {
         if (line.height != 0) updateLineHeight(line, 0);
-        if (line.widgets && cur.previousSibling) for (var i = 0; i < line.widgets.length; ++i) {
+        if (line.widgets && cur && cur.previousSibling) for (var i = 0; i < line.widgets.length; ++i) {
           var w = line.widgets[i];
           if (w.showIfHidden) {
             var prev = cur.previousSibling;


### PR DESCRIPTION
Not exactly sure if cur could be null at all. But in a use case where a line widget is added above the first line of the document, cur.previousSibling threw an NPE.
