### PR TITLE
[continuelist] Should continue list even after special chars (space, !, etc)

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -6,7 +6,7 @@
 
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {
     var pos = cm.getCursor(),
-        inList = cm.getStateAfter(pos.line).list,
+        inList = cm.getStateAfter(pos.line).list !== false,
         match;
 
     if (!inList || !(match = cm.getLine(pos.line).match(listRE))) {


### PR DESCRIPTION
`state.list` can be `true`, `false`, or `null`, and both `true` and `null` should be continued. Only `false` stops the list.

Fixes #1893.
