### PR TITLE
[merge addon] Allows disabling of the 'copy buttons'

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -31,10 +31,18 @@
       this.diff = getDiff(orig, options.value);
       this.diffOutOfDate = false;
 
+      this.showCopyButtons = options.showCopyButtons !== false;
       this.showDifferences = options.showDifferences !== false;
       this.forceUpdate = registerUpdate(this);
       setScrollLock(this, true, false);
       registerScroll(this);
+    },
+    setShowCopyButtons: function(val) {
+      val = val !== false;
+      if (val != this.showCopyButtons) {
+        this.showCopyButtons = val;
+        this.forceUpdate("full");
+      }
     },
     setShowDifferences: function(val) {
       val = val !== false;
@@ -257,11 +265,13 @@
               "d", "M -1 " + topRpx + curveTop + " L " + (w + 2) + " " + botLpx + curveBot + " z",
               "class", dv.classes.connect);
       }
-      var copy = dv.copyButtons.appendChild(elt("div", dv.type == "left" ? "\u21dd" : "\u21dc",
-                                                "CodeMirror-merge-copy"));
-      copy.title = "Revert chunk";
-      copy.chunk = {topEdit: topEdit, botEdit: botEdit, topOrig: topOrig, botOrig: botOrig};
-      copy.style.top = top + "px";
+      if(dv.showCopyButtons) {
+        var copy = dv.copyButtons.appendChild(elt("div", dv.type == "left" ? "\u21dd" : "\u21dc",
+                                                  "CodeMirror-merge-copy"));
+        copy.title = "Revert chunk";
+        copy.chunk = {topEdit: topEdit, botEdit: botEdit, topOrig: topOrig, botOrig: botOrig};
+        copy.style.top = top + "px";
+      }
     });
   }
 
@@ -345,6 +355,10 @@
     setShowDifferences: function(val) {
       if (this.right) this.right.setShowDifferences(val);
       if (this.left) this.left.setShowDifferences(val);
+    },
+    setShowCopyButtons: function(val) {
+      if (this.right) this.right.setShowCopyButtons(val);
+      if (this.left) this.left.setShowCopyButtons(val);
     }
   };
 

--- a/demo/merge.html
+++ b/demo/merge.html
@@ -45,14 +45,15 @@ addon provides an interface for displaying and merging diffs,
 either <span class=clicky onclick="initUI(2)">two-way</span>
 or <span class=clicky onclick="initUI(3)">three-way</span>. The left
 (or center) pane is editable, and the differences with the other
-pane(s) are <span class=clicky onclick="toggleDifferences()">optionally</span> shown live as you edit it.</p>
+pane(s) are <span class=clicky onclick="toggleDifferences()">optionally</span> shown live as you edit it.
+Functionality is also provided to allow you to <span class=clicky onclick="toggleCopyButtons()">click</span> to revert changes in the edited pane</p>
 
 <p>This addon depends on
 the <a href="https://code.google.com/p/google-diff-match-patch/">google-diff-match-patch</a>
 library to compute the diffs.</p>
 
 <script>
-var value, orig1, orig2, dv, hilight= true;
+var value, orig1, orig2, dv, hilight= true, copyButtons= true;
 function initUI(panes) {
   if (value == null) return;
   var target = document.getElementById("view");
@@ -63,12 +64,16 @@ function initUI(panes) {
     orig: orig2,
     lineNumbers: true,
     mode: "text/html",
-    highlightDifferences: hilight
+    showDifferences: hilight,
+    showCopyButtons: copyButtons
   });
 }
 
 function toggleDifferences() {
   dv.setShowDifferences(hilight = !hilight);
+}
+function toggleCopyButtons() {
+  dv.setShowCopyButtons(copyButtons = !copyButtons);
 }
 
 window.onload = function() {


### PR DESCRIPTION
Whilst a useful feature, for my usage I would _like_ to be able to hide them :) 

I've followed the same pattern that you laid out in the changes to my original 'ShowDifferences' patch,
hopefully this is ok.

Signed-off-by: ciaranj ciaranj@gmail.com
