### PR TITLE
[sublime keymap] When splitting selection, ignore last line if selection ends at beginning of line

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -63,8 +63,9 @@
     for (var i = 0; i < ranges.length; i++) {
       var from = ranges[i].from(), to = ranges[i].to();
       for (var line = from.line; line <= to.line; ++line)
-        lineRanges.push({anchor: line == from.line ? from : Pos(line, 0),
-                         head: line == to.line ? to : Pos(line)});
+        if (!(to.line > from.line && line == to.line && to.ch == 0))
+          lineRanges.push({anchor: line == from.line ? from : Pos(line, 0),
+                           head: line == to.line ? to : Pos(line)});
     }
     cm.setSelections(lineRanges, 0);
   };


### PR DESCRIPTION
In the current implementation, if you select a set of whole lines and do "split selection by line", you'll get an extra cursor on the line below the last whole line selected, which doesn't seem like expected behavior. This fixes that case. (Note that if the range is just a single cursor at a beginning of a line, we don't eliminate it.)
