### PR TITLE
[vim]: IE8 fixes.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1645,9 +1645,8 @@
         do {
           symbol = lineText.charAt(ch++);
           if (symbol && isMatchableSymbol(symbol)) {
-            var ignoreStyle = ["string", "comment"];
             var style = cm.getTokenTypeAt(Pos(line, ch));
-            if (ignoreStyle.indexOf(style) < 0) {
+            if (style !== "string" && style !== "comment") {
               break;
             }
           }
@@ -2908,15 +2907,15 @@
     // Translates a search string from ex (vim) syntax into javascript form.
     function translateRegex(str) {
       // When these match, add a '\' if unescaped or remove one if escaped.
-      var specials = ['|', '(', ')', '{'];
+      var specials = '|(){';
       // Remove, but never add, a '\' for these.
-      var unescape = ['}'];
+      var unescape = '}';
       var escapeNextChar = false;
       var out = [];
       for (var i = -1; i < str.length; i++) {
         var c = str.charAt(i) || '';
         var n = str.charAt(i+1) || '';
-        var specialComesNext = (specials.indexOf(n) != -1);
+        var specialComesNext = (n && specials.indexOf(n) != -1);
         if (escapeNextChar) {
           if (c !== '\\' || !specialComesNext) {
             out.push(c);
@@ -2926,7 +2925,7 @@
           if (c === '\\') {
             escapeNextChar = true;
             // Treat the unescape list as special for removing, but not adding '\'.
-            if (unescape.indexOf(n) != -1) {
+            if (n && unescape.indexOf(n) != -1) {
               specialComesNext = true;
             }
             // Not passing this test means removing a '\'.

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -98,7 +98,7 @@ function copyCursor(cur) {
 
 function forEach(arr, func) {
   for (var i = 0; i < arr.length; i++) {
-    func(arr[i]);
+    func(arr[i], i, arr);
   }
 }
 
@@ -2325,7 +2325,8 @@ testVim('HML', function(cm, vim, helpers) {
   return upper + lower;
 })()});
 
-var zVals = ['zb','zz','zt','z-','z.','z<CR>'].map(function(e, idx){
+var zVals = [];
+forEach(['zb','zz','zt','z-','z.','z<CR>'], function(e, idx){
   var lineNum = 250;
   var lines = 35;
   testVim(e, function(cm, vim, helpers) {


### PR DESCRIPTION
- avoid array .indexOf - fixes % key and non-pcre searches.
- avoid array .map - fixes a couple of non-running tests.

vim.js should probably be rewritten to use an indexOf() shim throughout (but I don't care enough about vim nor IE to undertake that).
