### PR TITLE
Multiline selection doesn't get rendered property 

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1451,7 +1451,7 @@
   function paddingTop(display) {return display.lineSpace.offsetTop;}
   function paddingVert(display) {return display.mover.offsetHeight - display.lineSpace.offsetHeight;}
   function paddingH(display) {
-    if (display.cachedPaddingH) return display.cachedPaddingH;
+    if (display.cachedPaddingH && !isNaN(display.cachedPaddingH.left) && !isNaN(display.cachedPaddingH.right)) return display.cachedPaddingH;
     var e = removeChildrenAndAdd(display.measure, elt("pre", "x"));
     var style = window.getComputedStyle ? window.getComputedStyle(e) : e.currentStyle;
     return display.cachedPaddingH = {left: parseInt(style.paddingLeft),


### PR DESCRIPTION
Hi Marijnh,

From time to time we encounter a problem with selection in codemirror which doesn't get rendered whenever it spans multiple lines. We don't have a stable repro, but debugging of the broken state showed that this is due to `display.chachedPaddingH` storing `NaN`s as values for both `left` and `right`.

The patch, unfortunately, doesn't fix the root cause of the problem, however it will make codemirror to self-recover from the bad state. If the root cause remains undetected, it will be nice to have this in.
What would you say?
