### PR TITLE
[merge addon] Shows differences when the non-edit pane is updated

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -71,13 +71,15 @@
       clearTimeout(debounceChange);
       debounceChange = setTimeout(update, slow == true ? 250 : 100);
     }
-    dv.edit.on("change", function() {
+    function change() {
       if (!dv.diffOutOfDate) {
         dv.diffOutOfDate = true;
         edit.from = edit.to = orig.from = orig.to = 0;
       }
       set(true);
-    });
+    }
+    dv.edit.on("change", change);
+    dv.orig.on("change", change);
     dv.edit.on("viewportChange", set);
     dv.orig.on("viewportChange", set);
     update();


### PR DESCRIPTION
Previous behaviour was to only update the displayed differences if
the edit pane was modified.  There exists use-cases such that the
differences should be updated when any of the panes change.

I don't expect this to introduce any performance regressions due
to the existing debounce code within the update function.

Signed-off-by: ciaranj ciaranj@gmail.com
