### PR TITLE
Line number is added as first item in the gutter

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -374,7 +374,7 @@
   function setGuttersForLineNumbers(options) {
     var found = indexOf(options.gutters, "CodeMirror-linenumbers");
     if (found == -1 && options.lineNumbers) {
-      options.gutters = options.gutters.concat(["CodeMirror-linenumbers"]);
+      options.gutters.unshift("CodeMirror-linenumbers");
     } else if (found > -1 && !options.lineNumbers) {
       options.gutters = options.gutters.slice(0);
       options.gutters.splice(found, 1);


### PR DESCRIPTION
At the moment the line number as last item in the gutter, but usually (and in the demos too) this is the first item in the gutter.
In website like jsbin.com if we double click the language menu in the editors, it will hide/show the line numbers, but if other addons are active, like folding, then the number is added after the fold icon, while I think it should stay as first.
