### PR TITLE
Expose triggerOnKeyPress and triggerOnKeyUp events for testing

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1629,10 +1629,7 @@ window.CodeMirror = (function() {
     }
     setTimeout(unregister, 5000);
 
-    on(d.input, "keyup", operation(cm, function(e) {
-      if (signalDOMEvent(cm, e) || cm.options.onKeyEvent && cm.options.onKeyEvent(cm, addStop(e))) return;
-      if (e.keyCode == 16) cm.doc.sel.shift = false;
-    }));
+    on(d.input, "keyup", operation(cm, onKeyUp));
     on(d.input, "input", function() {
       if (ie && !ie_lt9 && cm.display.inputHasSelection) cm.display.inputHasSelection = null;
       fastPoll(cm);
@@ -2140,6 +2137,12 @@ window.CodeMirror = (function() {
       signalLater(cm, "keyHandled", cm, "'" + ch + "'", e);
     }
     return handled;
+  }
+
+  function onKeyUp(e) {
+    var cm = this;
+    if (signalDOMEvent(cm, e) || cm.options.onKeyEvent && cm.options.onKeyEvent(cm, addStop(e))) return;
+    if (e.keyCode == 16) cm.doc.sel.shift = false;
   }
 
   var lastStoppedKey = null;
@@ -3158,6 +3161,7 @@ window.CodeMirror = (function() {
 
     triggerOnKeyDown: operation(null, onKeyDown),
     triggerOnKeyPress: operation(null, onKeyPress),
+    triggerOnKeyUp: operation(null, onKeyUp),
 
     execCommand: function(cmd) {
       if (commands.hasOwnProperty(cmd))


### PR DESCRIPTION
I would like to set up a test harness for the CodeMirror text editor, and I didn't find a way to emulate keyboard events from javascript.
Nevertheless, I've found method `triggerOnKeyDown` that you exposed for testing purposes. If there were also methods `triggerOnKeyPress` and `triggerOnKeyUp`, then it would be possible to fully emulate key events for CodeMirror - here's [how I did it](https://gist.github.com/aslushnikov/8583301).

This pull request suggests exposing these methods from the codemirror. What would you say?
