### PR TITLE
show-hint: modified Completion pick to emit "pick" event

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -45,8 +45,8 @@
       var completion = data.list[i];
       if (completion.hint) completion.hint(this.cm, data, completion);
       else this.cm.replaceRange(getText(completion), data.from, data.to);
-      this.close();
       CodeMirror.signal(data, "pick", completion);
+      this.close();
     },
 
     showHints: function(data) {


### PR DESCRIPTION
modified `addon/hint/show-hint.js` to emit a "pick" event wen a user picks a specific item from the hint widget. This event is useful for dynamically adapting the list of completions based on usage frequency.
## Documentation

```
"pick" (completion)
```

Fired when a completion is picked. Passed the completion value (string or object).
