### PR TITLE
expose full completion data to extraKeys in show-hints.

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -220,7 +220,8 @@
       menuSize: function() { return widget.screenAmount(); },
       length: completions.length,
       close: function() { completion.close(); },
-      pick: function() { widget.pick(); }
+      pick: function() { widget.pick(); },
+      data: data
     }));
 
     if (options.closeOnUnfocus !== false) {

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2110,7 +2110,11 @@
         has <code>moveFocus(n)</code>, <code>setFocus(n)</code>, <code>pick()</code>,
         and <code>close()</code> methods (see the source for details),
         that can be used to change the focused element, pick the
-        current element or close the menu.</dd>
+        current element or close the menu. Additionnaly <code>menuSize()</code>
+        can give you access to the size of the current dropdown menu,
+        <code>length</code> give you the number of availlable completions, and
+        <code>data</code> give you full access to the completion returned by the
+        hinting function.</dd>
         <dt><code><strong>extraKeys</strong>: keymap</code></dt>
         <dd>Like <code>customKeys</code> above, but the bindings will
         be added to the set of default bindings, instead of replacing


### PR DESCRIPTION
Hi, 

Accessing full completion data is convenient is one want to bind `extraKeys` in `show-hints` to insert the common prefix of all completions (cf [context in question I asked a few hours ago](https://groups.google.com/forum/#!topic/codemirror/tGRx65Sft70) ).

This is my attempt at adding what I need to have this functionality. 

I added some more doc at the same time. 

Hope you will accept or at least add this capability to 4.x

Thanks.
