### PR TITLE
Add the ability to specify which object is set as "this" when signaling ...

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5367,8 +5367,8 @@ window.CodeMirror = (function() {
   CodeMirror.on = on; CodeMirror.off = off; CodeMirror.signal = signal;
 
   function eventMixin(ctor) {
-    ctor.prototype.on = function(type, f) {on(this, type, f);};
-    ctor.prototype.off = function(type, f) {off(this, type, f);};
+    ctor.prototype.on = function(type, f, thisArg) {on(this, type, f, thisArg);};
+    ctor.prototype.off = function(type, f, thisArg) {off(this, type, f, thisArg);};
   }
 
   // MISC UTILITIES


### PR DESCRIPTION
...an event. this is useful when the call back function uses "this" to call other functions within the same object.
