### PR TITLE
cursor misplaced on lines wrapped after a backslash on safari

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5519,7 +5519,7 @@ window.CodeMirror = (function() {
         if (/\w/.test(str.charAt(i - 2)) && /[^\-?\.]/.test(str.charAt(i))) return true;
         if (i > 2 && /[\d\.,]/.test(str.charAt(i - 2)) && /[\d\.,]/.test(str.charAt(i))) return false;
       }
-      return /[~!#%&*)=+}\]|\"\.>,:;][({[<]|-[^\-?\.\u2010-\u201f\u2026]|\?[\w~`@#$%\^&*(_=+{[|><]|…[\w~`@#$%\^&*(_=+{[><]/.test(str.slice(i - 1, i + 1));
+      return /[~!#%&*)=+}\]|\"\.>,:;\\][({[<]|-[^\-?\.\u2010-\u201f\u2026]|\?[\w~`@#$%\^&*(_=+{[|><]|…[\w~`@#$%\^&*(_=+{[><]/.test(str.slice(i - 1, i + 1));
     };
 
   var knownScrollbarWidth;


### PR DESCRIPTION
This is a suggested fix for the following issue:

Steps to reproduce:
1. In Safari, go to http://codemirror.net/demo/btree.html
and enter

```
type here, see a summary of the document b-tree below blah blah xxx \(1+2\) blah.
```

so that the line wraps between the "\" and the "(".
2. Insert a character on the second line.

The inserted character does not appear in the expected position.

Reported on Safari 5.0.6 on OSX 10.5.8. Reproduced on Safari 6.0.5 on OSX 10.7.5. I couldn't reproduce it on any of the other browsers I tried -- works fine on Chrome 29 on Mac and Windows, FireFox 23 on Mac and Windows, and IE8.

Adding backslash to the final regular expression in spanAffectsWrapping for webkit appears to fix the issue on Safari 6. All tests still pass on Safari 6 & the non-Safari browsers listed above.

This won't help on Safari 5.0.6, which is matched by one of the earlier if-else conditions, but it looks that version is no longer officially supported (Safari 5.2+ only), so I'm not sure about making any other changes.

Note that unlike #1809 this appears to affect old and stable versions of Safari.
