### PR TITLE
fixes ruby mode /= operator for highlighting

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -34,6 +34,7 @@ CodeMirror.defineMode("ruby", function(config) {
     if (ch == "`" || ch == "'" || ch == '"') {
       return chain(readQuoted(ch, "string", ch == '"' || ch == "`"), stream, state);
     } else if (ch == "/" && !stream.eol() && stream.peek() != " ") {
+      if (stream.eat("=")) return "operator";
       return chain(readQuoted(ch, "string-2", true), stream, state);
     } else if (ch == "%") {
       var style = "string", embed = true;

--- a/mode/ruby/test.js
+++ b/mode/ruby/test.js
@@ -1,0 +1,11 @@
+(function() {
+  var mode = CodeMirror.getMode({indentUnit: 2}, "ruby");
+  function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
+
+  MT("divide_equal_operator",
+     "[variable bar] [operator /=] [variable foo]");
+
+  MT("divide_equal_operator_no_spacing",
+     "[variable foo][operator /=][number 42]");
+
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -82,6 +82,7 @@
     <script src="../mode/xml/xml.js"></script>
     <script src="../mode/htmlmixed/htmlmixed.js"></script>
     <script src="../mode/ruby/ruby.js"></script>
+    <script src="../mode/ruby/test.js"></script>
     <script src="../mode/haml/haml.js"></script>
     <script src="../mode/haml/test.js"></script>
     <script src="../mode/markdown/markdown.js"></script>


### PR DESCRIPTION
relates to https://github.com/marijnh/CodeMirror/issues/314

now in ruby mode something like `foo /= 3` highlights correctly.
