### PR TITLE
fix Issue #1890: [vim] Double clicking a word to select it selects an ex...

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -346,13 +346,17 @@
         cm.state.vim = null;
       }
     });
-    function beforeSelectionChange(cm, cur) {
+    function beforeSelectionChange(cm, obj) {
       var vim = cm.state.vim;
       if (vim.insertMode || vim.exMode) return;
 
-      var head = cur.head;
-      if (head.ch && head.ch == cm.doc.getLine(head.line).length) {
+      var head = obj.head, anchor = obj.anchor;
+      if ((obj.clicktype == 'double') ||
+          (head.ch && head.ch == cm.doc.getLine(head.line).length))
         head.ch--;
+      if (obj.clicktype == 'triple'){
+        head.ch = cm.doc.getLine(anchor.line).length - 1;
+        head.line = anchor.line;
       }
     }
     function getOnPasteFn(cm) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1768,16 +1768,21 @@ window.CodeMirror = (function() {
     var now = +new Date, type = "single";
     if (lastDoubleClick && lastDoubleClick.time > now - 400 && posEq(lastDoubleClick.pos, start)) {
       type = "triple";
+      cm.doc.sel._clicktype = type;
       e_preventDefault(e);
       setTimeout(bind(focusInput, cm), 20);
       selectLine(cm, start.line);
     } else if (lastClick && lastClick.time > now - 400 && posEq(lastClick.pos, start)) {
       type = "double";
+      cm.doc.sel._clicktype = type;
       lastDoubleClick = {time: now, pos: start};
       e_preventDefault(e);
       var word = findWordAt(getLine(doc, start.line).text, start);
       extendSelection(cm.doc, word.from, word.to);
-    } else { lastClick = {time: now, pos: start}; }
+    } else {
+      cm.doc.sel._clicktype = type;
+      lastClick = {time: now, pos: start};
+    }
 
     var last = start;
     if (cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) && !posEq(sel.from, sel.to) &&
@@ -2591,8 +2596,8 @@ window.CodeMirror = (function() {
     if (doc.cm) doc.cm.curOp.userSelChange = true;
   }
 
-  function filterSelectionChange(doc, anchor, head) {
-    var obj = {anchor: anchor, head: head};
+  function filterSelectionChange(doc, anchor, head, clicktype) {
+    var obj = {anchor: anchor, head: head, clicktype: clicktype};
     signal(doc, "beforeSelectionChange", doc, obj);
     if (doc.cm) signal(doc.cm, "beforeSelectionChange", doc.cm, obj);
     obj.anchor = clipPos(doc, obj.anchor); obj.head = clipPos(doc, obj.head);
@@ -2603,8 +2608,10 @@ window.CodeMirror = (function() {
   // updateDoc, since they have to be expressed in the line
   // numbers before the update.
   function setSelection(doc, anchor, head, bias, checkAtomic) {
+    var clicktype = doc.sel._clicktype;
+    doc.sel._clicktype = null;
     if (!checkAtomic && hasHandler(doc, "beforeSelectionChange") || doc.cm && hasHandler(doc.cm, "beforeSelectionChange")) {
-      var filtered = filterSelectionChange(doc, anchor, head);
+      var filtered = filterSelectionChange(doc, anchor, head, clicktype);
       head = filtered.head;
       anchor = filtered.anchor;
     }


### PR DESCRIPTION
This patch is a fix to Issue #1890. It also resolves another bug that is following:

Bug: In normal mode of Vim, triple clicking any character selects whole line and the first character on the next line. So when we do cut/copy operation that character on the next line gets also involved in the operation.

This patch resolves this bug too.
