### PR TITLE
Adding markdown folding

### DIFF
--- a/addon/fold/markdown-fold.js
+++ b/addon/fold/markdown-fold.js
@@ -1,0 +1,23 @@
+CodeMirror.registerHelper("fold", "markdown", function(cm, start) {
+  var level, end, maxDepth = 100, firstLine = cm.getLine(start.line), lastLine = cm.lastLine();
+
+  function headerLevel(line) {
+    if (!line) return maxDepth;
+    var match = line.match(/^#+/);
+    return match ? match[0].length : maxDepth;
+  }
+
+  level = headerLevel(firstLine);
+  if (level === maxDepth) return undefined;
+
+  for (end = start.line + 1; end < lastLine; ++end) {
+    if (headerLevel(cm.getLine(end + 1)) <= level) {
+      break;
+    }
+  }
+
+  return {
+    from: CodeMirror.Pos(start.line, cm.getLine(start.line).length),
+    to: CodeMirror.Pos(end, cm.getLine(end).length)
+  };
+});

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -12,9 +12,11 @@
   <script src="../addon/fold/foldgutter.js"></script>
   <script src="../addon/fold/brace-fold.js"></script>
   <script src="../addon/fold/xml-fold.js"></script>
+  <script src="../addon/fold/markdown-fold.js"></script>
   <script src="../addon/fold/comment-fold.js"></script>
   <script src="../mode/javascript/javascript.js"></script>
   <script src="../mode/xml/xml.js"></script>
+  <script src="../mode/markdown/markdown.js"></script>
   <style type="text/css">
     .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
   </style>
@@ -39,8 +41,10 @@
   <form>
     <div style="max-width: 50em; margin-bottom: 1em">JavaScript:<br>
     <textarea id="code" name="code"></textarea></div>
-    <div style="max-width: 50em">HTML:<br>
+    <div style="max-width: 50em; margin-bottom: 1em">HTML:<br>
     <textarea id="code-html" name="code-html"></textarea></div>
+    <div style="max-width: 50em">Markdown:<br>
+    <textarea id="code-markdown" name="code"></textarea></div>
   </form>
   <script id="script">
 /*
@@ -53,6 +57,8 @@ window.onload = function() {
   sc.innerHTML = "";
   var te_html = document.getElementById("code-html");
   te_html.value = document.documentElement.innerHTML;
+  var te_markdown = document.getElementById("code-markdown");
+  te_markdown.value = "# Foo\n## Bar\n\nblah blah\n\n## Baz\n\nblah blah\n\n# Quux\n\nblah blah\n"
 
   window.editor = CodeMirror.fromTextArea(te, {
     mode: "javascript",
@@ -74,6 +80,15 @@ window.onload = function() {
   });
   editor_html.foldCode(CodeMirror.Pos(0, 0));
   editor_html.foldCode(CodeMirror.Pos(21, 0));
+
+  window.editor_markdown = CodeMirror.fromTextArea(te_markdown, {
+    mode: "markdown",
+    lineNumbers: true,
+    lineWrapping: true,
+    extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},
+    foldGutter: true,
+    gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+  });
 };
   </script>
 </article>

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -738,7 +738,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     blankLine: blankLine,
 
-    getType: getType
+    getType: getType,
+
+    fold: "markdown"
   };
   return mode;
 }, "xml");


### PR DESCRIPTION
Add folding for atx-style headers in markdown, ie.:

```
# Foo

bar

# Baz
```

folds to

```
# Foo <->
# Baz
```
