### PR TITLE
[css] implement @document

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -136,6 +136,8 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       return pushContext(state, stream, "block");
     } else if (type == "}" && state.context.prev) {
       return popContext(state);
+    } else if (type == "@document") {
+      return pushContext(state, stream, "keyframes");
     } else if (type == "@media") {
       return pushContext(state, stream, "media");
     } else if (type == "@font-face") {


### PR DESCRIPTION
Depends on pr #2161

``` css
@document url(http://www.w3.org/),
               url-prefix(http://www.w3.org/Style/),
               domain(mozilla.org),
               regexp("https:.*")
{
  /* CSS rules here apply to:
     + The page "http://www.w3.org/".
     + Any page whose URL begins with "http://www.w3.org/Style/"
     + Any page whose URL's host is "mozilla.org" or ends with
       ".mozilla.org"
     + Any page whose URL starts with "https:" */

  /* make the above-mentioned pages really ugly */
  body { color: purple; background: yellow; }
}
```
