### PR TITLE
[closebracket addon] Fix: Trigger auto-close-triple behaviour after exactly 3 quotes.

### DIFF
--- a/addon/edit/closebrackets.js
+++ b/addon/edit/closebrackets.js
@@ -69,7 +69,8 @@
             else
               curType = "skip";
           } else if (left == right && cur.ch > 1 &&
-                     cm.getRange(Pos(cur.line, cur.ch - 2), cur) == left + left)
+                     cm.getRange(Pos(cur.line, cur.ch - 2), cur) == left + left &&
+                     (cur.ch <= 2 || cm.getRange(Pos(cur.line, cur.ch - 3), Pos(cur.line, cur.ch - 2)) != left))
             curType = "addFour";
           else if (left == right && CodeMirror.isWordChar(next))
             return CodeMirror.Pass;


### PR DESCRIPTION
Issue #2385

I have updated the condition for auto-close-triple behaviour.

![test1](https://cloud.githubusercontent.com/assets/5851313/2574522/25c7b232-b935-11e3-8514-5e96f4a2fcb8.gif)

Tested in Chromium 33.0.1750.152 Ubuntu 12.04 (256984)
