### PR TITLE
Support collection literals in Smalltalk

### DIFF
--- a/mode/smalltalk/smalltalk.js
+++ b/mode/smalltalk/smalltalk.js
@@ -35,7 +35,7 @@ CodeMirror.defineMode('smalltalk', function(config) {
     } else if (aChar === '\'') {
       token = nextString(stream, new Context(nextString, context));
 
-    } else if (aChar === '#') {
+    } else if (aChar === '#' && !/[{(]/.test(stream.peek())) {
       if (stream.peek() === '\'') {
         stream.next();
         token = nextSymbol(stream, new Context(nextSymbol, context));


### PR DESCRIPTION
For example, #{'a' -> 1. 'b' -> 2} and #(1 2 3). This change allows matchBrackets to function correctly with these elements. Tested manually with Amber Smalltalk.

I also loaded index.html which looks fine. I can add some code to that if it would be useful.
