### PR TITLE
[Vim] repeatLastEdit action works after any operation in visual mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1318,16 +1318,32 @@
             motionArgs.inclusive = true;
           }
           // Swap start and end if motion was backward.
-          if (cursorIsBefore(curEnd, curStart)) {
+          if (curEnd && cursorIsBefore(curEnd, curStart)) {
             var tmp = curStart;
             curStart = curEnd;
             curEnd = tmp;
             inverted = true;
+          } else if (!curEnd) {
+            curEnd = copyCursor(curStart);
           }
           if (motionArgs.inclusive && !(vim.visualMode && inverted)) {
             // Move the selection end one to the right to include the last
             // character.
             curEnd.ch++;
+          }
+          if (operatorArgs.relCurEnd) {
+            curEnd.line = curStart.line + operatorArgs.relCurEnd.line;
+            if (operatorArgs.relCurEnd.line) curEnd.ch = operatorArgs.relCurEnd.ch;
+            else curEnd.ch = curStart.ch + operatorArgs.relCurEnd.ch;
+          }
+          else if (vim.visualMode) {
+            // Set relative curEnd position w.r.t. curStart in operatorArgs
+            // to be used by repeatLastEdit action.
+            var relCurEnd = Pos();
+            relCurEnd.line = curEnd.line - curStart.line;
+            if (relCurEnd.line) relCurEnd.ch = curEnd.ch;
+            else relCurEnd.ch = curEnd.ch - curStart.ch;
+            operatorArgs.relCurEnd = relCurEnd;
           }
           var linewise = motionArgs.linewise ||
               (vim.visualMode && vim.visualLine);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -2031,6 +2031,14 @@ testVim('._delete_repeat', function(cm, vim, helpers) {
   eq('zzce', cm.getValue());
   helpers.assertCursorAt(0, 1);
 }, { value: 'zzabcde'});
+testVim('._visual_>', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('V', 'j', '>');
+  cm.setCursor(2, 0)
+  helpers.doKeys('.');
+  eq('  1\n  2\n  3\n  4', cm.getValue());
+  helpers.assertCursorAt(2, 2);
+}, { value: '1\n2\n3\n4'});
 testVim('f;', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
   helpers.doKeys('f', 'x');


### PR DESCRIPTION
This PR resolves issue #2124.
repeatLastEdit ('.' key) action is working after any operation in visual mode.
