### PR TITLE
Copy CodeMirror.defaults.gutters Array on CodeMirror instance initialization

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -43,8 +43,10 @@ window.CodeMirror = (function() {
 
     this.options = options = options || {};
     // Determine effective options based on given values and defaults.
-    for (var opt in defaults) if (!options.hasOwnProperty(opt) && defaults.hasOwnProperty(opt))
-      options[opt] = defaults[opt];
+    for (var opt in defaults) if (!options.hasOwnProperty(opt) && defaults.hasOwnProperty(opt)) {
+      var deflt = defaults[opt];
+      options[opt] = deflt instanceof Array ? Array.prototype.slice.call(deflt, 0) : deflt;
+    }
     setGuttersForLineNumbers(options);
 
     var docStart = typeof options.value == "string" ? 0 : options.value.first;

--- a/test/test.js
+++ b/test/test.js
@@ -187,6 +187,25 @@ test("core_defaults", function() {
   }
 });
 
+test("core_defaults_copy_array", function() {
+    var place = document.getElementById("testground"), cm1 = CodeMirror(place, {lineNumbers: true});
+    var tmp = document.createElement("div");
+    document.body.appendChild(tmp);
+    var cm2 = CodeMirror(tmp);
+    try {
+      eq(CodeMirror.defaults.gutters.length, 0, "default is no gutters");
+      eq(cm1.getOption("gutters").length, 1, "cm1 has lineNumbers gutter");
+      eq(cm2.getOption("gutters").length, 0, "cm2 has no gutters");
+      is(cm1.getOption("gutters") != CodeMirror.defaults.gutters, "gutters instances is not the default, it was copied");
+      is(cm2.getOption("gutters") != CodeMirror.defaults.gutters, "gutters instances is not the default, it was copied");
+      is(cm1.getOption("gutters") != cm2.getOption("gutters"), "gutters instances are different");
+    }
+    finally {
+      place.removeChild(cm1.getWrapperElement());
+      document.body.removeChild(tmp);
+    }
+});
+
 testCM("lineInfo", function(cm) {
   eq(cm.lineInfo(-1), null);
   var mark = document.createElement("span");


### PR DESCRIPTION
This prevents unexpectedly sharing an Array between all CodeMirror instances
that don't explicitly specify a gutters array in options.

This would Close #1807
## 

This is a suggested patch, but there are of course alternative solutions. No need to take my specific patch as is.
