### PR TITLE
fixed commenting, added more builtins

### DIFF
--- a/mode/octave/index.html
+++ b/mode/octave/index.html
@@ -27,25 +27,16 @@
 
     <div><textarea id="code" name="code">
 %numbers
-1234
-1234i
-1234j
-.234
-.234j
-2.23i
-23e2
-12E1j
-123D-4
-0x234
+[1234 1234i 1234j]
+[.234 .234j 2.23i]
+[23e2 12E1j 123D-4 0x234]
 
 %strings
 'asda''a'
 "asda""a"
 
 %identifiers
-a
-as123
-__asd__
+a + as123 - __asd__
 
 %operators
 -
@@ -73,10 +64,8 @@ classdef properties events methods
 global persistent
 
 %one line comment
-...one line comment
 %{ multi 
 line commment %}
-1
 
     </textarea></div>
     <script>

--- a/mode/octave/octave.js
+++ b/mode/octave/octave.js
@@ -13,17 +13,19 @@ CodeMirror.defineMode("octave", function() {
 
   var builtins = wordRegexp([
     'error', 'eval', 'function', 'abs', 'acos', 'atan', 'asin', 'cos',
-    'cosh', 'exp', 'log', 'prod', 'log10', 'max', 'min', 'sign', 'sin', 'sinh',
+    'cosh', 'exp', 'log', 'prod', 'sum', 'log10', 'max', 'min', 'sign', 'sin', 'sinh',
     'sqrt', 'tan', 'reshape', 'break', 'zeros', 'default', 'margin', 'round', 'ones',
     'rand', 'syn', 'ceil', 'floor', 'size', 'clear', 'zeros', 'eye', 'mean', 'std', 'cov',
     'det', 'eig', 'inv', 'norm', 'rank', 'trace', 'expm', 'logm', 'sqrtm', 'linspace', 'plot',
-    'title', 'xlabel', 'ylabel', 'legend', 'text', 'meshgrid', 'mesh', 'num2str'
+    'title', 'xlabel', 'ylabel', 'legend', 'text', 'grid', 'meshgrid', 'mesh', 'num2str',
+    'fft', 'ifft', 'arrayfun', 'cellfun', 'input', 'fliplr', 'flipud', 'ismember'
   ]);
 
   var keywords = wordRegexp([
     'return', 'case', 'switch', 'else', 'elseif', 'end', 'endif', 'endfunction',
     'if', 'otherwise', 'do', 'for', 'while', 'try', 'catch', 'classdef', 'properties', 'events',
-    'methods', 'global', 'persistent', 'endfor', 'endwhile', 'printf', 'disp', 'until', 'continue'
+    'methods', 'global', 'persistent', 'endfor', 'endwhile', 'printf', 'sprintf', 'disp', 'until',
+    'continue', 'pkg'
   ]);
 
 
@@ -59,7 +61,7 @@ CodeMirror.defineMode("octave", function() {
       return 'comment';
     }
 
-    if (stream.match(/^(%)|(\.\.\.)/)){
+    if (stream.match(/^[%#]/)){
       stream.skipToEnd();
       return 'comment';
     }


### PR DESCRIPTION
I added some builtins that I commonly use in my own projects. I also noticed that "octave mode" was behaving more like "MATLAB mode," in that it treated everything after a ... as a comment and disallowed # comments. Codemirror may want to offer Octave and MATLAB modes separately, as there are minor but important syntax differences.
