### PR TITLE
[mac] Turn mouse cursor into crosshair when Alt held

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -250,6 +250,7 @@ div.CodeMirror-cursors {
 
 .CodeMirror-selected { background: #d9d9d9; }
 .CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
+.CodeMirror-crosshair { cursor: crosshair; }
 
 .cm-searching {
   background: #ffa;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2999,6 +2999,20 @@
       if (!handled && code == 88 && !hasCopyEvent && (mac ? e.metaKey : e.ctrlKey))
         cm.replaceSelection("", null, "cut");
     }
+    // Turn mouse into crosshair when Alt is held on Mac.
+    var lineDiv = cm.display.lineDiv;
+    function up(e) {
+      if (e.keyCode == 18 || !e.altKey) {
+        lineDiv.className = lineDiv.className.replace(" CodeMirror-crosshair", "");
+        off(document, "keyup", up);
+        off(document, "mouseover", up);
+      }
+    }
+    if (mac && code == 18 && lineDiv.className.search(/\bCodeMirror-crosshair\b/) == -1) {
+      lineDiv.className += " CodeMirror-crosshair";
+      on(document, "keyup", up);
+      on(document, "mouseover", up);
+    }
   }
 
   function onKeyUp(e) {


### PR DESCRIPTION
On Macs, in native text editing apps with multiple selection available -- TextEdit and Xcode, and in the popular TextMate editor, the mouse cursor turns into a crosshair when alt is held to hint that the selection can be rectangular.

Might be useful for other platforms too, but I only see this behavior on Macs.
