### PR TITLE
[vim] Add :nunmap and a simple test

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3217,14 +3217,16 @@
             this.commandMap_[commandName] = {
               name: commandName,
               type: 'exToEx',
-              toInput: rhs.substring(1)
+              toInput: rhs.substring(1),
+              user: true
             };
           } else {
             // Ex to key mapping
             this.commandMap_[commandName] = {
               name: commandName,
               type: 'exToKey',
-              toKeys: parseKeyString(rhs)
+              toKeys: parseKeyString(rhs),
+              user: true
             };
           }
         } else {
@@ -3233,7 +3235,8 @@
             var mapping = {
               keys: parseKeyString(lhs),
               type: 'keyToEx',
-              exArgs: { input: rhs.substring(1) }};
+              exArgs: { input: rhs.substring(1) },
+              user: true};
             if (ctx) { mapping.context = ctx; }
             defaultKeymap.unshift(mapping);
           } else {
@@ -3241,7 +3244,8 @@
             var mapping = {
               keys: parseKeyString(lhs),
               type: 'keyToKey',
-              toKeys: parseKeyString(rhs)
+              toKeys: parseKeyString(rhs),
+              user: true
             };
             if (ctx) { mapping.context = ctx; }
             defaultKeymap.unshift(mapping);
@@ -3262,12 +3266,16 @@
           // Ex to Ex or Ex to key mapping
           if (ctx) { throw Error('Mode not supported for ex mappings'); }
           var commandName = lhs.substring(1);
-          delete this.commandMap_[commandName];
+          if (this.commandMap_[commandName] && this.commandMap_[commandName].user) {
+            delete this.commandMap_[commandName];
+          }
         } else {
           // Key to Ex or key to key mapping
           var keys = parseKeyString(lhs);
           for (var i = 0; i < defaultKeymap.length; i++) {
-            if (arrayEquals(keys, defaultKeymap[i].keys) && defaultKeymap[i].context === ctx) {
+            if (arrayEquals(keys, defaultKeymap[i].keys)
+                && defaultKeymap[i].context === ctx
+                && defaultKeymap[i].user) {
               defaultKeymap.splice(i, 1);
               return;
             }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -2554,6 +2554,11 @@ testVim('ex_unmap_key2key', function(cm, vim, helpers) {
   helpers.doKeys('a');
   eq('vim-insert', cm.getOption('keyMap'));
 }, { value: 'abc' });
+testVim('ex_unmap_key2key_does_not_remove_default', function(cm, vim, helpers) {
+  helpers.doEx('unmap a');
+  helpers.doKeys('a');
+  eq('vim-insert', cm.getOption('keyMap'));
+}, { value: 'abc' });
 testVim('ex_map_key2key_to_colon', function(cm, vim, helpers) {
   helpers.doEx('map ; :');
   var dialogOpened = false;


### PR DESCRIPTION
In Vim, defaults keymap cannot be unmapped. They must be explicitly set to <NOP>. In this case we allow that because user defined maps are stored in the same map as the defaults.
There is an ugly array comparison function in unmap(), the reason is that defaultKeymap is an array.
