### PR TITLE
Fix missing state on calls to blankLine in runMode

### DIFF
--- a/addon/runmode/runmode.js
+++ b/addon/runmode/runmode.js
@@ -57,7 +57,7 @@ CodeMirror.runMode = function(string, modespec, callback, options) {
   for (var i = 0, e = lines.length; i < e; ++i) {
     if (i) callback("\n");
     var stream = new CodeMirror.StringStream(lines[i]);
-    if (!stream.string && mode.blankLine) mode.blankLine();
+    if (!stream.string && mode.blankLine) mode.blankLine(state);
     while (!stream.eol()) {
       var style = mode.token(stream, state);
       callback(stream.current(), style, i, stream.start, state);


### PR DESCRIPTION
I think this was just an oversight, but blankLine requires state... This was causing a JS error
