### PR TITLE
[gfm] Adding support for ~~strikethrough~~ text

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -89,6 +89,7 @@
 .cm-header, .cm-strong {font-weight: bold;}
 .cm-em {font-style: italic;}
 .cm-link {text-decoration: underline;}
+.cm-strikethrough {text-decoration: line-through;}
 
 .cm-s-default .cm-error {color: #f00;}
 .cm-invalidchar {color: #f00;}

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -63,7 +63,11 @@ CodeMirror.defineMode("gfm", function(config) {
       }
       if (stream.sol() || state.ateSpace) {
         state.ateSpace = false;
-        if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
+        if (stream.match(/^(?:~~([^ ~]|[^ ~].*[^ ~])~~)/)) {
+          // ~~strikethrough text~~
+          // strikethrough text can't start or end with a space
+          return 'strikethrough';
+        } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
           // User/Project@SHA
           // User@SHA
           // SHA

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -41,6 +41,12 @@ Everything from markdown plus GFM features:
 
 Underscores_are_allowed_between_words.
 
+## Strikethrough text
+
+GFM adds syntax to strikethrough text, which is missing from standard Markdown.
+
+~~Mistaken text.~~
+
 ## Fenced code blocks (and syntax highlighting)
 
 ```javascript

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -11,6 +11,18 @@
   MT("emStrongUnderscore",
      "[strong __][em&strong _foo__][em _] bar");
 
+  MT("strikethrough",
+     "This [strikethrough ~~needs~~] should to be done");
+
+  MT("strikethroughWithStartingSpace",
+     "This ~~ space~~ should break it");
+
+  MT("strikethroughWithEndingSpace",
+     "This ~~space ~~ should break it");
+
+  MT("strikethroughOneLetter",
+     "This [strikethrough ~~a~~] should work");
+
   MT("fencedCodeBlocks",
      "[comment ```]",
      "[comment foo]",


### PR DESCRIPTION
Fixes #1887.

> GFM adds syntax to strikethrough text, which is missing from standard Markdown.
> 
> ```
> ~~Mistaken text.~~
> ```
> 
> becomes
> 
> ~~Mistaken text.~~

Added test cases, added a new style (strikethrough text is displayed with a strikethrough to be consistent with how the rest of the markdown is rendered). 
