### PR TITLE
Don't highlight properties named "off"/"on" as errors

### DIFF
--- a/mode/coffeescript/coffeescript.js
+++ b/mode/coffeescript/coffeescript.js
@@ -33,7 +33,7 @@ CodeMirror.defineMode('coffeescript', function(conf) {
 
     var stringPrefixes = new RegExp("^('{3}|\"{3}|['\"])");
     var regexPrefixes = new RegExp("^(/{3}|/)");
-    var commonConstants = ['Infinity', 'NaN', 'undefined', 'null', 'true', 'false', 'on', 'off', 'yes', 'no'];
+    var commonConstants = ['Infinity', 'NaN', 'undefined', 'null', 'true', 'false', 'yes', 'no'];
     var constants = wordRegexp(commonConstants);
 
     // Tokenizers


### PR DESCRIPTION
Highlighting properties named `on` and `off` as errors is SUPER annoying when using [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)s since they have [properties named `on`](http://nodejs.org/api/events.html#events_emitter_on_event_listener) and [sometimes `off`](https://github.com/hij1nx/EventEmitter2#emitteroffevent-listener).

Before

![screen shot 2013-08-25 at 12 23 13 am](https://f.cloud.github.com/assets/13998/1020828/a1043920-0cc9-11e3-99f3-270132f3d966.png)

After

![screen shot 2013-08-25 at 12 22 57 am](https://f.cloud.github.com/assets/13998/1020829/a55a9f8c-0cc9-11e3-90e0-f6a0ce81a614.png)
