### PR TITLE
Yet more built-ins and keywords for octave

### DIFF
--- a/mode/octave/octave.js
+++ b/mode/octave/octave.js
@@ -62,7 +62,7 @@ CodeMirror.defineMode("octave", function() {
       return 'comment';
     }
 
-    if (stream.match(/^(%)|(\.\.\.)/)){
+    if (stream.match(/^[%#]/)){
       stream.skipToEnd();
       return 'comment';
     }


### PR DESCRIPTION
I'm thinking about creating a script to list all the built-ins included with a typical octave install, rather than adding them piecemeal. Is that encouraged? Do we run the risk of spending too much time in regex? My Octave has a lot of built-ins, more than 1000, but some number are from packages not typically included by default.

If that's not the way we want to go, I'll keep slowly adding them as I use them.
