### PR TITLE
Allow linter to run on windows

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-var lint = require("../test/lint/lint");
+var lint = require("../test/lint/lint")
+   ,path = require("path");
 
 if (process.argv.length > 2) {
   lint.checkDir(process.argv[2]);
 } else {
-  process.chdir(__dirname.slice(0, __dirname.lastIndexOf("/")));
+  process.chdir(path.resolve(__dirname, '..'));
   lint.checkDir("lib");
   lint.checkDir("mode");
   lint.checkDir("addon");


### PR DESCRIPTION
Node provides some cross-platform utility methods to enable safe
path traversal.

This change merely swaps out a hardcoded '/' (unix path separator)
to use one of these methods.

An alternative strategy would be to use the constant 'path.sep' but
this felt 'cleaner'.

Signed-off-by: ciaranj ciaranj@gmail.com
