### PR TITLE
[merge addon] Add highlightDifferences option and method

### DIFF
--- a/demo/merge.html
+++ b/demo/merge.html
@@ -45,15 +45,14 @@ addon provides an interface for displaying and merging diffs,
 either <span class=clicky onclick="initUI(2)">two-way</span>
 or <span class=clicky onclick="initUI(3)">three-way</span>. The left
 (or center) pane is editable, and the differences with the other
-pane(s) are shown live as you edit it.</p>
+pane(s) are <span class=clicky onclick="toggleDifferences()">optionally</span> shown live as you edit it.</p>
 
 <p>This addon depends on
 the <a href="https://code.google.com/p/google-diff-match-patch/">google-diff-match-patch</a>
 library to compute the diffs.</p>
 
 <script>
-var value, orig1, orig2, dv;
-
+var value, orig1, orig2, dv, hilight= true;
 function initUI(panes) {
   if (value == null) return;
   var target = document.getElementById("view");
@@ -63,8 +62,14 @@ function initUI(panes) {
     origLeft: panes == 3 ? orig1 : null,
     orig: orig2,
     lineNumbers: true,
-    mode: "text/html"
+    mode: "text/html",
+    highlightDifferences: hilight
   });
+}
+
+function toggleDifferences() {
+  hilight= !hilight;
+  dv.highlightDifferences( hilight );
 }
 
 window.onload = function() {


### PR DESCRIPTION
_Note, I'm not expecting this changeset as it currently stands to be the best approach, for example I suspect line 60 is very odd, but it 'works' (I suspect at quite a great performance cost) and I was going to apply the same 'options' based approach used in the core CodeMirror object, but was put off as I'd basically have to copy'n'paste the same code verbatim, the contribution guidelines that I skimmed did not appear to suggest how one should properly do options in this sort of scenario :/ (sorry)_

Provides new option (highlightDifferences) and method highlightDifferences(bool)
to the MergeView plugin.

If true (or undefined) the original behaviour is maintained, which is to show
the differences (line highlighting and gutter graphics), if false then
the changes will not be shown.

Calling the method causes the visual change to occur 'immediately'

Signed-off-by: ciaranj ciaranj@gmail.com
