### PR TITLE
Stop propagation on keydown events handled as shortcuts.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2097,7 +2097,7 @@ window.CodeMirror = (function() {
     }
 
     if (handled) {
-      e_preventDefault(e);
+      e_stop(e);
       restartBlink(cm);
       if (ie_lt9) { e.oldKeyCode = e.keyCode; e.keyCode = 0; }
       signalLater(cm, "keyHandled", cm, name, e);


### PR DESCRIPTION
I'm guessing there's a good reason CM currently doesn't stop propagation on these events. But this would be a great way of letting codemirror-based and external keyboard shortcuts play well together.
