### PR TITLE
Record change objects even if only 'changes' event has a handler

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3367,7 +3367,7 @@
     else
       regChange(cm, from.line, to.line + 1, lendiff);
 
-    if (hasHandler(cm, "change"))
+    if (hasHandler(cm, "change") || hasHandler(cm, "changes"))
       (cm.curOp.changeObjs || (cm.curOp.changeObjs = [])).push({
         from: from, to: to,
         text: change.text,


### PR DESCRIPTION
Add-on to fix for #2281. The 'changes' event doesn't work properly without this. 
