### PR TITLE
[markdown] Lists after atx headers should be highlighted

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -664,7 +664,15 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.formatting = false;
 
       if (stream.sol()) {
-        if (stream.match(/^\s*$/, true)) {
+        var forceBlankLine = false;
+        if (stream.match(/^\s*$/, true) || state.header) {
+          forceBlankLine = true;
+        }
+
+        // Reset state.header
+        state.header = 0;
+
+        if (forceBlankLine) {
           state.prevLineHasContent = false;
           return blankLine(state);
         } else {
@@ -674,9 +682,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
         // Reset state.escape
         state.escape = false;
-
-        // Reset state.header
-        state.header = 0;
 
         // Reset state.taskList
         state.taskList = false;

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -276,6 +276,11 @@
      "1. bar",
      "2. hello");
 
+  // List after header
+  MT("listAfterHeader",
+     "[header&header1 # foo]",
+     "[variable-2 - bar]");
+
   // Formatting in lists (*)
   MT("listAsteriskFormatting",
      "[variable-2 * ][variable-2&em *foo*][variable-2  bar]",


### PR DESCRIPTION
Atx-style headers are special in that they don't require a blank line after them to start a new block.

Closes #2040
