### PR TITLE
Fix for Haxe mode

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -322,6 +322,7 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
   function typedef (type, value)
   {
   if(type == "variable" && /[A-Z]/.test(value.charAt(0))) { registerimport(value); return cont(); }
+  else if (type == "type" && /[A-Z]/.test(value.charAt(0))) { return cont(); }
   }
 
   function maybelabel(type) {


### PR DESCRIPTION
Fix indent for types

Before:
![Imgur](http://i.imgur.com/zMxImfY.gif)

After:
![Imgur](http://i.imgur.com/uzzGgaq.gif)

Should work fine, but sometimes(maybe some delays because of parsing?) doesn't indent properly.
