### PR TITLE
Pass lint options on when not in async mode (as for JavaScript JSHint us...

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -112,7 +112,7 @@
     if (options.async)
       options.getAnnotations(cm, updateLinting, options);
     else
-      updateLinting(cm, options.getAnnotations(cm.getValue()));
+      updateLinting(cm, options.getAnnotations(cm.getValue(), options));
   }
 
   function updateLinting(cm, annotationsNotSorted) {


### PR DESCRIPTION
Pass lint options on when not in async mode (as for JavaScript JSHint usage)

I didn't see this async used anywhere else in your code (and I didn't touch it here), but I think you might want to the `updateLinting` argument passed AFTER options so that it can parallel the synchronous way I am adding.
