### PR TITLE
Set !important on background for solarized theme

### DIFF
--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -165,10 +165,10 @@ Active line. Negative margin compensates left padding of the text in the
 view-port
 */
 .cm-s-solarized.cm-s-dark .CodeMirror-activeline-background {
-  background: rgba(255, 255, 255, 0.10);
+  background: rgba(255, 255, 255, 0.10) !important;
 }
 .cm-s-solarized.cm-s-light .CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0.10);
+  background: rgba(0, 0, 0, 0.10) !important;
 }
 
 /*


### PR DESCRIPTION
Without `!important` set, the rule is ignored.
