### PR TITLE
Make setMark() be a toggle like in Emacs:

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1006,6 +1006,8 @@
       the shift key, in that it will cause cursor movement and calls
       to <a href="#extendSelection"><code>extendSelection</code></a>
       to leave the selection anchor in place.</dd>
+      <dt id="getExtending"><code><strong>doc.getExtending</strong>() → boolean</code></dt>
+      <dd>Get the value of the 'extending' flag.</dd>
 
       <dt id="hasFocus"><code><strong>cm.hasFocus</strong>() → boolean</code></dt>
       <dd>Tells you whether the editor currently has focus.</dd>

--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -197,7 +197,7 @@
 
   function setMark(cm) {
     cm.setCursor(cm.getCursor());
-    cm.setExtending(true);
+    cm.setExtending(!cm.getExtending());
     cm.on("change", function() { cm.setExtending(false); });
   }
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5034,6 +5034,7 @@ window.CodeMirror = (function() {
     redo: docOperation(function() {makeChangeFromHistory(this, "redo");}),
 
     setExtending: function(val) {this.sel.extend = val;},
+    getExtending: function() {return this.sel.extend;},
 
     historySize: function() {
       var hist = this.history;


### PR DESCRIPTION
pressing Ctrl-Space once starts the selection extension mode,
pressing it again cancels that

This fixes #2339, [emacs] setMark() / Ctrl-Space is not a toggle
