### PR TITLE
[gfm] Stack link tokens in overlay with base tokens.

### DIFF
--- a/addon/mode/overlay.js
+++ b/addon/mode/overlay.js
@@ -3,8 +3,9 @@
 // functionality, but a second (typically simple) mode is used, which
 // can override the style of text. Both modes get to parse all of the
 // text, but when both assign a non-null style to a piece of code, the
-// overlay wins, unless the combine argument was true, in which case
-// the styles are combined.
+// overlay wins, unless the combine argument was true and not overridden,
+// or state.overlay.combineTokens was true, in which case the styles are
+// combined.
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
@@ -54,8 +55,13 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
       }
       stream.pos = Math.min(state.basePos, state.overlayPos);
 
+      // state.overlay.combineTokens always takes precedence over combine,
+      // unless set to null
       if (state.overlayCur == null) return state.baseCur;
-      if (state.baseCur != null && combine) return state.baseCur + " " + state.overlayCur;
+      else if (state.baseCur != null &&
+               state.overlay.combineTokens ||
+               combine && state.overlay.combineTokens == null)
+        return state.baseCur + " " + state.overlayCur;
       else return state.overlayCur;
     },
 

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -30,6 +30,8 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
       };
     },
     token: function(stream, state) {
+      state.combineTokens = null;
+
       // Hack to prevent formatting override inside code blocks (block and inline)
       if (state.codeBlock) {
         if (stream.match(/^```/)) {
@@ -77,11 +79,13 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
           // User/Project@SHA
           // User@SHA
           // SHA
+          state.combineTokens = true;
           return "link";
         } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+)?#[0-9]+\b/)) {
           // User/Project#Num
           // User#Num
           // #Num
+          state.combineTokens = true;
           return "link";
         }
       }
@@ -90,6 +94,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
         // URLs
         // Taken from http://daringfireball.net/2010/07/improved_regex_for_matching_urls
         // And then (issue #1160) simplified to make it not crash the Chrome Regexp engine
+        state.combineTokens = true;
         return "link";
       }
       stream.next();

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -73,6 +73,9 @@
   MT("SHA",
      "foo [link be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2] bar");
 
+  MT("SHAEmphasis",
+     "[em *foo ][em&link be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2][em *]");
+
   MT("shortSHA",
      "foo [link be6a8cc] bar");
 
@@ -88,11 +91,20 @@
   MT("userSHA",
      "foo [link bar@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2] hello");
 
+  MT("userSHAEmphasis",
+     "[em *foo ][em&link bar@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2][em *]");
+
   MT("userProjectSHA",
      "foo [link bar/hello@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2] world");
 
+  MT("userProjectSHAEmphasis",
+     "[em *foo ][em&link bar/hello@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2][em *]");
+
   MT("num",
      "foo [link #1] bar");
+
+  MT("numEmphasis",
+     "[em *foo ][em&link #1][em *]");
 
   MT("badNum",
      "foo #1bar hello");
@@ -100,8 +112,14 @@
   MT("userNum",
      "foo [link bar#1] hello");
 
+  MT("userNumEmphasis",
+     "[em *foo ][em&link bar#1][em *]");
+
   MT("userProjectNum",
      "foo [link bar/hello#1] world");
+
+  MT("userProjectNumEmphasis",
+     "[em *foo ][em&link bar/hello#1][em *]");
 
   MT("vanillaLink",
      "foo [link http://www.example.com/] bar");
@@ -113,7 +131,7 @@
      "foo [link http://www.example.com/index.html] bar");
 
   MT("vanillaLinkEmphasis",
-     "foo [em *][link http://www.example.com/index.html][em *] bar");
+     "foo [em *][em&link http://www.example.com/index.html][em *] bar");
 
   MT("notALink",
      "[comment ```css]",


### PR DESCRIPTION
Added `combineTokens` for overlays that can override default `combine` argument.
- If `combineTokens` is set in overlay's state to `true`, tokens will be combined.
- If `combineTokens` is set in overlay's state to `false`, tokens will not combined.
- Else the previous behavior is matched (depends on `combine`)

Closes #2449
