### PR TITLE
Remove bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "CodeMirror",
-  "version": "3.18.0",
   "main": ["lib/codemirror.js", "lib/codemirror.css"],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Removed the version attribute from `bower.json` as it's no longer needed. Recent versions of Bower will pull from Git tags instead. 

Fixes #1705, #1700
