### PR TITLE
Start search from dialog using common search keys

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -26,11 +26,12 @@
     if (inp) {
       CodeMirror.on(inp, "keydown", function(e) {
         if (options && options.onKeyDown && options.onKeyDown(e, inp.value, close)) { return; }
-        if (e.keyCode == 13 || e.keyCode == 27) {
+        var doSearch = e.keyCode == 13 || e.keyCode == 27 || e.keyCode == 114 || (e.keyCode == 71 && e.ctrlKey);
+    		if (doSearch || e.keyCode == 27) {
           CodeMirror.e_stop(e);
           close();
           me.focus();
-          if (e.keyCode == 13) callback(inp.value);
+          if (doSearch) callback(inp.value);
         }
       });
       if (options && options.onKeyUp) {


### PR DESCRIPTION
Instead of having to hit enter key (13) to start search from dialog, the search can begin using F3 (std. find next on Windows) or CTRL + G (std. find next on Mac)
