### PR TITLE
Feature to show completion for the selected text

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -85,7 +85,7 @@
       CodeMirror.signal(data, "shown");
 
       var debounce = 0, completion = this, finished;
-      var closeOn = this.options.closeCharacters || /\s[()\[\]{};:>,]/;
+      var closeOn = this.options.closeCharacters || /[()\[\]{};:>,]/;
       var startPos = this.cm.getCursor(), startLen = this.cm.getLine(startPos.line).length;
 
       var requestAnimationFrame = window.requestAnimationFrame || function(fn) {


### PR DESCRIPTION
This feature allows users to get autoCompletion for the selected text which would replace the selected text with the selected option from completion widget.
Earlier user has to select , then delete the keyword and then exec autoCompletion to achieve, Now with this feature once can easily get the completions for the selected text.

Please review the code and give comment on the feature.

Thank you
Dheeraj
