### PR TITLE
use correct classes for headers in variable size md demo

### DIFF
--- a/demo/variableheight.html
+++ b/demo/variableheight.html
@@ -11,12 +11,12 @@
 <style type="text/css">
       .CodeMirror {border: 1px solid silver; border-width: 1px 2px; }
       .cm-header { font-family: arial; }
-      .cm-header1 { font-size: 150%; }
-      .cm-header2 { font-size: 130%; }
-      .cm-header3 { font-size: 120%; }
-      .cm-header4 { font-size: 110%; }
-      .cm-header5 { font-size: 100%; }
-      .cm-header6 { font-size: 90%; }
+      .cm-header-1 { font-size: 150%; }
+      .cm-header-2 { font-size: 130%; }
+      .cm-header-3 { font-size: 120%; }
+      .cm-header-4 { font-size: 110%; }
+      .cm-header-5 { font-size: 100%; }
+      .cm-header-6 { font-size: 90%; }
       .cm-strong { font-size: 140%; }
     </style>
 <div id=nav>


### PR DESCRIPTION
In the variable sizes demo of markdown file, the header classes for specific levels of headers, which should set the size of each header did not match the classes in the editor. This commit fixes that.
