### PR TITLE
More precise getHintElement() function

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -144,9 +144,9 @@
     return ourMap;
   }
 
-  function getHintElement(stopAt, el) {
-    while (el && el != stopAt) {
-      if (el.nodeName.toUpperCase() === "LI") return el;
+  function getHintElement(hintsElement, el) {
+    while (el && el != hintsElement) {
+      if (el.nodeName.toUpperCase() === "LI" && el.parentNode == hintsElement) return el;
       el = el.parentNode;
     }
   }


### PR DESCRIPTION
Be more precise in identifying hint element, to prevent misbehavior in cases where the rendered hint element contains an LI in its child nodes. With this change, only those elements that are direct children of the hints element are considered hint elements for event handing purposes.
