### PR TITLE
Add an alwaysInsertAfter option on the editor to always force content to...

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4615,9 +4615,12 @@ window.CodeMirror = (function() {
     var from = change.from, to = change.to, text = change.text;
     var firstLine = getLine(doc, from.line), lastLine = getLine(doc, to.line);
     var lastText = lst(text), lastSpans = spansFor(text.length - 1), nlines = to.line - from.line;
+    // In some use cases it is desirable to always insert content after the last line
+    // and not insert immediately before the currently last line.
+    var alwaysInsertAfter = doc.cm && doc.cm.options.alwaysInsertAfter;
 
     // First adjust the line structure
-    if (from.ch == 0 && to.ch == 0 && lastText == "") {
+    if (from.ch == 0 && to.ch == 0 && lastText == "" && !alwaysInsertAfter) {
       // This is a whole-line replace. Treated specially to make
       // sure line objects move the way they are supposed to.
       for (var i = 0, e = text.length - 1, added = []; i < e; ++i)


### PR DESCRIPTION
Add an alwaysInsertAfter option on the editor to always force content to be injected after a targeted line to avoid pushing the current last line to the end of the document. Fixes #1967
