### PR TITLE
[markdown mode] Fix code block styling after indented line

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -209,7 +209,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
   function htmlBlock(stream, state) {
     var style = htmlMode.token(stream, state.htmlState);
-    if ((htmlFound && !state.htmlState.tagName && !state.htmlState.context) ||
+    if ((htmlFound && state.htmlState.tagStart === null && !state.htmlState.context) ||
         (state.md_inside && stream.current().indexOf(">") > -1)) {
       state.f = inlineNormal;
       state.block = blockNormal;

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -729,4 +729,23 @@
      "[comment ```]",
      "foo",
      "[comment ```]");
+
+  // Tests that require XML mode
+
+  MT("xmlMode",
+     "[tag&bracket <][tag div][tag&bracket >]",
+     "*foo*",
+     "[tag&bracket <][tag http://github.com][tag&bracket />]",
+     "[tag&bracket </][tag div][tag&bracket >]",
+     "[link <http://github.com/>]");
+
+  MT("xmlModeWithMarkdownInside",
+     "[tag&bracket <][tag div] [attribute markdown]=[string 1][tag&bracket >]",
+     "[em *foo*]",
+     "[link <http://github.com/>]",
+     "[tag </div>]",
+     "[link <http://github.com/>]",
+     "[tag&bracket <][tag div][tag&bracket >]",
+     "[tag&bracket </][tag div][tag&bracket >]");
+
 })();


### PR DESCRIPTION
These changes should fix Issue #2479 and XML rendering in Markdown mode, both of which affected the [official demo](http://codemirror.net/mode/markdown/index.html). Could you please review the changes?
