### PR TITLE
check getBoundingClientRect() did not return null

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1622,6 +1622,9 @@
           rect = nullRect;
       } else {
         rect = range(node, start, end).getBoundingClientRect();
+        if (!rect) {
+          rect = nullRect;
+        }
       }
     } else { // If it is a widget, simply get the box for the whole widget.
       if (start > 0) collapse = bias = "right";


### PR DESCRIPTION
Sometimes in Safari `range.getBoundingClientRect()` returns null - this seems to occur when the editor is not in a visible portion of the DOM. Using `nullRect` fixes the null ref error, and does not seem to have any adverse effects.
