### PR TITLE
runmode-standalone.js lacks text/plain mode definition

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -91,6 +91,10 @@ CodeMirror.getMode = function (options, spec) {
   return mfactory(options, spec);
 };
 CodeMirror.registerHelper = CodeMirror.registerGlobalHelper = Math.min;
+CodeMirror.defineMode("null", function() {
+  return {token: function(stream) {stream.skipToEnd();}};
+});
+CodeMirror.defineMIME("text/plain", "null");
 
 CodeMirror.runMode = function (string, modespec, callback, options) {
   var mode = CodeMirror.getMode({ indentUnit: 2 }, modespec);


### PR DESCRIPTION
This patch adds definition of text/plain mode into runmode-standalone.js. This mode is needed as htmlmixed mode relies on its existence. 
