### PR TITLE
Fixed Ruler Addon Editor extra lines

### DIFF
--- a/addon/display/rulers.js
+++ b/addon/display/rulers.js
@@ -31,7 +31,7 @@
     var val = cm.getOption("rulers");
     var cw = cm.defaultCharWidth();
     var left = cm.charCoords(CodeMirror.Pos(cm.firstLine(), 0), "div").left;
-    var bot = -cm.display.scroller.offsetHeight;
+    var bot = 0;
     for (var i = 0; i < val.length; i++) {
       var elt = document.createElement("div");
       var col, cls = null;

--- a/demo/rulers.html
+++ b/demo/rulers.html
@@ -42,7 +42,7 @@
   }
   var editor = CodeMirror(document.body.lastChild, {
     rulers: rulers,
-    value: value + value + value,
+    value: value + value + value + value,
     lineNumbers: true
 });
 </script>


### PR DESCRIPTION
Patch for Issue :  #2439 - Rulers Addon makes editor scroll too far downwards

Now I think the demo for Rulers is looking better as the issue pointed by lkcampbell.
Please review the code and try to merge if you feel it the issue is resolved properly.

Thank you
Dheeraj
