### PR TITLE
YAML lint suport

### DIFF
--- a/addon/lint/yaml-lint.js
+++ b/addon/lint/yaml-lint.js
@@ -1,0 +1,14 @@
+// Depends on js-yaml.js from https://github.com/nodeca/js-yaml
+
+// declare global: jsyaml
+
+CodeMirror.registerHelper("lint", "yaml", function(text) {
+  var found = [];
+  try { jsyaml.load(text); }
+  catch(e) {
+      var loc = e.mark;
+      found.push({ from: CodeMirror.Pos(loc.line, loc.column), to: CodeMirror.Pos(loc.line, loc.column), message: e.message });
+  }
+  return found;
+});
+CodeMirror.yamlValidator = CodeMirror.lint.yaml; // deprecated


### PR DESCRIPTION
Added a wrapper for js-yaml.js to enable YAML lint support. Followed json-lint.js pattern. Unfortunately js-yaml.js only shows one error at a time, but something is better nothing. Checked code with linter and
ran tests. All came back clean.
