### PR TITLE
implement vim's indented paste - adjusting indent to current line

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2025,18 +2025,26 @@
           return;
         }
         if (actionArgs.matchIndent) {
-          var indent = findFirstNonWhiteSpaceCharacter(cm.getLine(cm.getCursor().line));
+          // length that considers tabs and cm.options.tabSize
+          var whitespaceLength = function(str) {
+            var tabs = (str.split("\t").length - 1);
+            var spaces = (str.split(" ").length - 1);
+            return tabs * cm.options.tabSize + spaces * 1;
+          };
+          var currentLine = cm.getLine(cm.getCursor().line);
+          var indent = whitespaceLength(currentLine.match(/^\s*/)[0]);
           // chomp last newline b/c don't want it to match /^\s*/gm
           var chompedText = text.replace(/\n$/, '');
           var wasChomped = text !== chompedText;
-          var firstIndent = text.match(/^\s*/)[0].length;
+          var firstIndent = whitespaceLength(text.match(/^\s*/)[0]);
           var text = chompedText.replace(/^\s*/gm, function(wspace) {
-            var newIndent = indent + (wspace.length - firstIndent);
+            var newIndent = indent + (whitespaceLength(wspace) - firstIndent);
             if (newIndent < 0) {
               return "";
             }
             else if (cm.options.indentWithTabs) {
-              return Array(newIndent + 1).join('\t');
+              var quotient = Math.floor(newIndent / cm.options.tabSize);
+              return Array(quotient + 1).join('\t');
             }
             else {
               return Array(newIndent + 1).join(' ');

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1242,11 +1242,15 @@ testVim(']p_first_indent_is_larger', function(cm, vim, helpers) {
   eq('  ___\n  abc\ndef', cm.getValue());
 }, { value: '  ___' });
 testVim(']p_with_tab_indents', function(cm, vim, helpers) {
-  cm.options.indentWithTabs = true;
   helpers.getRegisterController().pushText('"', 'yank', '\t\tabc\n\t\t\tdef\n', true);
   helpers.doKeys(']', 'p');
   eq('\t___\n\tabc\n\t\tdef', cm.getValue());
-}, { value: '\t___' });
+}, { value: '\t___', indentWithTabs: true});
+testVim(']p_with_spaces_translated_to_tabs', function(cm, vim, helpers) {
+  helpers.getRegisterController().pushText('"', 'yank', '  abc\n    def\n', true);
+  helpers.doKeys(']', 'p');
+  eq('\t___\n\tabc\n\t\tdef', cm.getValue());
+}, { value: '\t___', indentWithTabs: true, tabSize: 2 });
 testVim('[p', function(cm, vim, helpers) {
   helpers.getRegisterController().pushText('"', 'yank', '  abc\n    def\n', true);
   helpers.doKeys('[', 'p');


### PR DESCRIPTION
Hi,
This is a first pass at implementing vim's indented paste, `]p`. If this is going in a good direction, I can also add tests and implement  `[p`, which pastes above using the current line's indent.
Two things to note:
-  I've used `vimApi.handleKey` which isn't a standard thing to do. I didn't know if you wanted to instead use `commandDispatcher.processAction` and `commandDispatcher.matchCommand` which starts to implement parts of `handleKey`.
- I set back the unnamed register because this is consistent with vim's behavior: the register doesn't change when using `]p`. 
