### PR TITLE
Reduce initial layout time

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -49,6 +49,7 @@ window.CodeMirror = (function() {
 
     var docStart = typeof options.value == "string" ? 0 : options.value.first;
     var display = this.display = makeDisplay(place, docStart);
+    getSelection().empty();
     display.wrapper.CodeMirror = this;
     updateGutters(this);
     if (options.autofocus && !mobile) focusInput(this);


### PR DESCRIPTION
This suggestion comes from @achicu in Brackets issue https://github.com/adobe/brackets/issues/4757.

In Brackets on Win7, I am seeing an reduction of ~400ms on initial page load.
