### PR TITLE
Fix background color matching foreground in Monokai theme.

### DIFF
--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -20,7 +20,7 @@
 .cm-s-monokai span.cm-bracket {color: #f8f8f2;}
 .cm-s-monokai span.cm-tag {color: #f92672;}
 .cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0 !important;}
 
 .cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
 .cm-s-monokai .CodeMirror-matchingbracket {


### PR DESCRIPTION
In case `cm-error` coincides with `cm-tag` in HTML files, sometimes part of the text becomes a solid pink block.
See the related issue: https://github.com/GoogleChrome/text-app/issues/227
