### PR TITLE
[markdown] Specify type of list when highlightFormatting is enabled

### DIFF
--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -16,8 +16,8 @@
      "[comment&formatting&formatting-code-block ```]");
 
   FT("taskList",
-     "[variable-2&formatting&formatting-list - ][meta&formatting&formatting-task [ ]]][variable-2  foo]",
-     "[variable-2&formatting&formatting-list - ][property&formatting&formatting-task [x]]][variable-2  foo]");
+     "[variable-2&formatting&formatting-list&formatting-list-ul - ][meta&formatting&formatting-task [ ]]][variable-2  foo]",
+     "[variable-2&formatting&formatting-list&formatting-list-ul - ][property&formatting&formatting-task [x]]][variable-2  foo]");
 
   MT("emInWordAsterisk",
      "foo[em *bar*]hello");

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -165,7 +165,14 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return switchInline(stream, state, footnoteLink);
     } else if (stream.match(hrRE, true)) {
       return hr;
-    } else if ((!state.prevLineHasContent || prevLineIsList) && (stream.match(ulRE, true) || stream.match(olRE, true))) {
+    } else if ((!state.prevLineHasContent || prevLineIsList) && (stream.match(ulRE, false) || stream.match(olRE, false))) {
+      var listType = null;
+      if (stream.match(ulRE, true)) {
+        listType = 'ul';
+      } else {
+        stream.match(olRE, true);
+        listType = 'ol';
+      }
       state.indentation += 4;
       state.list = true;
       state.listDepth++;
@@ -173,7 +180,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         state.taskList = true;
       }
       state.f = state.inline;
-      if (modeCfg.highlightFormatting) state.formatting = "list";
+      if (modeCfg.highlightFormatting) state.formatting = ["list", "list-" + listType];
       return getType(state);
     } else if (modeCfg.fencedCodeBlocks && stream.match(/^```([\w+#]*)/, true)) {
       // try switching mode

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -33,9 +33,9 @@
      "[atom&formatting&formatting-quote > ][atom foo]");
 
   FT("formatting_list",
-     "[variable-2&formatting&formatting-list - ][variable-2 foo]");
+     "[variable-2&formatting&formatting-list&formatting-list-ul - ][variable-2 foo]");
   FT("formatting_list",
-     "[variable-2&formatting&formatting-list 1. ][variable-2 foo]");
+     "[variable-2&formatting&formatting-list&formatting-list-ol 1. ][variable-2 foo]");
 
   FT("formatting_link",
      "[link&formatting&formatting-link [][link foo][link&formatting&formatting-link ]]][string&formatting&formatting-link-string (][string http://example.com/][string&formatting&formatting-link-string )]");


### PR DESCRIPTION
Closes #2039. There was some confusion when the issue was opened, but the request was narrowed down [in the comments](https://github.com/marijnh/CodeMirror/issues/2039#issuecomment-30163517). It was originally [requested in another issue](https://github.com/marijnh/CodeMirror/issues/1919#issuecomment-29655125).

@davedawson and @lukasoppermann, want to take a look at this and verify all of the features are in now?
