### PR TITLE
[vim] Implement aB, iB, ab and ib text objects with an operator.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1660,6 +1660,13 @@
         var selfPaired = {'\'': true, '"': true};
 
         var character = motionArgs.selectedCharacter;
+        // 'b' refers to  '()' block.
+        // 'B' refers to  '{}' block.
+        if (character == 'b') {
+          character = '(';
+        } else if (character == 'B') {
+          character = '{';
+        }
 
         // Inclusive is the difference between a and i
         // TODO: Instead of using the additional text object map to perform text

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1015,18 +1015,32 @@ testEdit('daW_end_punct', 'foo \tbAr.', /A/, 'daW', 'foo');
 //    Open and close on same line
 testEdit('di(_open_spc', 'foo (bAr) baz', /\(/, 'di(', 'foo () baz');
 testEdit('di)_open_spc', 'foo (bAr) baz', /\(/, 'di)', 'foo () baz');
+testEdit('dib_open_spc', 'foo (bAr) baz', /\(/, 'dib', 'foo () baz');
 testEdit('da(_open_spc', 'foo (bAr) baz', /\(/, 'da(', 'foo  baz');
 testEdit('da)_open_spc', 'foo (bAr) baz', /\(/, 'da)', 'foo  baz');
+testEdit('dab_open_spc', 'foo (bAr) baz', /\(/, 'dab', 'foo  baz');
 
 testEdit('di(_middle_spc', 'foo (bAr) baz', /A/, 'di(', 'foo () baz');
 testEdit('di)_middle_spc', 'foo (bAr) baz', /A/, 'di)', 'foo () baz');
+testEdit('dib_middle_spc', 'foo (bAr) baz', /A/, 'dib', 'foo () baz');
 testEdit('da(_middle_spc', 'foo (bAr) baz', /A/, 'da(', 'foo  baz');
 testEdit('da)_middle_spc', 'foo (bAr) baz', /A/, 'da)', 'foo  baz');
+testEdit('dab_middle_spc', 'foo (bAr) baz', /A/, 'dab', 'foo  baz');
 
 testEdit('di(_close_spc', 'foo (bAr) baz', /\)/, 'di(', 'foo () baz');
 testEdit('di)_close_spc', 'foo (bAr) baz', /\)/, 'di)', 'foo () baz');
+testEdit('dib_close_spc', 'foo (bAr) baz', /\)/, 'dib', 'foo () baz');
 testEdit('da(_close_spc', 'foo (bAr) baz', /\)/, 'da(', 'foo  baz');
 testEdit('da)_close_spc', 'foo (bAr) baz', /\)/, 'da)', 'foo  baz');
+testEdit('dab_close_spc', 'foo (bAr) baz', /\)/, 'dab', 'foo  baz');
+
+//  delete around and inner b.
+testEdit('dab_on_(_should_delete_around_()block', 'o( in(abc) )', /\(a/, 'dab', 'o( in )');
+testEdit('dib_on_(_should_delete_inner_()block', 'o( in(abc) )', /\(a/, 'dib', 'o( in() )');
+
+//  delete around and inner B.
+testEdit('daB_on_{_should_delete_around_{}block', 'o{ in{abc} }', /{a/, 'daB', 'o{ in }');
+testEdit('diB_on_{_should_delete_inner_{}block', 'o{ in{abc} }', /{a/, 'diB', 'o{ in{} }');
 
 testEdit('da{_on_{_should_delete_inner_block', 'o{ in{abc} }', /{a/, 'da{', 'o{ in }');
 testEdit('di[_on_(_should_not_delete', 'foo (bAr) baz', /\(/, 'di[', 'foo (bAr) baz');
@@ -1038,14 +1052,18 @@ testMotion('di(_outside_should_stay', ['d', 'i', '('], { line: 0, ch: 0}, { line
 //  Open and close on different lines, equally indented
 testEdit('di{_middle_spc', 'a{\n\tbar\n}b', /r/, 'di{', 'a{}b');
 testEdit('di}_middle_spc', 'a{\n\tbar\n}b', /r/, 'di}', 'a{}b');
+testEdit('diB_middle_spc', 'a{\n\tbar\n}b', /r/, 'diB', 'a{}b');
 testEdit('da{_middle_spc', 'a{\n\tbar\n}b', /r/, 'da{', 'ab');
 testEdit('da}_middle_spc', 'a{\n\tbar\n}b', /r/, 'da}', 'ab');
+testEdit('daB_middle_spc', 'a{\n\tbar\n}b', /r/, 'daB', 'ab');
 
 // open and close on diff lines, open indented less than close
 testEdit('di{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'di{', 'a{}b');
 testEdit('di}_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'di}', 'a{}b');
+testEdit('diB_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'diB', 'a{}b');
 testEdit('da{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'da{', 'ab');
 testEdit('da}_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'da}', 'ab');
+testEdit('daB_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'daB', 'ab');
 
 // open and close on diff lines, open indented more than close
 testEdit('di[_middle_spc', 'a\t[\n\tbar\n]b', /r/, 'di[', 'a\t[]b');


### PR DESCRIPTION
This code implements and tests ab/ib/aB/iB with an operator as indicated below. *Todo all the remaining x's.

```
  -----------------------
  | text-object | o | v |
  -----------------------
  | aw          | y | x |
  | iw          | y | x |
  | aW          | y | x |
  | iW          | y | x |
  | as          | x | x |
  | is          | x | x |
  | ap          | x | x |
  | ip          | x | x |
  | a] a[       | y | x |
  | i] i[       | y | x |
  | a) a( ab    | p | x |
  | i) i( ib    | p | x |
  | a> a<       | x | x |
  | i> i<       | x | x |
  | at          | x | x |
  | it          | x | x |
  | a} a{ aB    | p | x |
  | i} i{ iB    | p | x |
  | a" a' a`    | y | x |
  | i" i' i`    | y | x |
  -----------------------
```

  Legend:
    o: Operator such as d, y, c, etc.
    v: Visual mode (including blockwise & linewise visual mode)
    y: Implemented
    p: Newly implemented b & B.
    x: Not implemented
