### PR TITLE
Do not scroll while applying indentation to selection

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2922,9 +2922,17 @@ window.CodeMirror = (function() {
     }),
     indentSelection: operation(null, function(how) {
       var sel = this.doc.sel;
-      if (posEq(sel.from, sel.to)) return indentLine(this, sel.from.line, how);
       var e = sel.to.line - (sel.to.ch ? 0 : 1);
-      for (var i = sel.from.line; i <= e; ++i) indentLine(this, i, how);
+
+      if (posEq(sel.from, sel.to)) {
+        indentLine(this, sel.from.line, how);
+      } else {
+        for (var i = sel.from.line; i <= e; ++i) indentLine(this, i, how);
+      }
+
+      // don't treat indentation changes as
+      // selection changes to not scroll the view
+      this.curOp.selectionChanged = false;
     }),
 
     // Fetch the parser token for a given character. Useful for hacks


### PR DESCRIPTION
When i do selection and scroll down to select additional lines that out of view and then scroll back to the top and press Tab or Shift-Tab, a view is automatically scrolled to the bottom of selection against my will and i want to see what's going on right where i'm looking at now. I don't want my view jump here and there with no reason that is annoying.

I think overall logic behind **selectionChanged** variable makes more sense to situations when you select something and replace it with whatever you have in your buffer (copy/paste) otherwise (indentation changes) no cursor changes (blinking, position) are required as user is still working with selection.
