### PR TITLE
Add hanging indent to Python mode

### DIFF
--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -168,7 +168,7 @@ def pairwise_cython(double[:, ::1] X):
     <ul>
       <li>version - 2/3 - The version of Python to recognize.  Default is 2.</li>
       <li>singleLineStringErrors - true/false - If you have a single-line string that is not terminated at the end of the line, this will show subsequent lines as errors if true, otherwise it will consider the newline as the end of the string. Default is false.</li>
-      <li>hangingIndent - int - If you want to write long arguments to a function starting on a new line, how much that line should be indented.</li>
+      <li>hangingIndent - int - If you want to write long arguments to a function starting on a new line, how much that line should be indented. Defaults to one normal indentation unit.</li>
     </ul>
     <h2>Advanced Configuration Options:</h2>
     <p>Usefull for superset of python syntax like Enthought enaml, IPython magics and  questionmark help</p>

--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -11,7 +11,7 @@ CodeMirror.defineMode("python", function(conf, parserConf) {
     var doubleDelimiters = parserConf.doubleDelimiters || new RegExp("^((\\+=)|(\\-=)|(\\*=)|(%=)|(/=)|(&=)|(\\|=)|(\\^=))");
     var tripleDelimiters = parserConf.tripleDelimiters || new RegExp("^((//=)|(>>=)|(<<=)|(\\*\\*=))");
     var identifiers = parserConf.identifiers|| new RegExp("^[_A-Za-z][_A-Za-z0-9]*");
-    var hangingIndent = parserConf.hangingIndent || 4;
+    var hangingIndent = parserConf.hangingIndent || parserConf.indentUnit;
 
     var wordOperators = wordRegexp(['and', 'or', 'not', 'is', 'in']);
     var commonkeywords = ['as', 'assert', 'break', 'class', 'continue',


### PR DESCRIPTION
With this change it still aligns to the opening paren/bracket/brace in general. But if you go to a new line immediately after the opening paren/bracket/brace, it indents a fixed amount. This makes it easy to type things like:

```
foo = {
    1: 2,
    2: 3,
}

def myReallyLongMethod(
    someReallyLongParam="defaultValue",
    anotherReallyLongParam)
```
