### PR TITLE
Copy action in emacs mode should stop extending selection.

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -249,6 +249,8 @@
     }),
     "Alt-W": function(cm) {
       addToRing(cm.getSelection());
+      cm.setExtending(false);
+      cm.setCursor(cm.getCursor());
     },
     "Ctrl-Y": function(cm) {
       var start = cm.getCursor();


### PR DESCRIPTION
Found this issue by playing with LightTable but it is fully reproducible here http://codemirror.net/demo/emacs.html

Alt-W should normally copy the selected text and reset the selection. But in codemirror the selection remains, and it is still extensible, thus moving the cursor changes the selection (even after the copy).
