### PR TITLE
Added pastel on dark theme

### DIFF
--- a/theme/pastel-on-dark.css
+++ b/theme/pastel-on-dark.css
@@ -1,16 +1,18 @@
 /**
  * Pastel On Dark theme ported from ACE editor
- * @license BSD
+ * @license MIT
  * @copyright AtomicPages LLC 2014
  * @author Dennis Thompson, AtomicPages LLC
- * @version 1.0
- * @source https://github.com/atomicpages/codemirror-pastel-on-dark-theme/
+ * @version 1.1
+ * @source https://github.com/atomicpages/codemirror-pastel-on-dark-theme
  */
 
 .cm-s-pastel-on-dark.CodeMirror {
 	background: #2c2827;
 	color: #8F938F;
 	line-height: 1.5;
+	font-family: consolas, Courier, monospace;
+	font-size: 14px;
 }
 .cm-s-pastel-on-dark div.CodeMirror-selected { background: rgba(221,240,255,0.2) !important; }
 .cm-s-pastel-on-dark .CodeMirror-gutters {


### PR DESCRIPTION
Added pastel on dark theme. See [the repo](https://github.com/atomicpages/codemirror-pastel-on-dark) for more details and images. If there are any issues then please work the repo or let us know so it can be fixed promtly!
