### PR TITLE
Fixed CSS mode to accept empty parenthesis

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -92,7 +92,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
 
   function tokenParenthesized(stream, state) {
     stream.next(); // Must be '('
-    if (!stream.match(/\s*[\"\']/, false))
+    if (!stream.match(/\s*[\"\']?/, false))
       state.tokenize = tokenString(")");
     else
       state.tokenize = null;


### PR DESCRIPTION
This is in reference to https://github.com/marijnh/CodeMirror/issues/2465 . 
