### PR TITLE
Fix LiveScript string and comment highlighting

### DIFF
--- a/mode/livescript/livescript.js
+++ b/mode/livescript/livescript.js
@@ -203,7 +203,7 @@
         next: 'start'
       }, {
         token: 'text',
-        regex: '.',
+        regex: '',
         next: 'start'
       }
     ],


### PR DESCRIPTION
Only change `state.next` if `r.next` is defined and check if `r.regex` is a string before converting it into a `RegExp` (in the optimization step). Closes #2474.
