### PR TITLE
Fix bug in updateScrollbars.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -337,8 +337,9 @@ window.CodeMirror = (function() {
     if (needsV) {
       d.scrollbarV.style.display = "block";
       d.scrollbarV.style.bottom = needsH ? scrollbarWidth(d.measure) + "px" : "0";
+      // A bug in IE8 can cause this value to be negative, so guard it.
       d.scrollbarV.firstChild.style.height =
-        (scrollHeight - d.scroller.clientHeight + d.scrollbarV.clientHeight) + "px";
+        Math.max(0, scrollHeight - d.scroller.clientHeight + d.scrollbarV.clientHeight) + "px";
     } else {
       d.scrollbarV.style.display = "";
       d.scrollbarV.firstChild.style.height = "0";


### PR DESCRIPTION
On IE8 only scrollHeight - d.scroller.clientHeight + d.scrollbarV.clientHeight evaluates to -ve in some cases. Guard that with returning 0 in that case. Seems a bug in IE8, so this can be treated as a workaround.
