### PR TITLE
Fix: [theme] [ambiance] text selection uses default background color

### DIFF
--- a/theme/ambiance.css
+++ b/theme/ambiance.css
@@ -33,7 +33,7 @@
 .cm-s-ambiance .CodeMirror-selected {
   background: rgba(255, 255, 255, 0.15);
 }
-.cm-s-ambiance .CodeMirror-focused .CodeMirror-selected {
+.cm-s-ambiance.CodeMirror-focused .CodeMirror-selected {
   background: rgba(255, 255, 255, 0.10);
 }
 


### PR DESCRIPTION
`cm-s-ambiance` and `CodeMirror-focused` are classes to the same element, so search for `.cm-s-ambiance .CodeMirror-focused` will fail.
