### PR TITLE
Use the github url for `repository`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
                     "email": "marijnh@gmail.com",
                     "web": "http://marijnhaverbeke.nl"}],
     "repository": {"type": "git",
-                   "url": "http://marijnhaverbeke.nl/git/codemirror"}
+                   "url": "https://github.com/marijnh/CodeMirror.git"}
 }


### PR DESCRIPTION
This makes it easy to find the GitHub repo from https://npmjs.org/package/codemirror
