### PR TITLE
[sublime] Make swapLineUp/Down consistent with Sublime Text behavior.

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -183,10 +183,17 @@
     });
   };
 
+  // Returns whether the range represents a zero-length selection.
+  function isCursor(range) {
+    return range.from().line == range.to().line && range.from().ch == range.to().ch;
+  }
+
   cmds[map["Shift-" + ctrl + "Up"] = "swapLineUp"] = function(cm) {
     var ranges = cm.listSelections(), linesToMove = [], at = cm.firstLine() - 1;
     for (var i = 0; i < ranges.length; i++) {
       var range = ranges[i], from = range.from().line - 1, to = range.to().line;
+      // If a selection extends just past the end of line L, exclude line L+1.
+      if (range.to().ch == 0 && !isCursor(range)) to--;
       if (from > at) linesToMove.push(from, to);
       else if (linesToMove.length) linesToMove[linesToMove.length - 1] = to;
       at = to;
@@ -214,6 +221,8 @@
     var ranges = cm.listSelections(), linesToMove = [], at = cm.lastLine() + 1;
     for (var i = ranges.length - 1; i >= 0; i--) {
       var range = ranges[i], from = range.to().line + 1, to = range.from().line;
+      // If a selection extends just past the end of line L, exclude line L+1.
+      if (range.to().ch == 0 && !isCursor(range)) from--;
       if (from < at) linesToMove.push(from, to);
       else if (linesToMove.length) linesToMove[linesToMove.length - 1] = to;
       at = to;


### PR DESCRIPTION
Currently if you select part of line L, extend the selection just past the end, and use swapLineUp/Down, it will swap both line L and line L+1. In Sublime Text it would only shift line L. This also makes it more consistent with the rest of CodeMirror since tooggleComment with that selection only toggles the comment on line L.

Of course if the selection is of length zero (i.e. a cursor) at the beginning of line L+1, only line L+1 should be shifted.

Note: This currently works incorrectly for swapLineUp because of some special casing in that code. I tried to fix it but couldn't grok exactly what was happening. I'm hoping you can make the relevant fix since you wrote the code :)
