### PR TITLE
Add angle brackets to Clojure symbol matching

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -45,7 +45,7 @@ CodeMirror.defineMode("clojure", function (options) {
         sign: /[+-]/,
         exponent: /e/i,
         keyword_char: /[^\s\(\[\;\)\]]/,
-        symbol: /[\w*+!\-\._?:\/]/
+        symbol: /[\w*+!\-\._?:<>\/]/
     };
 
     function stateStack(indent, type, prev) { // represents a state stack object


### PR DESCRIPTION
Clojure allows angle brackets in symbol names.

They're also quite popular. For example, here is a  [style guide](https://github.com/bbatsov/clojure-style-guide#naming) suggesting to "use `->` instead of `to` in the names of conversion functions".
