### PR TITLE
Fixed cursor layers

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -236,13 +236,13 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
 .CodeMirror div.CodeMirror-cursor {
   position: absolute;
+  z-index: 3;
   border-right: none;
   width: 0;
 }
 
 div.CodeMirror-cursors {
   visibility: hidden;
-  z-index: 3;
 }
 .CodeMirror-focused div.CodeMirror-cursors {
   visibility: visible;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -146,7 +146,7 @@
     // Will contain the actual code, positioned to cover the viewport.
     d.lineDiv = elt("div", null, "CodeMirror-code");
     // Elements are added to these to represent selection and cursors.
-    d.selectionDiv = elt("div", null, null, "z-index: 1");
+    d.selectionDiv = elt("div", null, null, "position: relative; z-index: 1");
     d.cursorDiv = elt("div", null, "CodeMirror-cursors");
     // A visibility: hidden element used to find the size of things.
     d.measure = elt("div", null, "CodeMirror-measure");


### PR DESCRIPTION
I suspect that only z-index styles are inherited only if the parent and child are both absolute or relatively positioned. Since the cursors container is not absolutely, or relatively positioned the z-index: 3 does not affect how the cursors are rendered, which is why we saw leading cursor heads being hidden by the selection.
