### PR TITLE
Wrap long lint messages

### DIFF
--- a/addon/lint/lint.css
+++ b/addon/lint/lint.css
@@ -14,6 +14,7 @@
   padding: 2px 5px;
   position: fixed;
   white-space: pre;
+  white-space: pre-wrap;
   z-index: 100;
   max-width: 600px;
   opacity: 0;


### PR DESCRIPTION
Long messages are visually truncated in lint.
For example errors on css `input.someLongClassName {}` will produce an error, that doesn't fit on 600px width.

`white-space: pre-wrap` added after previous declaration to preserve behavior on browsers doesn't understand it. 
