### PR TITLE
CSS mode: remove color-profile and kerning svg properties

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -453,13 +453,13 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     // SVG-specific
     "clip-path", "clip-rule", "mask", "enable-background", "filter", "flood-color",
     "flood-opacity", "lighting-color", "stop-color", "stop-opacity", "pointer-events",
-    "color-interpolation", "color-interpolation-filters", "color-profile",
+    "color-interpolation", "color-interpolation-filters",
     "color-rendering", "fill", "fill-opacity", "fill-rule", "image-rendering",
     "marker", "marker-end", "marker-mid", "marker-start", "shape-rendering", "stroke",
     "stroke-dasharray", "stroke-dashoffset", "stroke-linecap", "stroke-linejoin",
     "stroke-miterlimit", "stroke-opacity", "stroke-width", "text-rendering",
     "baseline-shift", "dominant-baseline", "glyph-orientation-horizontal",
-    "glyph-orientation-vertical", "kerning", "text-anchor", "writing-mode"
+    "glyph-orientation-vertical", "text-anchor", "writing-mode"
   ], propertyKeywords = keySet(propertyKeywords_);
 
   var nonStandardPropertyKeywords = [


### PR DESCRIPTION
This patch removes `color-profile` and `kerning` svg properties from css mode as they no longer exist in SVG 2.0.
[SVG 2.0 spec](http://www.w3.org/TR/SVG2/single-page.html)
