### PR TITLE
CSS lint addon with https://github.com/stubbornella/csslint

### DIFF
--- a/addon/lint/css-lint.js
+++ b/addon/lint/css-lint.js
@@ -1,0 +1,16 @@
+// Depends on csslint.js from https://github.com/stubbornella/csslint
+
+CodeMirror.registerHelper("lint", "css", function(text) {
+  var found = [];
+  var results = CSSLint.verify(text), messages = results.messages, message = null;
+  for ( var i = 0; i < messages.length; i++) {
+    message = messages[i];
+    var startLine = message.line -1, endLine = message.line -1, startCol = message.col -1, endCol = message.col;
+    found.push({from: CodeMirror.Pos(startLine, startCol),
+      to: CodeMirror.Pos(endLine, endCol),
+      message: message.message,
+      severity : message.type});  
+  }
+  return found;
+});
+CodeMirror.cssValidator = CodeMirror.lint.css; // deprecated

--- a/demo/lint.html
+++ b/demo/lint.html
@@ -8,11 +8,15 @@
 <link rel="stylesheet" href="../addon/lint/lint.css">
 <script src="../lib/codemirror.js"></script>
 <script src="../mode/javascript/javascript.js"></script>
+<script src="../mode/css/css.js"></script>
 <script src="http://ajax.aspnetcdn.com/ajax/jshint/r07/jshint.js"></script>
 <script src="https://rawgithub.com/zaach/jsonlint/79b553fb65c192add9066da64043458981b3972b/lib/jsonlint.js"></script>
+<script src="https://rawgithub.com/stubbornella/csslint/master/release/csslint.js"></script>
+<script src="../addon/lint/lint.js"></script>
 <script src="../addon/lint/lint.js"></script>
 <script src="../addon/lint/javascript-lint.js"></script>
 <script src="../addon/lint/json-lint.js"></script>
+<script src="../addon/lint/css-lint.js"></script>
 <style type="text/css">
       .CodeMirror {border: 1px solid black;}
     </style>
@@ -82,6 +86,66 @@ function updateHints() {
 ]
 </textarea></p>
 
+    <p><textarea id="code-css">@charset "UTF-8";
+
+@import url("booya.css") print, screen;
+@import "whatup.css" screen;
+@import "wicked.css";
+
+/*Error*/
+@charset "UTF-8";
+
+
+@namespace "http://www.w3.org/1999/xhtml";
+@namespace svg "http://www.w3.org/2000/svg";
+
+/*Warning: empty ruleset */
+.foo {
+}
+
+h1 {
+    font-weight: bold;
+}
+
+/*Warning: qualified heading */
+.foo h1 {
+    font-weight: bold;
+}
+
+/*Warning: adjoining classes */
+.foo.bar {
+    zoom: 1;
+}
+
+li.inline {
+    width: 100%;  /*Warning: 100% can be problematic*/
+}
+
+li.last {
+  display: inline;
+  padding-left: 3px !important;
+  padding-right: 3px;
+  border-right: 0px;
+}
+
+@media print {
+    li.inline {
+      color: black;
+    }
+}
+
+@page {
+  margin: 10%;
+  counter-increment: page;
+
+  @top-center {
+    font-family: sans-serif;
+    font-weight: bold;
+    font-size: 2em;
+    content: counter(page);
+  }
+}
+</textarea></p>
 <script>
   var editor = CodeMirror.fromTextArea(document.getElementById("code-js"), {
     lineNumbers: true,
@@ -93,6 +157,13 @@ function updateHints() {
   var editor_json = CodeMirror.fromTextArea(document.getElementById("code-json"), {
     lineNumbers: true,
     mode: "application/json",
+    gutters: ["CodeMirror-lint-markers"],
+    lint: true
+  });
+  
+  var editor_css = CodeMirror.fromTextArea(document.getElementById("code-css"), {
+    lineNumbers: true,
+    mode: "css",
     gutters: ["CodeMirror-lint-markers"],
     lint: true
   });


### PR DESCRIPTION
Here a patch which provides a CSS Lint addon which uses https://github.com/stubbornella/csslint

This addon highlighted only one character when there is an error/warn message because the CSSLint provides just line/col info. 

I have created an issue for this problem https://github.com/stubbornella/csslint/issues/411 
If CSSLint fixes the problem I will do a patch for this CSS lint addon to highlight the whole word (and not only one character).
