### PR TITLE
[placeholder addon] Don't hide placeholder on focus

### DIFF
--- a/addon/display/placeholder.js
+++ b/addon/display/placeholder.js
@@ -2,12 +2,10 @@
   CodeMirror.defineOption("placeholder", "", function(cm, val, old) {
     var prev = old && old != CodeMirror.Init;
     if (val && !prev) {
-      cm.on("focus", onFocus);
       cm.on("blur", onBlur);
       cm.on("change", onChange);
       onChange(cm);
     } else if (!val && prev) {
-      cm.off("focus", onFocus);
       cm.off("blur", onBlur);
       cm.off("change", onChange);
       clearPlaceholder(cm);
@@ -33,9 +31,6 @@
     cm.display.lineSpace.insertBefore(elt, cm.display.lineSpace.firstChild);
   }
 
-  function onFocus(cm) {
-    clearPlaceholder(cm);
-  }
   function onBlur(cm) {
     if (isEmpty(cm)) setPlaceholder(cm);
   }
@@ -43,7 +38,6 @@
     var wrapper = cm.getWrapperElement(), empty = isEmpty(cm);
     wrapper.className = wrapper.className.replace(" CodeMirror-empty", "") + (empty ? " CodeMirror-empty" : "");
 
-    if (cm.hasFocus()) return;
     if (empty) setPlaceholder(cm);
     else clearPlaceholder(cm);
   }


### PR DESCRIPTION
Most modern browsers now keep displaying the placeholder even if the
user has focus on the input and only hide it when the input has content.

This change is to make this addon consistent with this, so users won't
tell the difference with native inputs' placeholder behaviour.
