### PR TITLE
[markdown mode] Add dash in `header-2`, `formatting-header-4` styles for consistency.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -239,7 +239,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         styles.push(formatting + "-" + state.formatting[i]);
 
         if (state.formatting[i] === "header") {
-          styles.push(formatting + "-" + state.formatting[i] + state.header);
+          styles.push(formatting + "-" + state.formatting[i] + "-" + state.header);
         }
 
         // Add `formatting-quote` and `formatting-quote-#` for blockquotes
@@ -275,7 +275,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     if (state.code) { styles.push(code); }
 
-    if (state.header) { styles.push(header); styles.push(header + state.header); }
+    if (state.header) { styles.push(header); styles.push(header + "-" + state.header); }
 
     if (state.quote) {
       styles.push(quote);

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -23,11 +23,11 @@
      "[comment&formatting&formatting-code ``][comment foo ` bar][comment&formatting&formatting-code ``]");
 
   FT("formatting_atxHeader",
-     "[header&header1&formatting&formatting-header&formatting-header1 #][header&header1  foo # bar ][header&header1&formatting&formatting-header&formatting-header1 #]");
+     "[header&header-1&formatting&formatting-header&formatting-header-1 #][header&header-1  foo # bar ][header&header-1&formatting&formatting-header&formatting-header-1 #]");
 
   FT("formatting_setextHeader",
      "foo",
-     "[header&header1&formatting&formatting-header&formatting-header1 =]");
+     "[header&header-1&formatting&formatting-header&formatting-header-1 =]");
 
   FT("formatting_blockquote",
      "[quote&quote-1&formatting&formatting-quote&formatting-quote-1 > ][quote&quote-1 foo]");
@@ -138,31 +138,31 @@
   // http://daringfireball.net/projects/markdown/syntax#header
 
   MT("atxH1",
-     "[header&header1 # foo]");
+     "[header&header-1 # foo]");
 
   MT("atxH2",
-     "[header&header2 ## foo]");
+     "[header&header-2 ## foo]");
 
   MT("atxH3",
-     "[header&header3 ### foo]");
+     "[header&header-3 ### foo]");
 
   MT("atxH4",
-     "[header&header4 #### foo]");
+     "[header&header-4 #### foo]");
 
   MT("atxH5",
-     "[header&header5 ##### foo]");
+     "[header&header-5 ##### foo]");
 
   MT("atxH6",
-     "[header&header6 ###### foo]");
+     "[header&header-6 ###### foo]");
 
   // H6 - 7x '#' should still be H6, per Dingus
   // http://daringfireball.net/projects/markdown/dingus
   MT("atxH6NotH7",
-     "[header&header6 ####### foo]");
+     "[header&header-6 ####### foo]");
 
   // Inline styles should be parsed inside headers
   MT("atxH1inline",
-     "[header&header1 # foo ][header&header1&em *bar*]");
+     "[header&header-1 # foo ][header&header-1&em *bar*]");
 
   // Setext headers - H1, H2
   // Per documentation, "Any number of underlining =’s or -’s will work."
@@ -174,22 +174,22 @@
   // Check if single underlining = works
   MT("setextH1",
      "foo",
-     "[header&header1 =]");
+     "[header&header-1 =]");
 
   // Check if 3+ ='s work
   MT("setextH1",
      "foo",
-     "[header&header1 ===]");
+     "[header&header-1 ===]");
 
   // Check if single underlining - works
   MT("setextH2",
      "foo",
-     "[header&header2 -]");
+     "[header&header-2 -]");
 
   // Check if 3+ -'s work
   MT("setextH2",
      "foo",
-     "[header&header2 ---]");
+     "[header&header-2 ---]");
 
   // Single-line blockquote with trailing space
   MT("blockquoteSpace",
@@ -278,7 +278,7 @@
 
   // List after header
   MT("listAfterHeader",
-     "[header&header1 # foo]",
+     "[header&header-1 # foo]",
      "[variable-2 - bar]");
 
   // Formatting in lists (*)


### PR DESCRIPTION
CM generally tends to use dashes before numbers, e.g. `variable-2`.
And markdown mode clearly went this way with `quote-3`, `formatting-quote-3` etc.
Seems better to fix while it's fresh rather than keep inconsistent forever. 
@bfrohs, @lukasoppermann any objections?
