### PR TITLE
Fix TOML's new array of objects syntax

### DIFF
--- a/mode/toml/toml.js
+++ b/mode/toml/toml.js
@@ -38,6 +38,8 @@ CodeMirror.defineMode("toml", function () {
         return 'bracket';
       } else if (state.lhs && stream.peek() === '[' && stream.skipTo(']')) {
         stream.next();//skip closing ]
+        // array of objects has an extra open & close []
+        if (stream.peek() === ']') stream.next();
         return "atom";
       } else if (stream.peek() === "#") {
         stream.skipToEnd();


### PR DESCRIPTION
TOML recently added a syntax like:

``` toml
[[servers]]
name = "alpha"
ip = "10.10.10.10"

[[servers]]
name = "beta"
ip = "20.20.20.20"
```

which compiles to

``` js
[
  {
    name: "alpha",
    ip: "10.10.10.10"
  },
  {
    name: "beta",
    ip: "20.20.20.20"
  }
]
```

This change makes it syntax highlight correctly.
