### PR TITLE
fix indentation of closing xml tag

### DIFF
--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -334,7 +334,7 @@ CodeMirror.defineMode("xml", function(config, parserConfig) {
           return state.tagStart + indentUnit * multilineTagIndentFactor;
       }
       if (alignCDATA && /<!\[CDATA\[/.test(textAfter)) return 0;
-      var tagAfter = textAfter && /^<(\/)?(\w*)/.exec(textAfter);
+      var tagAfter = textAfter && /^<(\/)?([\w_:\.-]*)/.exec(textAfter);
       if (tagAfter && tagAfter[1]) { // Closing tag spotted
         while (context) {
           if (context.tagName == tagAfter[2]) {


### PR DESCRIPTION
There's a regression in the xml mode that prevents the correct indentation of closing tags. This only happens if your tag contains characters that are not word characters, e.g. "-", or ":". Those are supported in XML 1.0 (and 1.1)

The existing regexp in mode/xml/xml.js line 337 would fail to correctly detect the closing tag &lt;/hello-world&gt;  so tagAfter[2] gets the value "hello" instead of "hello-world" 
