### PR TITLE
Ability to change in runtime autoCloseTags property

### DIFF
--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -24,16 +24,15 @@
 
 (function() {
   CodeMirror.defineOption("autoCloseTags", false, function(cm, val, old) {
-    if (val && (old == CodeMirror.Init || !old)) {
-      var map = {name: "autoCloseTags"};
-      if (typeof val != "object" || val.whenClosing)
-        map["'/'"] = function(cm) { return autoCloseSlash(cm); };
-      if (typeof val != "object" || val.whenOpening)
-        map["'>'"] = function(cm) { return autoCloseGT(cm); };
-      cm.addKeyMap(map);
-    } else if (!val && (old != CodeMirror.Init && old)) {
+    if (old != CodeMirror.Init && old)
       cm.removeKeyMap("autoCloseTags");
-    }
+    if (!val) return;
+    var map = {name: "autoCloseTags"};
+    if (typeof val != "object" || val.whenClosing)
+      map["'/'"] = function(cm) { return autoCloseSlash(cm); };
+    if (typeof val != "object" || val.whenOpening)
+      map["'>'"] = function(cm) { return autoCloseGT(cm); };
+    cm.addKeyMap(map);
   });
 
   var htmlDontClose = ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param",


### PR DESCRIPTION
Now there is no ability to change autoCloseTags property of closetag addon in runtime.
This commit fixes this problem.
