### PR TITLE
Introduce a new configurable option that allows to customize text selection

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2186,9 +2186,6 @@ window.CodeMirror = (function() {
     if (reset && (posEq(sel.from, sel.to) || posLess(pos, sel.from) || !posLess(pos, sel.to)))
       operation(cm, setSelection)(cm.doc, pos, pos);
 
-    if (posEq(sel.from, sel.to) || posLess(pos, sel.from) || !posLess(pos, sel.to))
-      operation(cm, setSelection)(cm.doc, pos, pos);
-
     var oldCSS = display.input.style.cssText;
     display.inputDiv.style.position = "absolute";
     display.input.style.cssText = "position: fixed; width: 30px; height: 30px; top: " + (e.clientY - 5) +


### PR DESCRIPTION
Right clicking within CodeMirror editor, but outside of an existing selected text clears the selection.

This pull request introduces a new option that allows to customize the behavior.

Not sure about the option name. Any better suggestions?

See also this thread:
https://groups.google.com/forum/#!topic/codemirror/kzy1oGnmhBI

Honza
