### PR TITLE
[vim] correctly append to register and update the unnamed register to match last used register

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -860,13 +860,12 @@
         var append = isUpperCase(registerName);
         if (append) {
           register.pushText(text, linewise);
-          // The unnamed register always has the same value as the last used
-          // register.
-          this.unnamedRegister.setText(text, linewise);
         } else {
           register.setText(text, linewise);
-          this.unnamedRegister.setText(text, linewise);
         }
+        // The unnamed register always has the same value as the last used
+        // register.
+        this.unnamedRegister.setText(register.toString(), linewise);
       },
       // Gets the register named @name.  If one of @name doesn't already exist,
       // create it.  If @name is invalid, return the unnamedRegister.

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1899,6 +1899,7 @@ testVim('yank_append_line_to_line_register', function(cm, vim, helpers) {
   cm.openDialog = helpers.fakeOpenDialog('registers');
   cm.openNotification = helpers.fakeOpenNotification(function(text) {
     is(/a\s+foo\nbar/.test(text));
+    is(/"\s+foo\nbar/.test(text));
   });
   helpers.doKeys(':');
 }, { value: 'foo\nbar'});
@@ -1909,6 +1910,7 @@ testVim('yank_append_word_to_word_register', function(cm, vim, helpers) {
   cm.openDialog = helpers.fakeOpenDialog('registers');
   cm.openNotification = helpers.fakeOpenNotification(function(text) {
     is(/a\s+foobar/.test(text));
+    is(/"\s+foobar/.test(text));
   });
   helpers.doKeys(':');
 }, { value: 'foo\nbar'});
@@ -1919,6 +1921,7 @@ testVim('yank_append_line_to_word_register', function(cm, vim, helpers) {
   cm.openDialog = helpers.fakeOpenDialog('registers');
   cm.openNotification = helpers.fakeOpenNotification(function(text) {
     is(/a\s+foo\nbar/.test(text));
+    is(/"\s+foo\nbar/.test(text));
   });
   helpers.doKeys(':');
 }, { value: 'foo\nbar'});
@@ -1929,6 +1932,7 @@ testVim('yank_append_word_to_line_register', function(cm, vim, helpers) {
   cm.openDialog = helpers.fakeOpenDialog('registers');
   cm.openNotification = helpers.fakeOpenNotification(function(text) {
     is(/a\s+foo\nbar/.test(text));
+    is(/"\s+foo\nbar/.test(text));
   });
   helpers.doKeys(':');
 }, { value: 'foo\nbar'});


### PR DESCRIPTION
Test for the following were added:
Yanking a 
- word then a line should result in two lines:  [word]\n[line]
- word then a word should result in one line:  [word][word]
- line then a line should result in two lines:  [line]\n[line]
- line then a word should result in two lines:  [line]\n[word]

The unnamed register should be identical to last used register in any case.
