### PR TITLE
[v4] Always check/restore focus around call to `patchDisplay()`

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -609,17 +609,17 @@
 
     // For big changes, we hide the enclosing element during the
     // update, since that speeds up the operations on most browsers.
+    var focused = activeElt();
     if (toUpdate > 4) {
-      var focused = activeElt();
       display.lineDiv.style.display = "none";
     }
     patchDisplay(cm, display.updateLineNumbers, dims);
     if (toUpdate > 4) {
       display.lineDiv.style.display = "";
-      // There might have been a widget with a focused element in the
-      // hidden nodes, if so re-focus it.
-      if (focused && activeElt() != focused && focused.offsetHeight) focused.focus();
     }
+    // There might have been a widget with a focused element that got
+    // hidden or updated, if so re-focus it.
+    if (focused && activeElt() != focused && focused.offsetHeight) focused.focus();
 
     // Prevent these from interfering with the scroll size during
     // subsequent call to updateScrollbars


### PR DESCRIPTION
Prevents focus loss in line widgets when they're updated. See #2279.
