### PR TITLE
Fix IE showing empty with 0 padding and resize-to-content

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -450,7 +450,7 @@ window.CodeMirror = (function() {
   // updates.
   function updateDisplayInner(cm, changes, visible, forced) {
     var display = cm.display, doc = cm.doc;
-    if (!display.wrapper.clientWidth) {
+    if (!display.wrapper.offsetWidth) {
       display.showingFrom = display.showingTo = doc.first;
       display.viewOffset = 0;
       return;


### PR DESCRIPTION
Fixes #2011 in at least IE8+.

When the resize-to-content styles are applied along with a removal of vertical padding on .CodeMirror-lines, IE would not display any content. Using `offsetWidth` instead of `clientWidth` fixes this for modern-ish IE.

A more complex solution is needed to solve it for older browsers.

Working example based on this PR is at http://jsbin.com/IWaCobaR/5/edit
Tests passed in Travis: https://travis-ci.org/hitsthings/CodeMirror (just merged this branch into my master)
