### PR TITLE
Implement Solr language mode

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -94,6 +94,7 @@ option.</p>
       <li><a href="smalltalk/index.html">Smalltalk</a></li>
       <li><a href="smarty/index.html">Smarty</a></li>
       <li><a href="smartymixed/index.html">Smarty/HTML mixed</a></li>
+      <li><a href="solr/index.html">Solr</a></li>
       <li><a href="sql/index.html">SQL</a> (several dialects)</li>
       <li><a href="sparql/index.html">SPARQL</a></li>
       <li><a href="stex/index.html">sTeX, LaTeX</a></li>

--- a/mode/solr/index.html
+++ b/mode/solr/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+
+<title>CodeMirror: Solr mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="solr.js"></script>
+<style type="text/css">
+  .CodeMirror {
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
+  }
+
+  .CodeMirror .cm-operator {
+    color: orange;
+  }
+</style>
+<div id=nav>
+  <a href="http://codemirror.net"><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/marijnh/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">Solr</a>
+  </ul>
+</div>
+
+<article>
+  <h2>Solr mode</h2>
+
+  <div>
+    <textarea id="code" name="code">author:Camus
+
+title:"The Rebel" and author:Camus
+
+philosophy:Existentialism -author:Kierkegaard
+
+hardToSpell:Dostoevsky~
+
+published:[194* TO 1960] and author:(Sartre or "Simone de Beauvoir")</textarea>
+  </div>
+
+  <script>
+    var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+      mode: 'solr',
+      lineNumbers: true
+    });
+  </script>
+
+  <p><strong>MIME types defined:</strong> <code>text/x-solr</code>.</p>
+</article>

--- a/mode/solr/solr.js
+++ b/mode/solr/solr.js
@@ -1,0 +1,89 @@
+CodeMirror.defineMode('solr', function(config, parserConfig) {
+  'use strict';
+
+  var isStringChar = /[^\s\|\!\+\-\*\?\~\^\&\:\(\)\[\]\{\}\^\"\\]/;
+  var isOperatorChar = /[\|\!\+\-\*\?\~\^\&]/;
+  var isOperatorString = /^(OR|AND|NOT|TO)$/i;
+
+  function isNumber(word) {
+    return parseFloat(word, 10).toString() === word;
+  }
+
+  function tokenString(quote) {
+    return function(stream, state) {
+      var escaped = false, next;
+      while ((next = stream.next()) != null) {
+        if (next == quote && !escaped) break;
+        escaped = !escaped && next == '\\';
+      }
+
+      if (!escaped) state.tokenize = tokenBase;
+      return 'string';
+    };
+  }
+
+  function tokenOperator(operator) {
+    return function(stream, state) {
+      var style = 'operator';
+      if (operator == '+')
+        style += ' positive';
+      else if (operator == '-')
+        style += ' negative';
+      else if (operator == '|')
+        stream.eat(/\|/);
+      else if (operator == '&')
+        stream.eat(/\&/);
+      else if (operator == '^')
+        style += ' boost'
+
+      state.tokenize = tokenBase;
+      return style;
+    };
+  }
+
+  function tokenWord(ch) {
+    return function(stream, state) {
+      var word = ch;
+      while ((ch = stream.peek()) && ch.match(isStringChar) != null) {
+        word += stream.next()
+      }
+
+      state.tokenize = tokenBase;
+      if (isOperatorString.test(word))
+        return 'operator';
+      else if (isNumber(word))
+        return 'number';
+      else if (stream.peek() == ':')
+        return 'field';
+      else
+        return 'string';
+    };
+  }
+
+  function tokenBase(stream, state) {
+    var ch = stream.next();
+    if (ch == '"')
+      state.tokenize = tokenString(ch);
+    else if (isOperatorChar.test(ch))
+      state.tokenize = tokenOperator(ch);
+    else if (isStringChar.test(ch))
+      state.tokenize = tokenWord(ch);
+
+    return (state.tokenize != tokenBase) ? state.tokenize(stream, state) : null;
+  }
+
+  return {
+    startState: function() {
+      return {
+        tokenize: tokenBase
+      };
+    },
+
+    token: function(stream, state) {
+      if (stream.eatSpace()) return null;
+      return state.tokenize(stream, state);
+    }
+  }
+});
+
+CodeMirror.defineMIME('text/x-solr', 'solr');


### PR DESCRIPTION
Implements a simple Lucene/EDisMax query language mode. We've found it very useful for query highlighting for advanced users.

I just kinda imitated the other language modes' setup - if I should structure it differently, please let me know.

Lucene / Solr query examples:
http://lucene.apache.org/core/2_9_4/queryparsersyntax.html
https://wiki.apache.org/solr/SolrQuerySyntax
