### PR TITLE
set origin to change done by completion

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -20,7 +20,7 @@ CodeMirror.showHint = function(cm, getHints, options) {
 
   function pickCompletion(cm, data, completion) {
     if (completion.hint) completion.hint(cm, data, completion);
-    else cm.replaceRange(getText(completion), data.from, data.to);
+    else cm.replaceRange(getText(completion), data.from, data.to, "completion");
   }
 
   function showHints(data) {


### PR DESCRIPTION
The change event currently doesn't have an origin set if the change was caused by picking a hint (i.e. a completion). Paste operations sets the "paste" origin right now, and it would be helpful to have "completion" as well.
