### PR TITLE
1) Fix a bug whereby multiple '\'es in the replace part of a search and ...

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -2408,6 +2408,10 @@ testVim('ex_substitute_backslash_replacement', function(cm, vim, helpers) {
   helpers.doEx('%s/,/\\\\/g');
   eq('one\\two \n three\\four', cm.getValue());
 }, { value: 'one,two \n three,four'});
+testVim('ex_substitute_multibackslash_replacement', function(cm, vim, helpers) {
+  helpers.doEx('%s/,/\\\\\\\\\\\\\\\\/g'); // 16 backslashes.
+  eq('one\\\\\\\\two \n three\\\\\\\\four', cm.getValue()); // 2*8 backslashes.
+}, { value: 'one,two \n three,four'});
 testVim('ex_substitute_count', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('s/\\d/0/i 2');


### PR DESCRIPTION
...replace

string were getting collapsed into a single one.
2) Split flipEscaping into two specialized functions -- one for the regex part,
and one for the replace part.
