### PR TITLE
A fix for multiple-line search

### DIFF
--- a/addon/search/searchcursor.js
+++ b/addon/search/searchcursor.js
@@ -69,7 +69,7 @@
         this.matches = function(reverse, pos) {
           var ln = pos.line, idx = (reverse ? target.length - 1 : 0), match = target[idx], line = fold(doc.getLine(ln));
           var offsetA = (reverse ? line.indexOf(match) + match.length : line.lastIndexOf(match));
-          if (reverse ? offsetA >= pos.ch || offsetA != match.length
+          if (reverse ? offsetA > pos.ch || offsetA != match.length
               : offsetA < pos.ch || offsetA != line.length - match.length)
             return;
           for (;;) {


### PR DESCRIPTION
There must be an error in line 73 because if the phrase starts at the same character position then conditional if will always become true (same number is equal to same number) therefore it must be changed to strict less than.
Here's an example using addon from your official website http://pastebin.com/UdEffwPv
As you can see replacing multiple line doesn't work because first character starts at position number 0
Now there's example with the edit which I have proposed and it works fine
http://pastebin.com/K3xQ87nd
