### PR TITLE
[vim] Macro clean up

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1753,6 +1753,17 @@ testVim('macro_insert', function(cm, vim, helpers) {
   helpers.doKeys('q', '@', 'a');
   eq('foofoo', cm.getValue());
 }, { value: ''});
+testVim('macro_space', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('<Space>', '<Space>');
+  helpers.assertCursorAt(0, 2);
+  helpers.doKeys('q', 'a', '<Space>', '<Space>', 'q');
+  helpers.assertCursorAt(0, 4);
+  helpers.doKeys('@', 'a');
+  helpers.assertCursorAt(0, 6);
+  helpers.doKeys('@', 'a');
+  helpers.assertCursorAt(0, 8);
+}, { value: 'one line of text.'});
 testVim('macro_parens', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
   helpers.doKeys('q', 'z', 'i');


### PR DESCRIPTION
Turn MacroModeState into a proper object instead of just a bag of properties.
fix a spelling error (unamed)
accumulate keys and insert mode changes directly into registers rather than copying from MacroModeState
store keybuffers in macro registers rather than text strings
fix bugs in macro handling (searching via 't' and 'f' keys was broken)
simplify control flow of macros
