### PR TITLE
Add a wrapper class to gutters to offer more control using CSS.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -717,7 +717,7 @@ window.CodeMirror = (function() {
     if (bgClass)
       wrap.insertBefore(elt("div", null, bgClass + " CodeMirror-linebackground"), wrap.firstChild);
     if (cm.options.lineNumbers || markers) {
-      var gutterWrap = wrap.insertBefore(elt("div", null, null, "position: absolute; left: " +
+      var gutterWrap = wrap.insertBefore(elt("div", null, "CodeMirror-gutter-wrapper", "position: absolute; left: " +
                                              (cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth) + "px"),
                                          lineElement);
       if (cm.options.fixedGutter) (wrap.alignable || (wrap.alignable = [])).push(gutterWrap);


### PR DESCRIPTION
After upgrading to the most recent dev snapshot to include the change from d07ec7eee25e557d1109b90e82c6d09a8204127e (#1972) I noticed that the change from 410bf3dc309105bb8dcf10e40f1678957314dea3 changed positioning of the gutter markers in the DOM when lines are updated.

In our implementation we use Line Widgets that span the entire width of the editor and sit above a line. In this scenario, we want to control the position of gutter markers so that they sit below the line widget visually, however because the wrapping element around the gutter markers does not have a CSS class it is not accessible for styling via CSS and thus it is harder to control styling of elements in the gutter.

I noticed this behaviour because when a line widget is added, it is also added immediately before the `<pre>` element which would affect the positioning of the items in the gutter.
