### PR TITLE
add LATIN SMALL LETTER SHARP S (U+00DF) as nonASCIISingleCaseWordChar

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5628,7 +5628,7 @@ window.CodeMirror = (function() {
     return function(){return f.apply(null, args);};
   }
 
-  var nonASCIISingleCaseWordChar = /[\u3040-\u309f\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcc\uac00-\ud7af]/;
+  var nonASCIISingleCaseWordChar = /[\u00df\u3040-\u309f\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcc\uac00-\ud7af]/;
   function isWordChar(ch) {
     return /\w/.test(ch) || ch > "\x80" &&
       (ch.toUpperCase() != ch.toLowerCase() || nonASCIISingleCaseWordChar.test(ch));


### PR DESCRIPTION
Selection via double click does not find the correct word boundaries if the word token contains a 'ß' (U+00DF).

Since "ß".toUpperCase() == "ß".toLowerCase, isWordChar("ß") returns false.

Note: This applies (at least) to recent Firefox and Opera releases, in Chrome based browsers
"ß".toUpperCase() yields to "SS", and everything is fine.

In my eyes this is a bug in Firefox and Opera, but there has already been to much discussion about this ... Even the German speaking community (and "authorities") differ about the capitalisation of "ß" (not to mention, there is a even an LATIN CAPITAL LETTER SHARP S U+1E9E, which is actually not really in use).

So I've added U+00DF to the nonASCIISingleCaseWordChar list.
