### PR TITLE
[closetag addon] Allow typing '/' if there's no matching open tag

### DIFF
--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -82,6 +82,7 @@
 
     var tagName = state.context && state.context.tagName;
     if (tagName) cm.replaceSelection("/" + tagName + ">", "end");
+    else return CodeMirror.Pass;
   }
 
   function indexOf(collection, elt) {


### PR DESCRIPTION
This fixes the following bug:
1. Open demo/closetag.html
2. Delete all the text in the editor
3. Type `</`

Result: typing `/` has no effect
