### PR TITLE
[changemode demo] Really rate-limit looksLikeScheme() calls

### DIFF
--- a/demo/changemode.html
+++ b/demo/changemode.html
@@ -44,11 +44,11 @@ either JavaScript or Scheme mode based on that.</p>
     lineNumbers: true,
     tabMode: "indent"
   });
+  var pending;
   editor.on("change", function() {
     clearTimeout(pending);
-    setTimeout(update, 400);
+    pending = setTimeout(update, 400);
   });
-  var pending;
   function looksLikeScheme(code) {
     return !/^\s*\(\s*function\b/.test(code) && /^\s*[;\(]/.test(code);
   }


### PR DESCRIPTION
After the fix: http://rawgithub.com/cben/CodeMirror/patch-changemode/demo/changemode.html
Type `;var x;` at the start and rapidly delete and re-insert the leading `;` to see the mode switch only after inactivity.

Hard to observe a performance win, but this was clearly the intent of the example code.
