### PR TITLE
Make it possible to have some other than fist option selected by default...

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -147,12 +147,12 @@
 
     var hints = this.hints = document.createElement("ul");
     hints.className = "CodeMirror-hints";
-    this.selectedHint = 0;
+    this.selectedHint = options.getDefaultSelection ? options.getDefaultSelection(cm,options,data) : 0;
 
     var completions = data.list;
     for (var i = 0; i < completions.length; ++i) {
       var elt = hints.appendChild(document.createElement("li")), cur = completions[i];
-      var className = "CodeMirror-hint" + (i ? "" : " CodeMirror-hint-active");
+      var className = "CodeMirror-hint" + (i==this.selectedHint ? " CodeMirror-hint-active" : "");
       if (cur.className != null) className = cur.className + " " + className;
       elt.className = className;
       if (cur.render) cur.render(elt, data, cur);


### PR DESCRIPTION
... in show-hint

It is sometimes desirable to have some other than the first in the list to be selected. Basically always when hinting is not strict auto-complete, but gives other options as well.
