### PR TITLE
[go mode] Add () as electric characters.

### DIFF
--- a/mode/go/go.js
+++ b/mode/go/go.js
@@ -158,7 +158,7 @@ CodeMirror.defineMode("go", function(config) {
       else return ctx.indented + (closing ? 0 : indentUnit);
     },
 
-    electricChars: "{}:",
+    electricChars: "{}):",
     blockCommentStart: "/*",
     blockCommentEnd: "*/",
     lineComment: "//"


### PR DESCRIPTION
As a result, the common pattern

import (
    "foo"
    "bar"
    )

will re-indent automatically to the gofmt-blessed

import (
    "foo"
    "bar"
)
