### PR TITLE
Added "historyAdded" doc event.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5329,6 +5329,8 @@ window.CodeMirror = (function() {
     hist.lastTime = time;
     hist.lastOp = opId;
     hist.lastOrigin = change.origin;
+    
+    if (!last) { signal(doc, "historyAdded"); }
   }
 
   function removeClearedSpans(spans) {


### PR DESCRIPTION
Added a doc event "historyAdded" which is dispatched when a new entry is added to the document history. It is not dispatched when a history entry is amended. This allows CM's history to be integrated easily into application-level undo/redo.

For example, I have used this in an application that includes multiple CM instances with separate documents (not views on a single document, so linkedDoc does not help), and with additional external controls/data. I was able to listen for new history entries on the CM instances, and add corresponding entries into a unified application-level history stack.

Signed-off-by: Grant Skinner info@gskinner.com
