### PR TITLE
[clike demo] Fix duplicate variable names for C and C++ editors

### DIFF
--- a/mode/clike/index.html
+++ b/mode/clike/index.html
@@ -165,12 +165,12 @@ public class Class<T, V> implements MyInterface {
 </textarea></div>
 
     <script>
-      var editor = CodeMirror.fromTextArea(document.getElementById("c-code"), {
+      var cEditor = CodeMirror.fromTextArea(document.getElementById("c-code"), {
         lineNumbers: true,
         matchBrackets: true,
         mode: "text/x-csrc"
       });
-      var editor = CodeMirror.fromTextArea(document.getElementById("cpp-code"), {
+      var cppEditor = CodeMirror.fromTextArea(document.getElementById("cpp-code"), {
         lineNumbers: true,
         matchBrackets: true,
         mode: "text/x-c++src"


### PR DESCRIPTION
The C editor and the C++ editor have the same variable name, so
the latter shadows the former. Fixed by renaming both.
