### PR TITLE
Always move cursor to end of indent even if whitespace didn't change

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2759,7 +2759,9 @@ window.CodeMirror = (function() {
       for (var i = Math.floor(indentation / tabSize); i; --i) {pos += tabSize; indentString += "\t";}
     if (pos < indentation) indentString += spaceStr(indentation - pos);
 
-    if (indentString != curSpaceString)
+    if (indentString == curSpaceString)
+      setSelection(cm.doc, Pos(n, curSpaceString.length), Pos(n, curSpaceString.length));
+    else
       replaceRange(cm.doc, indentString, Pos(n, 0), Pos(n, curSpaceString.length), "+input");
     line.stateAfter = null;
   }


### PR DESCRIPTION
Currently, if you indent a line, the cursor is inside the whitespace at the beginning of the line, and CodeMirror determines that the whitespace needs to change, the cursor moves to the end of the indenting whitespace, which makes sense. However, if no change to the whitespace is needed, the cursor stays at its current location, which leads to inconsistent behavior. It would make sense to always move the cursor to the end of the indenting whitespace so the user is ready to type, even if there happens to already be the right amount of whitespace on the line. This proposed patch fixes that.
