### PR TITLE
Add handleEx() to Vim mode's API

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -609,6 +609,9 @@
           }
           commandDispatcher.processCommand(cm, vim, command);
         }
+      },
+      handleEx: function(cm, input) {
+        exCommandDispatcher.processCommand(cm, input);
       }
     };
 


### PR DESCRIPTION
Provide an alternative (programmatic) way to run Ex commands.
