### PR TITLE
Use requestAnimationFrame to prevent hint pop-over from flickering

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -64,9 +64,16 @@
       this.widget = new Widget(this, data);
       CodeMirror.signal(data, "shown");
 
-      var debounce = null, completion = this, finished;
+      var debounce = 0, completion = this, finished;
       var closeOn = this.options.closeCharacters || /[\s()\[\]{};:>,]/;
       var startPos = this.cm.getCursor(), startLen = this.cm.getLine(startPos.line).length;
+
+      var requestAnimationFrame = window.requestAnimationFrame || function(fn) {
+        return setTimeout(fn, 1000/60);
+      };
+      var cancelAnimationFrame = window.cancelAnimationFrame || function(id) {
+        return clearTimeout(id);
+      };
 
       function done() {
         if (finished) return;
@@ -91,15 +98,22 @@
         completion.widget = new Widget(completion, data);
       }
 
+      function clearDebounce() {
+        if (debounce) {
+          cancelAnimationFrame(debounce);
+          debounce = 0;
+        }
+      }
+
       function activity() {
-        clearTimeout(debounce);
+        clearDebounce();
         var pos = completion.cm.getCursor(), line = completion.cm.getLine(pos.line);
         if (pos.line != startPos.line || line.length - pos.ch != startLen - startPos.ch ||
             pos.ch < startPos.ch || completion.cm.somethingSelected() ||
             (pos.ch && closeOn.test(line.charAt(pos.ch - 1)))) {
           completion.close();
         } else {
-          debounce = setTimeout(update, 170);
+          debounce = requestAnimationFrame(update);
           if (completion.widget) completion.widget.close();
         }
       }


### PR DESCRIPTION
Before:

![before](https://f.cloud.github.com/assets/55838/1834527/73186870-73de-11e3-9ab4-294c32c05f66.gif)

After:

![after](https://f.cloud.github.com/assets/55838/1834529/7aebee00-73de-11e3-996b-8f2451a0de63.gif)

Fixes #1852.

http://caniuse.com/requestanimationframe
