### PR TITLE
Tern addon rename bug fixed

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -439,7 +439,7 @@
     for (var file in perFile) {
       var known = ts.docs[file], chs = perFile[file];;
       if (!known) continue;
-      chs.sort(function(a, b) { return cmpPos(b, a); });
+      chs.sort(function(a, b) { return cmpPos(b.start, a.start); });
       var origin = "*rename" + (++nextChangeOrig);
       for (var i = 0; i < chs.length; ++i) {
         var ch = chs[i];


### PR DESCRIPTION
If you are trying to rename a variable and the variable is occurred several times in one line, rename does not work correctly. To prevent this, tern addon "sort" the changes in descending order, but there was an error on the sort.
