### PR TITLE
Factor default CSS rules for foldgutter out to standalone foldgutter.css

### DIFF
--- a/addon/fold/foldgutter.css
+++ b/addon/fold/foldgutter.css
@@ -1,0 +1,21 @@
+.CodeMirror-foldmarker {
+  color: blue;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  font-family: arial;
+  line-height: .3;
+  cursor: pointer;
+}
+.CodeMirror-foldgutter {
+  width: .7em;
+}
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  color: #555;
+  cursor: pointer;
+}
+.CodeMirror-foldgutter-open:after {
+  content: "\25BE";
+}
+.CodeMirror-foldgutter-folded:after {
+  content: "\25B8";
+}

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -5,6 +5,7 @@
 <link rel=stylesheet href="../doc/docs.css">
 
 <link rel="stylesheet" href="../lib/codemirror.css">
+<link rel="stylesheet" href="../addon/fold/fold-gutter.css" />
 <script src="../lib/codemirror.js"></script>
 <script src="../addon/fold/foldcode.js"></script>
 <script src="../addon/fold/foldgutter.js"></script>
@@ -15,28 +16,7 @@
 <script src="../mode/xml/xml.js"></script>
 <style type="text/css">
       .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
-      .CodeMirror-foldmarker {
-        color: blue;
-        text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
-        font-family: arial;
-        line-height: .3;
-        cursor: pointer;
-      }
-      .CodeMirror-foldgutter {
-        width: .7em;
-      }
-      .CodeMirror-foldgutter-open,
-      .CodeMirror-foldgutter-folded {
-        color: #555;
-        cursor: pointer;
-      }
-      .CodeMirror-foldgutter-open:after {
-        content: "\25BE";
-      }
-      .CodeMirror-foldgutter-folded:after {
-        content: "\25B8";
-      }
-    </style>
+</style>
 <div id=nav>
   <a href="http://codemirror.net"><img id=logo src="../doc/logo.png"></a>
 
@@ -56,7 +36,7 @@
       <div style="max-width: 50em; margin-bottom: 1em">JavaScript:<br><textarea id="code" name="code"></textarea></div>
       <div style="max-width: 50em">HTML:<br><textarea id="code-html" name="code-html"></textarea></div>
     </form>
-    <script id="script"> 
+    <script id="script">
 /*
  * Demonstration of code folding
  */
@@ -75,7 +55,7 @@ window.onload = function() {
     extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},
     foldGutter: {
     	rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.brace, CodeMirror.fold.comment)
-    },    
+    },
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
   });
   editor.foldCode(CodeMirror.Pos(8, 0));

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1867,7 +1867,14 @@
       giving it the class <code>CodeMirror-foldgutter</code> or
       something else if you configure the addon to use a different
       class, and this addon will show markers next to folded and
-      foldable blocks, and handle clicks in this gutter. The option
+      foldable blocks, and handle clicks in this gutter. Note that
+      CSS styles should be applied to make the gutter, and the fold
+      markers within it, visible. A default set of CSS styles are
+      available in:
+      <a href="../addon/fold/foldgutter.css">
+        <code>addon/fold/foldgutter.css</code>
+      </a>.
+      The option
       can be either set to <code>true</code>, or an object containing
       the following optional option fields:
       <dl>
@@ -1875,7 +1882,7 @@
         <dd>The CSS class of the gutter. Defaults
         to <code>"CodeMirror-foldgutter"</code>. You will have to
         style this yourself to give it a width (and possibly a
-        background).</dd>
+        background). See the default gutter style rules above.</dd>
         <dt><code><strong>indicatorOpen</strong>: string | Element</code></dt>
         <dd>A CSS class or DOM element to be used as the marker for
         open, foldable blocks. Defaults


### PR DESCRIPTION
Creating a CodeMirror editor with folding enabled, I failed to notice in the manual and in the sample code that CSS rules need to be applied to make the fold-gutter visible. This pull request moves the default styles, which were in-line in the demo code, out to a separate .css file to make them more reusable. It also updates the manual to make it clearer to the user that styles have to be applied.
