### PR TITLE
- Highlight SQL function names

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -62,6 +62,7 @@
 /* DEFAULT THEME */
 
 .cm-s-default .cm-keyword {color: #708;}
+.cm-s-default .cm-function {color: #ff8c00;}
 .cm-s-default .cm-atom {color: #219;}
 .cm-s-default .cm-number {color: #164;}
 .cm-s-default .cm-def {color: #00f;}

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -5,6 +5,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       atoms          = parserConfig.atoms || {"false": true, "true": true, "null": true},
       builtin        = parserConfig.builtin || {},
       keywords       = parserConfig.keywords || {},
+      functions      = parserConfig.functions || {},
       operatorChars  = parserConfig.operatorChars || /^[*+\-%<>!=&|~^]/,
       support        = parserConfig.support || {},
       hooks          = parserConfig.hooks || {},
@@ -98,6 +99,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       if (atoms.hasOwnProperty(word)) return "atom";
       if (builtin.hasOwnProperty(word)) return "builtin";
       if (keywords.hasOwnProperty(word)) return "keyword";
+      if (functions.hasOwnProperty(word)) return "function";
       if (client.hasOwnProperty(word)) return "string-2";
       return null;
     }


### PR DESCRIPTION
The "text/x-plsql" mime in mode/sql/sql.js contains a |functions|
property, which, according to the comment on line #329, is
"A list of function names you want to be highlighted."

Before these changes, the function names weren't being highlighted.
