### PR TITLE
#2288: IE 8 leaks memory when calling .setValue

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -613,11 +613,21 @@ window.CodeMirror = (function() {
   }
 
   function patchDisplay(cm, from, to, intact, updateNumbersFrom) {
+    function removeAllLines(e) {
+      for (var count = e.childNodes.length; count > 0; --count) {
+        // line divs contain the expando properties lineObj, alignable, lineNumber
+        // for IE 8: detach DOM objects alignable and lineNumber to prevent memory leak
+        var first = e.firstChild;
+        first.alignable = first.lineNumber = null;
+        e.removeChild(first);
+      }
+    }
+
     var dims = getDimensions(cm);
-    var display = cm.display, lineNumbers = cm.options.lineNumbers;
+    var display = cm.display, lineNumbers = cm.options.lineNumbers, container = display.lineDiv;
     if (!intact.length && (!webkit || !cm.display.currentWheelTarget))
-      removeChildren(display.lineDiv);
-    var container = display.lineDiv, cur = container.firstChild;
+      removeAllLines(container);
+    var cur = container.firstChild;
 
     function rm(node) {
       var next = node.nextSibling;
@@ -625,6 +635,7 @@ window.CodeMirror = (function() {
         node.style.display = "none";
         node.lineObj = null;
       } else {
+        node.alignable = node.lineNumber = null; // for IE 8, see removeAllLines
         node.parentNode.removeChild(node);
       }
       return next;


### PR DESCRIPTION
Fix. Detach DOM objects alignable and lineNumber from line div to prevent memory leak.
