### PR TITLE
[R mode] Fix bad post-'else if' indentation

### DIFF
--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -36,7 +36,11 @@ CodeMirror.defineMode("r", function(config) {
       var word = stream.current();
       if (atoms.propertyIsEnumerable(word)) return "atom";
       if (keywords.propertyIsEnumerable(word)) {
-        if (blockkeywords.propertyIsEnumerable(word)) curPunc = "block";
+        // Block keywords start new blocks, except 'else if', which only starts
+        // one new block for the 'if', no block for the 'else'.
+        if (blockkeywords.propertyIsEnumerable(word) &&
+            !stream.match(/\s*if(\s+|$)/, false))
+          curPunc = "block";
         return "keyword";
       }
       if (builtins.propertyIsEnumerable(word)) return "builtin";


### PR DESCRIPTION
Currently, if you have

```
if (x) {
  a
} else if (y) {
  b
}
```

in R mode and press return on the last line, you'll be indented to one level instead of at the very left.
