### PR TITLE
Attempted fix for #2420: re-check line heights after updating doc height/scrollbars

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -545,12 +545,14 @@
       var barMeasure = measureForScrollbars(cm);
       updateSelection(cm);
       setDocumentHeight(cm, barMeasure);
-      updateScrollbars(cm, barMeasure);
 
-      // The above updates might have caused lines to wrap differently, so
+      // The document height update might have caused lines to wrap differently, so
       // double-check the line heights.
-      if (cm.options.lineWrapping && updateHeightsInViewport(cm))
-        setDocumentHeight(cm, measureForScrollbars(cm));
+      if (cm.options.lineWrapping && updateHeightsInViewport(cm)) {
+        barMeasure = measureForScrollbars(cm);
+        setDocumentHeight(cm, barMeasure);
+      }
+      updateScrollbars(cm, barMeasure);
 
       if (first && cm.options.lineWrapping && oldWidth != cm.display.scroller.clientWidth) {
         forced = true;


### PR DESCRIPTION
This is an attempt to fix #2420, although I don't know if it's really a good approach.

What seems to be happening is that in some edge cases, when line wrapping is on, `setDocumentHeight()` can cause Chrome (and Safari) to change the wrapping of certain lines, possibly because it's trying to account for native scrollbar width (even though in this case the vertical scrollbar shouldn't appear). It's not entirely clear why this would happen - it might be a bug in WebKit/Blink; #2420 doesn't happen in Firefox.

When that happens, CodeMirror's line heights get out of sync, which causes things like the selection being drawn in the wrong position and mouse event coordinates being interpreted wrong. This attempts to fix it by re-checking the line heights in the current viewport after the doc height is updated. 

The main issue with this proposal is that introducing a second call to `updateHeightsInViewport()` might be bad for performance.
