### PR TITLE
[css] Fix indentation issue in SCSS mode with mixin variables (for #1846)

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -3,7 +3,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
 
   if (!parserConfig.propertyKeywords) parserConfig = CodeMirror.resolveMode("text/css");
 
-  var indentUnit = config.indentUnit,
+  var indentUnit = config.indentUnit || config.tabSize || 2,
       hooks = parserConfig.hooks || {},
       atMediaTypes = parserConfig.atMediaTypes || {},
       atMediaFeatures = parserConfig.atMediaFeatures || {},

--- a/mode/css/scss_test.js
+++ b/mode/css/scss_test.js
@@ -1,6 +1,7 @@
 (function() {
-  var mode = CodeMirror.getMode({tabSize: 4}, "text/x-scss");
+  var mode = CodeMirror.getMode({tabSize: 1}, "text/x-scss");
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1), "scss"); }
+  function IT(name) { test.indentation(name, mode, Array.prototype.slice.call(arguments, 1), "scss"); }
 
   MT('url_with_quotation',
     "[tag foo] { [property background][operator :][string-2 url]([string test.jpg]) }");
@@ -77,4 +78,7 @@
 
   MT('nested_structure_with_id_selector',
     "[tag p] { [builtin #hello] { [property color][operator :][keyword red]; } }");
+
+  IT('mixin',
+    "@mixin container[1 (][2 $a: 10][1 , ][2 $b: 10][1 , ][2 $c: 10]) [1 {]}");
 })();

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -1,6 +1,7 @@
 (function() {
-  var mode = CodeMirror.getMode({tabSize: 4}, "css");
+  var mode = CodeMirror.getMode({tabSize: 1}, "css");
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
+  function IT(name) { test.indentation(name, mode, Array.prototype.slice.call(arguments, 1)); }
 
   // Requires at least one media query
   MT("atMediaEmpty",
@@ -123,4 +124,7 @@
 
   MT("commentSGML",
      "[comment <!--comment-->]");
+		 
+  IT("tagSelector",
+    "strong, em [1 { background][2 : rgba][3 (255, 255, 0, .2][2 )][1 ;]}");
 })();

--- a/test/mode_test.js
+++ b/test/mode_test.js
@@ -59,6 +59,13 @@
     return {tokens: tokens, plain: plain};
   }
 
+  test.indentation = function(name, mode, tokens, modeName) {
+    var data = parseTokens(tokens);
+    return test((modeName || mode.name) + "_indent_" + name, function() {
+      return compare(data.plain, data.tokens, mode, true);
+    });
+  };
+
   test.mode = function(name, mode, tokens, modeName) {
     var data = parseTokens(tokens);
     return test((modeName || mode.name) + "_" + name, function() {
@@ -66,7 +73,7 @@
     });
   };
 
-  function compare(text, expected, mode) {
+  function compare(text, expected, mode, compareIndentation) {
 
     var expectedOutput = [];
     for (var i = 0; i < expected.length; i += 2) {
@@ -75,7 +82,7 @@
       expectedOutput.push(sty, expected[i + 1]);
     }
 
-    var observedOutput = highlight(text, mode);
+    var observedOutput = highlight(text, mode, compareIndentation);
 
     var pass, passStyle = "";
     pass = highlightOutputsEqual(expectedOutput, observedOutput);
@@ -114,7 +121,7 @@
    *
    * @return array of [style, token] pairs
    */
-  function highlight(string, mode) {
+  function highlight(string, mode, compareIndentation) {
     var state = mode.startState()
 
     var lines = string.replace(/\r\n/g,'\n').split('\n');
@@ -125,14 +132,15 @@
       if (line == "" && mode.blankLine) mode.blankLine(state);
       /* Start copied code from CodeMirror.highlight */
       while (!stream.eol()) {
-        var style = mode.token(stream, state), substr = stream.current();
-        if (style && style.indexOf(" ") > -1) style = style.split(' ').sort().join(' ');
+				var compare = mode.token(stream, state), substr = stream.current();
+				if(compareIndentation) compare = mode.indent(state) || null;
+        else if (compare && compare.indexOf(" ") > -1) compare = compare.split(' ').sort().join(' ');
 
-        stream.start = stream.pos;
-        if (pos && st[pos-2] == style && !newLine) {
+				stream.start = stream.pos;
+        if (pos && st[pos-2] == compare && !newLine) {
           st[pos-1] += substr;
         } else if (substr) {
-          st[pos++] = style; st[pos++] = substr;
+          st[pos++] = compare; st[pos++] = substr;
         }
         // Give up when line is ridiculously long
         if (stream.pos > 5000) {


### PR DESCRIPTION
Fixes the issue in #1846 and auto-resets the indentation level when parentheses and curly braces are present, which should help indentation issues be less bothersome when an issue does present itself in a block.

In the second commit I modified the mode testing code a bit to allow for testing indentation, and added a couple small tests for CSS/SCSS modes. This should help to avoid regressions in the future. But, as usual, feel free to alter, add to, or ignore the second commit.
