### PR TITLE
[addon runmode] Fixed resolveMode in runmode.node

### DIFF
--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -83,15 +83,13 @@ exports.defineMode("null", function() {
 exports.defineMIME("text/plain", "null");
 
 exports.resolveMode = function(spec) {
-  if (typeof spec == "string" && mimeModes.hasOwnProperty(spec))
+  if (typeof spec == "string" && mimeModes.hasOwnProperty(spec)) {
     spec = mimeModes[spec];
-  else if (spec && typeof spec.name == "string" && mimeModes.hasOwnProperty(spec.name))
+  } else if (spec && typeof spec.name == "string" && mimeModes.hasOwnProperty(spec.name)) {
     spec = mimeModes[spec.name];
-  if (typeof spec == "string")
-    spec = {name: spec};
-  else if (spec == null)
-    spec = {name: "null"};
-  return spec;
+  }
+  if (typeof spec == "string") return {name: spec};
+  else return spec || {name: "null"};
 };
 exports.getMode = function(options, spec) {
   spec = exports.resolveMode(spec);


### PR DESCRIPTION
### Details

While using runmode.node with the "htmlmixed" mode in v3.21.0, the following error is thrown:

```
Object [object Object] has no method 'startState'
```

This is because `exports.resolveMode` is unable to correctly resolve the mode.

Modelling this fix using the getMode function in runmode.node in v3.20.0, the "spec" is correctly resolved with the appropriate mode factory function.
