### PR TITLE
Allow completion to have an independant from/to range

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -46,7 +46,7 @@
     pick: function(data, i) {
       var completion = data.list[i];
       if (completion.hint) completion.hint(this.cm, data, completion);
-      else this.cm.replaceRange(getText(completion), data.from, data.to);
+      else this.cm.replaceRange(getText(completion), completion.from||data.from, completion.to||data.to);
       CodeMirror.signal(data, "pick", completion);
       this.close();
     },


### PR DESCRIPTION
Hi Marijnh, 

I'm trying to merge the completions from different sources, which match a from-to range that differs, one of which I have no control about. It seams to me that allowing completion to have a `from-to` range would make sens (also that's how I understood the documentation the first time but that doesn't mater). I didn't found a way to redefine `pick()` myself so I'm proposing that.

Anyway I'm done playing with codemirror for today, I'll replay with that tomorrow (for me) and add docs if you like it, unless you found it not usefull or if I find a way get around. 
