### PR TITLE
Clip to valid pos when creating rectangular selection

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2507,7 +2507,7 @@
     var coords = coordsChar(cm, x, y), line;
     if (forRect && coords.xRel == 1 && (line = getLine(cm.doc, coords.line).text).length == coords.ch) {
       var colDiff = countColumn(line, line.length, cm.options.tabSize) - line.length;
-      coords = Pos(coords.line, Math.round((x - paddingH(cm.display).left) / charWidth(cm.display)) - colDiff);
+      coords = clipPos(cm.doc, Pos(coords.line, Math.round((x - paddingH(cm.display).left) / charWidth(cm.display)) - colDiff));
     }
     return coords;
   }


### PR DESCRIPTION
Fixes #2488. The problem is that the new pos in the `forRect` case wasn't being clipped, and in this case `ch` was becoming negative.

It doesn't seem like all the `clipPos()` logic is necessary in this case, but it seemed like the simplest fix.
