### PR TITLE
mode tests: optionally show mode state after every token

### DIFF
--- a/test/mode_test.css
+++ b/test/mode_test.css
@@ -8,3 +8,15 @@
 .mt-output .mt-style {
   font-size: x-small;
 }
+
+.mt-output .mt-state {
+  font-size: x-small;
+}
+
+.mt-output .mt-state-row {
+  display: none;
+}
+
+.mt-state-unhide .mt-output .mt-state-row {
+  display: table-row;
+}


### PR DESCRIPTION
Make mode debugging easier (and encourage test writing)  by displaying state after every token (hidden by default).
Demo:
https://rawgit.com/cben/CodeMirror/mode_test_logstate+b2479/test/index.html#markdown_*
click [display states], easily see `indentation` is going negative.

Fails safely in anient browsers, [e.g. Opera 9](https://saucelabs.com/jobs/0b1a8d7aae7e4321af4c37949b1f0572/0001screenshot.png)

Slight performance price: npm test 11.2 -> 11.8sec, IE8 1:50 -> 1:59.
