### PR TITLE
mbo theme: Fix matching tag background highlighting

### DIFF
--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -24,9 +24,11 @@
 
 .cm-s-mbo .CodeMirror-activeline-background {background: #494b41 !important;}
 .cm-s-mbo .CodeMirror-matchingbracket {
-   text-decoration: underline;
+  text-decoration: underline;
   color: #f5e107 !important;
  }
+ 
+.cm-s-mbo .CodeMirror-matchingtag {background: #4e4e4e;}
 
 div.CodeMirror span.CodeMirror-searching {
   background-color: none;


### PR DESCRIPTION
Change default, light-green color (that works well with light themes) to more subtle, dark #4e4e4e
