### PR TITLE
add reselect-Visual - vim's 'gv'

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1864,7 +1864,7 @@
           var lastSelection = vim.lastSelection;
           cm.setSelection(lastSelection.curStart, lastSelection.curEnd);
           if (lastSelection.visualLine) {
-            vim.visualMode = false;
+            vim.visualMode = true;
             vim.visualLine = true;
           }
           else {

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1533,6 +1533,10 @@ testVim('reselect_visual', function(cm, vim, helpers) {
   helpers.doKeys('d');
   eq('15', cm.getValue());
 }, { value: '12345' });
+testVim('reselect_visual_line', function(cm, vim, helpers) {
+  helpers.doKeys('l', 'V', 'l', 'j', 'j', 'V', 'g', 'v', 'd');
+  eq(' 4\n 5', cm.getValue());
+}, { value: ' 1\n 2\n 3\n 4\n 5' });
 testVim('s_normal', function(cm, vim, helpers) {
   cm.setCursor(0, 1);
   helpers.doKeys('s');


### PR DESCRIPTION
Hi,
  I'm looking to add vim's 'gv' functionality. Currently it handles a selection turned off by 'v', 'V' and 'y'.  I'm looking for feedback. If this looks good, I'm happy to add a test and implement this additional bit of gv:

```
 After using "p" or "P" in Visual mode the text that
 was put will be selected.
```

Thanks for your awesome editor! I'm currently using it from LightTable
