### PR TITLE
Add a F# mode with simple highlighting

### DIFF
--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 
-<title>CodeMirror: OCaml mode</title>
+<title>CodeMirror: ML-like mode</title>
 <meta charset="utf-8"/>
 <link rel=stylesheet href="../../doc/docs.css">
 
 <link rel=stylesheet href=../../lib/codemirror.css>
 <script src=../../lib/codemirror.js></script>
 <script src=../../addon/edit/matchbrackets.js></script>
-<script src=ocaml.js></script>
+<script src=mllike.js></script>
 <style type=text/css>
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
@@ -21,7 +21,7 @@
   </ul>
   <ul>
     <li><a href="../index.html">Language modes</a>
-    <li><a class=active href="#">OCaml</a>
+    <li><a class=active href="#">ML-like</a>
   </ul>
 </div>
 
@@ -29,7 +29,7 @@
 <h2>OCaml mode</h2>
 
 
-<textarea id=code>
+<textarea id="ocamlCode">
 (* Summing a list of integers *)
 let rec sum xs =
   match xs with
@@ -89,7 +89,7 @@ let rec sort = function
 
 and insert elem = function
   | [] -&gt; [elem]
-  | x :: l -&gt; 
+  | x :: l -&gt;
       if elem &lt; x then elem :: x :: l else x :: insert elem l;;
 
 (* Imperative features *)
@@ -134,13 +134,46 @@ let () =
 (* OCaml page on Wikipedia - http://en.wikipedia.org/wiki/OCaml *)
 </textarea>
 
+<h2>F# mode</h2>
+<textarea id="fsharpCode">
+module CodeMirror.FSharp
+
+let rec fib = function
+    | 0 -> 0
+    | 1 -> 1
+    | n -> fib (n - 1) + fib (n - 2)
+
+type Point =
+    {
+        x : int
+        y : int
+    }
+
+type Color =
+    | Red
+    | Green
+    | Blue
+
+[0 .. 10]
+|> List.map ((+) 2)
+|> List.fold (fun x y -> x + y) 0
+|> printf "%i"
+</textarea>
+
+
 <script>
-  var editor = CodeMirror.fromTextArea(document.getElementById('code'), {
-    mode: 'ocaml',
+  var ocamlEditor = CodeMirror.fromTextArea(document.getElementById('ocamlCode'), {
+    mode: 'text/x-ocaml',
+    lineNumbers: true,
+    matchBrackets: true
+  });
+
+  var fsharpEditor = CodeMirror.fromTextArea(document.getElementById('fsharpCode'), {
+    mode: 'text/x-fsharp',
     lineNumbers: true,
     matchBrackets: true
   });
 </script>
 
-<p><strong>MIME types defined:</strong> <code>text/x-ocaml</code>.</p>
+<p><strong>MIME types defined:</strong> <code>text/x-ocaml</code> (OCaml) and <code>text/x-fsharp</code> (F#).</p>
 </article>

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -1,14 +1,11 @@
-CodeMirror.defineMode('ocaml', function() {
+CodeMirror.defineMode('mllike', function(_config, parserConfig) {
 
   var words = {
-    'true': 'atom',
-    'false': 'atom',
     'let': 'keyword',
     'rec': 'keyword',
     'in': 'keyword',
     'of': 'keyword',
     'and': 'keyword',
-    'succ': 'keyword',
     'if': 'keyword',
     'then': 'keyword',
     'else': 'keyword',
@@ -25,16 +22,18 @@ CodeMirror.defineMode('ocaml', function() {
     'match': 'keyword',
     'with': 'keyword',
     'try': 'keyword',
-    'raise': 'keyword',
-    'begin': 'keyword',
-    'end': 'keyword',
     'open': 'builtin',
-    'trace': 'builtin',
     'ignore': 'builtin',
-    'exit': 'builtin',
-    'print_string': 'builtin',
-    'print_endline': 'builtin'
+    'begin': 'keyword',
+    'end': 'keyword'
   };
+
+  var extraWords = parserConfig.extraWords || {};
+  for (var prop in extraWords) {
+    if (extraWords.hasOwnProperty(prop)) {
+      words[prop] = parserConfig.extraWords[prop];
+    }
+  }
 
   function tokenBase(stream, state) {
     var ch = stream.next();
@@ -113,4 +112,74 @@ CodeMirror.defineMode('ocaml', function() {
   };
 });
 
-CodeMirror.defineMIME('text/x-ocaml', 'ocaml');
+CodeMirror.defineMIME('text/x-ocaml', {
+  name: 'mllike',
+  extraWords: {
+    'succ': 'keyword',
+    'trace': 'builtin',
+    'exit': 'builtin',
+    'print_string': 'builtin',
+    'print_endline': 'builtin',
+    'true': 'atom',
+    'false': 'atom',
+    'raise': 'keyword'
+  }
+});
+
+CodeMirror.defineMIME('text/x-fsharp', {
+  name: 'mllike',
+  extraWords: {
+    'abstract': 'keyword',
+    'as': 'keyword',
+    'assert': 'keyword',
+    'base': 'keyword',
+    'class': 'keyword',
+    'default': 'keyword',
+    'delegate': 'keyword',
+    'downcast': 'keyword',
+    'downto': 'keyword',
+    'elif': 'keyword',
+    'exception': 'keyword',
+    'extern': 'keyword',
+    'finally': 'keyword',
+    'global': 'keyword',
+    'inherit': 'keyword',
+    'inline': 'keyword',
+    'interface': 'keyword',
+    'internal': 'keyword',
+    'lazy': 'keyword',
+    'let!': 'keyword',
+    'member' : 'keyword',
+    'module': 'keyword',
+    'namespace': 'keyword',
+    'new': 'keyword',
+    'null': 'keyword',
+    'override': 'keyword',
+    'private': 'keyword',
+    'public': 'keyword',
+    'return': 'keyword',
+    'return!': 'keyword',
+    'select': 'keyword',
+    'static': 'keyword',
+    'struct': 'keyword',
+    'upcast': 'keyword',
+    'use': 'keyword',
+    'use!': 'keyword',
+    'val': 'keyword',
+    'when': 'keyword',
+    'yield': 'keyword',
+    'yield!': 'keyword',
+
+    'List': 'builtin',
+    'Seq': 'builtin',
+    'Map': 'builtin',
+    'Set': 'builtin',
+    'int': 'builtin',
+    'string': 'builtin',
+    'raise': 'builtin',
+    'failwith': 'builtin',
+    'not': 'builtin',
+    'true': 'builtin',
+    'false': 'builtin'
+  }
+});


### PR DESCRIPTION
Add support for the F# programming language. Highlighting is provided
for all keywords, simple number literals, and select built-ins. Comment
and string highlighting is not currently supported.
