### PR TITLE
[vim] fix Ctrl-[ (escape) shortcut for visual mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -74,7 +74,7 @@
     { keys: ['<S-BS>'], type: 'keyToKey', toKeys: ['b'] },
     { keys: ['<C-n>'], type: 'keyToKey', toKeys: ['j'] },
     { keys: ['<C-p>'], type: 'keyToKey', toKeys: ['k'] },
-    { keys: ['C-['], type: 'keyToKey', toKeys: ['<Esc>'] },
+    { keys: ['<C-[>'], type: 'keyToKey', toKeys: ['<Esc>'] },
     { keys: ['<C-c>'], type: 'keyToKey', toKeys: ['<Esc>'] },
     { keys: ['s'], type: 'keyToKey', toKeys: ['c', 'l'], context: 'normal' },
     { keys: ['s'], type: 'keyToKey', toKeys: ['x', 'i'], context: 'visual'},


### PR DESCRIPTION
This fixes a bug where Ctrl-[ does not leave vim visual mode.

Steps to reproduce:
1. go to http://codemirror.net/demo/vim.html
2. in the editor there, make a visual selection (type Vjj, for example)
3. Ctrl-[ should work like Escape, and cancel the visual selection, but it doesn't.

Escape does the right thing here, and Ctrl-[ works great to leave vim insert
mode. This is a one line patch to make Ctrl-[ work in visual mode
