### PR TITLE
[show-hint addon] Fix race with async enabled

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -93,6 +93,7 @@
         data = data_;
         if (finished) return;
         if (!data || !data.list.length) return done();
+        if (completion.widget) completion.widget.close();
         completion.widget = new Widget(completion, data);
       }
 


### PR DESCRIPTION
Summary: If `options.async` is enabled, it's possible for `activity` to
be called a second time before the first call's paired `finishUpdate` is
triggered. Then, when the second call to `finishUpdate` happens, the
still-active widget in `completion.widget` is unceremoneously
overwritten and can now never be closed. This leads to a lot of weird
and broken behavior, notably an autocomplete window in the browser that
never goes away and can insert its text over and over and over.

Test Plan: This is really hard to trigger. My project consists of a
webworker providing autocomplete, which has some latency before it calls
the `finishUpdate` callback. But it depends on the exact latency and
even the user's typing speed to whether things happen in just the right
order. I basically just added and deleted characters with the
autocomplete prompt open a bunch until it eventually reproduced. After
applying this patch, several minutes of bashing didn't trigger the issue
again.
