### PR TITLE
[v4] Only call signalLater if cm exists.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4822,7 +4822,7 @@
       this.doc.cantEdit = false;
       if (cm) reCheckSelection(cm.doc);
     }
-    signalLater(cm, "markerCleared", cm, this);
+    if (cm) signalLater(cm, "markerCleared", cm, this);
     if (withOp) endOperation(cm);
   };
 


### PR DESCRIPTION
If the document has no `cm` instance attached it results in an error calling `signalLater` without an emitter. This only calls `signalLater` when there is a `cm` instance.
