### PR TITLE
Replace ‘^’ back-to-top link with ‘↑’ in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@
 - [Submitting bug reports](#submitting-bug-reports-)
 - [Contributing code](#contributing-code-)
 
-## Getting help [^](#how-to-contribute)
+## Getting help [↑](#how-to-contribute)
 
 Community discussion, questions, and informal bug reporting is done on the
 [CodeMirror Google group](http://groups.google.com/group/codemirror).
 
-## Submitting bug reports [^](#how-to-contribute)
+## Submitting bug reports [↑](#how-to-contribute)
 
 The preferred way to report bugs is to use the
 [GitHub issue tracker](http://github.com/marijnh/CodeMirror/issues). Before
@@ -45,7 +45,7 @@ should be asked on the
   [jsbin.com](http://jsbin.com/ihunin/edit), enter it there, press save, and
   include the resulting link in your bug report.
 
-## Contributing code [^](#how-to-contribute)
+## Contributing code [↑](#how-to-contribute)
 
 - Make sure you have a [GitHub Account](https://github.com/signup/free)
 - Fork [CodeMirror](https://github.com/marijnh/CodeMirror/)


### PR DESCRIPTION
To make it clearer what that link does. At first I thought ‘^’ was a permalink for the heading it was next to. ‘↑’ is less likely to cause this confusion.
