### PR TITLE
Don't generate class="cm-"

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4476,7 +4476,7 @@ window.CodeMirror = (function() {
   function interpretTokenStyle(style, builder) {
     if (!style) return null;
     for (;;) {
-      var lineClass = style.match(/(?:^|\s)line-(background-)?(\S+)/);
+      var lineClass = style.match(/(?:^|\s+)line-(background-)?(\S+)/);
       if (!lineClass) break;
       style = style.slice(0, lineClass.index) + style.slice(lineClass.index + lineClass[0].length);
       var prop = lineClass[1] ? "bgClass" : "textClass";
@@ -4485,10 +4485,10 @@ window.CodeMirror = (function() {
       else if (!(new RegExp("(?:^|\s)" + lineClass[2] + "(?:$|\s)")).test(builder[prop]))
         builder[prop] += " " + lineClass[2];
     }
-    if (!style) return null;
+    if (/^\s*$/.test(style)) return null;
     var cache = builder.cm.options.addModeClass ? styleToClassCacheWithMode : styleToClassCache;
     return cache[style] ||
-      (cache[style] = "cm-" + style.replace(/ +/g, " cm-"));
+      (cache[style] = style.replace(/\S+/g, "cm-$&"));
   }
 
   function buildLineContent(cm, realLine, measure, copyWidgets) {

--- a/test/test.js
+++ b/test/test.js
@@ -1625,8 +1625,9 @@ testCM("change_removedText", function(cm) {
 testCM("lineStyleFromMode", function(cm) {
   CodeMirror.defineMode("test_mode", function() {
     return {token: function(stream) {
-      if (stream.match(/^\[[^\]]*\]/)) return "line-brackets";
-      if (stream.match(/^\([^\)]*\)/)) return "line-background-parens";
+      if (stream.match(/^\[[^\]]*\]/)) return "  line-brackets  ";
+      if (stream.match(/^\([^\)]*\)/)) return "  line-background-parens  ";
+      if (stream.match(/^<[^>]*>/)) return "  span  line-line  line-background-bg  ";
       stream.match(/^\s+|^\S+/);
     }};
   });
@@ -1636,13 +1637,20 @@ testCM("lineStyleFromMode", function(cm) {
   eq(bracketElts[0].nodeName, "PRE");
   is(!/brackets.*brackets/.test(bracketElts[0].className));
   eq(bracketElts[0].getElementsByTagName("span").length, 0);
+
   var parenElts = byClassName(cm.getWrapperElement(), "parens");
   eq(parenElts.length, 1);
   eq(parenElts[0].nodeName, "DIV");
   is(!/parens.*parens/.test(parenElts[0].className));
   eq(parenElts[0].parentElement.nodeName, "DIV");
   eq(parenElts[0].parentElement.getElementsByTagName("span").length, 0);
-}, {value: "line1: [br] [br]\nline2: (par) (par)\nline3: nothing"});
+
+  eq(byClassName(cm.getWrapperElement(), "bg").length, 1);
+  eq(byClassName(cm.getWrapperElement(), "line").length, 1);
+  var spanElts = byClassName(cm.getWrapperElement(), "cm-span");
+  eq(spanElts.length, 2);
+  is(/^\s*cm-span\s*$/.test(spanElts[0].className));
+}, {value: "line1: [br] [br]\nline2: (par) (par)\nline3: <tag> <tag>"});
 
 CodeMirror.registerHelper("xxx", "a", "A");
 CodeMirror.registerHelper("xxx", "b", "B");


### PR DESCRIPTION
The first commit is a bug fix.

The second is a nice-to-have relaxation - it's a bit hard that modes that want to return several styles must special-case the first (or last) to construct "foo bar baz" without leading/trailing spaces; "foo bar baz " would be easier.
It also opens the door to returning "" instead of null.  It could be nice if "" were the interface all along — one benefit is that when wrapping an inner mode the result from token() could be processed as a string without special-casing null — but we can't rewrite history.  Given existing modes that return null and existing wrappers that expect null and not "", I'm not sure you'll want to document this relaxation...
