### PR TITLE
Right to Left Layout

### DIFF
--- a/demo/rtl.html
+++ b/demo/rtl.html
@@ -1,0 +1,51 @@
+<!doctype html>
+
+<title>CodeMirror: Right to Left Layout Demo</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../doc/docs.css">
+
+<link rel="stylesheet" href="../lib/codemirror.css">
+<script src="../lib/codemirror.js"></script>
+<script src="../mode/markdown/markdown.js"></script>
+<style type="text/css">
+      .CodeMirror {border: 1px solid black}
+    </style>
+<div id=nav>
+  <a href="http://codemirror.net"><img id=logo src="../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../index.html">Home</a>
+    <li><a href="../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/marijnh/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a class=active href="#">Right to Left Layout</a>
+  </ul>
+</div>
+
+<article>
+<h2>Right to Left Layout Demo</h2>
+<textarea id="code" name="code">
+# مرتب
+متن *مرتب* یا [مارک‌دان]، نوشته‌ای است که شیوه نمایش آن با علامت‌های ساده‌ای مشخص شده است. یعنی شکل نمایش متن را لابه‌لای واژه‌ها می‌نویسید. مثلا *خاص* بودن یک عبارت و یا **تاکید** روی نکته‌ها با کمک ستاره انجام می‌شود.
+
+> وقتی *مرتب* می‌نویسید، مطمئن هستید که چیزی در متن پنهان نشده. در مقابل نرم‌افزار [ورد] که گاهی می‌بینید نشان‌گر روی یک خط خالی ایستاده و به صورت *مورب* قرار گرفته؛ انگار چیزی آن زیر هست. راستش آن زیر، [چیز خیلی مزخرفی] هست.
+
+[مارک‌دان]: https://daringfireball.net/projects/markdown
+[ورد]: http://office.microsoft.com/en-us/word
+[چیز خیلی مزخرفی]: http://www.antipope.org/charlie/blog-static/2013/10/why-microsoft-word-must-die.html
+</textarea>
+
+    <script>
+var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+  mode: "markdown",
+  lineNumbers: false,
+  lineWrapping: true,
+  rtlMoveVisually: false,
+  rtlLayout: true
+});
+</script>
+
+  <p>Demonstration of right to left layout support.</p>
+
+</article>

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -225,6 +225,14 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow-x: hidden;
 }
 
+.CodeMirror-rtl {
+  direction: rtl;
+}
+.CodeMirror-rtl .CodeMirror-vscrollbar {
+  right: initial;
+  left: 0;
+}
+
 .CodeMirror-measure {
   position: absolute;
   width: 100%;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -73,6 +73,8 @@
     themeChanged(this);
     if (options.lineWrapping)
       this.display.wrapper.className += " CodeMirror-wrap";
+    if (options.rtlLayout)
+      this.display.wrapper.className += " CodeMirror-rtl";
     if (options.autofocus && !mobile) focusInput(this);
 
     this.state = {


### PR DESCRIPTION
I've added `rtlLayout` option for using CodeMirror as a right to left text editor. Provided example page  shows its usage which is in Persian language (just like Arabic). I created this example to explain how it should work and at the moment it has some issues.

Rendered text and its styling is correct. But in this mode [bidi algorithm](http://marijnhaverbeke.nl/blog/cursor-in-bidi-text.html)'s behavior must be changed. For example, in the following image, when I put my cursor in the **beginning of the line**, it stands after # character:

![cursor in beginning of the line](https://f.cloud.github.com/assets/370741/2119821/5870e61a-918d-11e3-969c-9e316fe86a5b.png)

Also behavior of multi-cursor algorithm, must be changed. Following image shows that when I move cursor to beginning character of word, it shows two cursor. When you are typing Left to Right, this behavior is right because editor doesn't know your next character is RTL or LTR, but in `rtlLayout` it is nonsense. In this state if you type RTL or LTR characters, CodeMirror appends them under gray cursor which is correct behavior and **the black cursor is useless**:

![multi-cursor](https://f.cloud.github.com/assets/370741/2119830/248458a4-918e-11e3-89da-b2cc7b997eca.png)

Finally, **mouse click and text selection is completely non-predictable**. The correct behavior is obvious: put cursor just under mouse position.

There is similar pull request #1103 which targets same problem but it seems that its changes are removed now. As I said, I've created this simple example for making clear the expected behavior of editor in Right to Left mode, so questions are welcome. 
