### PR TITLE
Fix selected code color in the-matrix.css

### DIFF
--- a/theme/the-matrix.css
+++ b/theme/the-matrix.css
@@ -1,5 +1,5 @@
 .cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
-.cm-s-the-matrix span.CodeMirror-selected { background: #a8f !important; }
+.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D !important; }
 .cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }
 .cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
 .cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00 !important; }


### PR DESCRIPTION
Current CSS selector for the selected text is wrong, also the color contrasts too much between the normal code and the selected code.
