### PR TITLE
Main CSS file: Clean-up and fix lint warnings

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -215,8 +215,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow: auto;
 }
 
-.CodeMirror-widget {
-}
+.CodeMirror-widget {}
 
 .CodeMirror-wrap .CodeMirror-scroll {
   overflow-x: hidden;
@@ -224,7 +223,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
 .CodeMirror-measure {
   position: absolute;
-  width: 100%; height: 0px;
+  width: 100%;
+  height: 0;
   overflow: hidden;
   visibility: hidden;
 }


### PR DESCRIPTION
Use 0 instead of 0px, clean-up two line breaks, to fix lint warning;
Three empty CSS blocks could also be removed.
