### PR TITLE
[pegjs] quotes can appear in character classes

### DIFF
--- a/mode/pegjs/pegjs.js
+++ b/mode/pegjs/pegjs.js
@@ -54,15 +54,11 @@ CodeMirror.defineMode("pegjs", function (config) {
         }
         return "comment";
       } else if (state.inChracterClass) {
-        if (stream.match(/^[^\]\\]+/)) {
-          return;
-        } else if (stream.match(/^\\./)) {
-          return;
-        } else {
-          stream.next();
-          state.inChracterClass = false;
-          return 'bracket';
-        }
+          while (state.inChracterClass && !stream.eol()) {
+            if (!(stream.match(/^[^\]\\]+/) || stream.match(/^\\./))) {
+              state.inChracterClass = false;
+            }
+          }
       } else if (stream.peek() === '[') {
         stream.next();
         state.inChracterClass = true;


### PR DESCRIPTION
when they do so, they don't indicate the start of a string.

[closes #1977]

This fix is a lot simpler than #1981 in my opinion.  Rather than relying on precedence it simply processes the entire character class in one loop.  This actually reduces the number of lines of code.
