### PR TITLE
[dialog addon] Make dialogDiv accept a detached DOM node in addition to a template string

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -10,7 +10,11 @@
     } else {
       dialog.className = "CodeMirror-dialog CodeMirror-dialog-top";
     }
-    dialog.innerHTML = template;
+    if (Object.prototype.toString.call(template) == "[object String]") {
+      dialog.innerHTML = template;
+    } else { // Assuming it's a detached DOM element.
+      dialog.appendChild(template);
+    }
     return dialog;
   }
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1710,9 +1710,9 @@
       <dd>Provides a very simple way to query users for text input.
       Adds an <strong><code>openDialog</code></strong> method to
       CodeMirror instances, which can be called with an HTML fragment
-      that provides the prompt (should include an <code>input</code>
-      tag), and a callback function that is called when text has been
-      entered. Also adds
+      or a detached DOM node that provides the prompt (should include
+      an <code>input</code> tag), and a callback function that is called
+      when text has been entered. Also adds
       an <strong><code>openNotification</code></strong> function that
       simply shows an HTML fragment as a notification. Depends
       on <code>addon/dialog/dialog.css</code>.</dd>


### PR DESCRIPTION
Mozilla's sec-review for the CodeMirror went well ([bug 935694](https://bugzilla.mozilla.org/show_bug.cgi?id=935694)). One thing our security team noted is the use of innerHTML in the dialog addon ([bug 938111](https://bugzilla.mozilla.org/show_bug.cgi?id=938111)). **This is not exploitable** today but as noted in that bug, "the use of innerHTML now is a common cause of vulnerability later".

This patch makes dialogDiv function accept a detached DOM node in addition to a template string. This way you don't need to change search and other addons that depend on the dialog addon while we can modify our extensions to avoid innerHTML altogether.

I could find unit tests for the dialog addon (outside of vim tests) so I tested manually.

Example:

``` javascript
var inp = document.createElement("inp");
var div = document.createElement("div");

inp.type = "text";
inp.style.width = "10em";

div.appendChild(document.createTextNode("Search: "));
div.appendChild(inp);

editor.openDialog(div, function () { /* ... */ });
```
