### PR TITLE
Fix optionality of "architecture" in gas mode

### DIFF
--- a/mode/gas/gas.js
+++ b/mode/gas/gas.js
@@ -211,7 +211,7 @@ CodeMirror.defineMode("gas", function(_config, parserConfig) {
     });
   }
 
-  var arch = parserConfig.architecture.toLowerCase();
+  var arch = parserConfig.architecture && parserConfig.architecture.toLowerCase();
   if (arch === "x86") {
     x86(parserConfig);
   } else if (arch === "arm" || arch === "armv6") {


### PR DESCRIPTION
Currently, using gas mode without specifying an architecture causes
an error. Fix by checking if "architecture" actually exists.
