### PR TITLE
[Sublime] Cursor stays in view while scrolling with Ctrl+Up or Ctrl+Down

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -53,17 +53,17 @@
 
   cmds[map[ctrl + "Up"] = "scrollLineUp"] = function(cm) {
     if(!cm.somethingSelected()){
-      var visibleTopLine = Math.floor((cm.getScrollInfo().top + cm.getScrollInfo().clientHeight) / cm.defaultTextHeight());
+      var visibleBottomLine = cm.lineAtHeight(cm.getScrollInfo().top + cm.getScrollInfo().clientHeight, "local");
       var cur = cm.getCursor();
-      if(cur.line >= visibleTopLine){
-        cm.setCursor({line:visibleTopLine-1, ch:cur.ch});
+      if(cur.line >= visibleBottomLine){
+        cm.setCursor({line:visibleBottomLine-1, ch:cur.ch});
       }
     }
     cm.scrollTo(null, cm.getScrollInfo().top - cm.defaultTextHeight());
   };
   cmds[map[ctrl + "Down"] = "scrollLineDown"] = function(cm) {
     if(!cm.somethingSelected()){
-      var visibleTopLine = cm.getScrollInfo().top/cm.defaultTextHeight();
+      var visibleTopLine = cm.lineAtHeight(cm.getScrollInfo().top, "local")+1;
       var cur = cm.getCursor();
       if(cur.line-1 < visibleTopLine){
         cm.setCursor({line:visibleTopLine+1, ch:cur.ch});


### PR DESCRIPTION
Cursor stays in view while scrolling with Ctrl+Up or Ctrl+Down unless something is selected.
