### PR TITLE
Add "gutterContextMenu" event to capture context menu events in gutters

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -502,6 +502,16 @@
       argument, and the raw <code>mousedown</code> event object as
       fourth argument.</dd>
 
+      <dt id="event_gutterContextMenu"><code><strong>"gutterContextMenu"</strong> (instance: CodeMirror, line: integer, gutter: string, contextMenu: Event: Event)</code></dt>
+      <dd>Fires when the editor gutter (the line-number area)
+      receives a <code>contextmenu</code> event. Will pass the editor
+      instance as first argument, the (zero-based) number of the line
+      that was clicked as second argument, the CSS class of the
+      gutter that was clicked as third argument, and the raw
+      <code>contextmenu</code> mouse event object as fourth argument.
+      You can <code>preventDefault</code> the event, to signal that
+      CodeMirror should do no further handling.</dd>
+
       <dt id="event_focus"><code><strong>"focus"</strong> (instance: CodeMirror)</code></dt>
       <dd>Fires whenever the editor is focused.</dd>
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1800,15 +1800,8 @@ window.CodeMirror = (function() {
     on(document, "mouseup", up);
   }
 
-  function clickInGutter(cm, e) {
+  function gutterEvent(cm, e, gutterEvent, mX, mY, signaler) {
     var display = cm.display;
-    try { var mX = e.clientX, mY = e.clientY; }
-    catch(e) { return false; }
-
-    if (mX >= Math.floor(getRect(display.gutters).right)) return false;
-    e_preventDefault(e);
-    if (!hasHandler(cm, "gutterClick")) return true;
-
     var lineBox = getRect(display.lineDiv);
     if (mY > lineBox.bottom) return true;
     mY -= lineBox.top - display.viewOffset;
@@ -1818,10 +1811,33 @@ window.CodeMirror = (function() {
       if (g && getRect(g).right >= mX) {
         var line = lineAtHeight(cm.doc, mY);
         var gutter = cm.options.gutters[i];
-        signalLater(cm, "gutterClick", cm, line, gutter, e);
-        break;
+        return signaler(cm, gutterEvent, cm, line, gutter, e);
       }
     }
+  }
+
+  function contextMenuInGutter(cm, e) {
+    if (!hasHandler(cm, "gutterContextMenu")) return false;
+
+    try { var mX = e.clientX, mY = e.clientY; }
+    catch(e) { return false; }
+    if (mX >= Math.floor(getRect(cm.display.gutters).right)) return false;
+
+    return gutterEvent(cm, e, "gutterContextMenu", mX, mY, function() {
+      signal.apply(null, arguments);
+      return e_defaultPrevented(e);
+    });
+  }
+
+  function clickInGutter(cm, e) {
+    try { var mX = e.clientX, mY = e.clientY; }
+    catch(e) { return false; }
+
+    if (mX >= Math.floor(getRect(cm.display.gutters).right)) return false;
+    e_preventDefault(e);
+    if (!hasHandler(cm, "gutterClick")) return true;
+
+    gutterEvent(cm, e, "gutterClick", mX, mY, signalLater);
     return true;
   }
 
@@ -2144,6 +2160,7 @@ window.CodeMirror = (function() {
     if (signalDOMEvent(cm, e, "contextmenu")) return;
     var display = cm.display, sel = cm.doc.sel;
     if (eventInWidget(display, e)) return;
+    if (contextMenuInGutter(cm, e)) return;
 
     var pos = posFromMouse(cm, e), scrollPos = display.scroller.scrollTop;
     if (!pos || opera) return; // Opera is difficult.


### PR DESCRIPTION
In Web Inspector we use `gutterClick` to add/remove breakpoints. We would also like to also handle `contextmenu` events in the gutter, with the same information that gutterClick gets (lineNumber, gutterClass, event).

This would let us do a couple of things that would be harder / error prone otherwise:
- Adding a breakpoint / widget by right clicking the gutter, with the real contextmenu event

![add-breakpoint](https://f.cloud.github.com/assets/11351/1005670/4fe71ac0-0ac2-11e3-8d6d-8462d0150a0b.png)
- Shared code path for contextmenu when gutter items do exist no matter the widget

![edit-breakpoint](https://f.cloud.github.com/assets/11351/1005671/5020830a-0ac2-11e3-94a8-3bd8e1eefbc3.png)
