### PR TITLE
[julia mode] added additional operators and fixed 'in' keyword

### DIFF
--- a/mode/julia/index.html
+++ b/mode/julia/index.html
@@ -156,16 +156,19 @@ in
 ::
 x ? y : z
 
+#macros
+@spawnat 2 1+1
+@eval(:x)
 
 #keywords and operators
 if else elseif while for
-in begin let end do
+ begin let end do
 try catch finally return break continue
 global local const 
 export import importall using
 function macro module baremodule 
 type immutable quote
-all true false any enumerate
+true false enumerate
 
 
     </textarea></div>

--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -11,7 +11,7 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
   var blockOpeners = ["begin", "function", "type", "immutable", "let", "macro", "for", "while", "quote", "if", "else", "elseif", "try", "finally", "catch"];
   var blockClosers = ["end", "else", "elseif", "catch", "finally"];
   var keywordList = ['if', 'else', 'elseif', 'while', 'for', 'begin', 'let', 'end', 'do', 'try', 'catch', 'finally', 'return', 'break', 'continue', 'global', 'local', 'const', 'export', 'import', 'importall', 'using', 'function', 'macro', 'module', 'baremodule', 'type', 'immutable', 'quote', 'typealias', 'abstract', 'bitstype', 'ccall'];
-  var builtinList = ['all', 'true', 'false', 'any', 'enumerate', 'open', 'close', 'linspace', 'nothing', 'NaN', 'Inf', 'print', 'println', 'Int8', 'Uint8', 'Int16', 'Uint16', 'Int32', 'Uint32', 'Int64', 'Uint64', 'Int128', 'Uint128', 'Bool', 'Char', 'Float16', 'Float32', 'Float64', 'Array', 'Vector', 'Matrix', 'String', 'error', 'warn', 'info'];
+  var builtinList = ['true', 'false', 'enumerate', 'open', 'close', 'nothing', 'NaN', 'Inf', 'print', 'println', 'Int8', 'Uint8', 'Int16', 'Uint16', 'Int32', 'Uint32', 'Int64', 'Uint64', 'Int128', 'Uint128', 'Bool', 'Char', 'Float16', 'Float32', 'Float64', 'Array', 'Vector', 'Matrix', 'String', 'UTF8String', 'ASCIIString', 'error', 'warn', 'info', '@printf'];
 
   //var stringPrefixes = new RegExp("^[br]?('|\")")
   var stringPrefixes = /^[br]?('|"{3}|")/;
@@ -19,6 +19,7 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
   var builtins = wordRegexp(builtinList);
   var openers = wordRegexp(blockOpeners);
   var closers = wordRegexp(blockClosers);
+  var macro = /@[_A-Za-z][_A-Za-z0-9]*!*/
   var indentInfo = null;
 
   function in_array(state) {
@@ -147,6 +148,7 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
     if (stream.match(operators)) {
       return 'operator';
     }
+
     if (stream.match(delimiters)) {
       return null;
     }
@@ -159,6 +161,9 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
       return 'builtin';
     }
 
+    if (stream.match(macro)) {
+      return 'meta';
+    }
 
     if (stream.match(identifiers)) {
       state.leaving_expr=true;
@@ -218,11 +223,6 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
         style = 'meta';
       }
       return style;
-    }
-
-    // Handle macro calls
-    if (current === '@') {
-      return stream.match(identifiers, false) ? 'meta' : ERRORCLASS;
     }
 
     return style;


### PR DESCRIPTION
The following operators are recognized, which I think are all the ones from https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm#L1, but I may have still missed some. 

Also 'in' is now classified as an operator instead of a keyword. 
# operators

```
|=
&=
^=
\-
%=
*=
+=
-=
<=
>=
!=
==
%
*
+
-
<
>
!
=
|
&
^
\
?
~
:
$
<:
.<
.>
<<
<<=
>>
>>>>
>>=
>>>=
<<=
<<<=
.<=
.>=
.==
->
//
in
...
//
:=
.//=
.*=
./=
.^=
.%=
.+=
.-=
\=
\\=
||
===
&&
|=
.|=
<:
>:
|>
<|
::
x ? y : z
```
