### PR TITLE
New events for status bar command

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -44,7 +44,7 @@
  *  'vim-mode-change' - raised on the editor anytime the current mode changes,
  *                      Event object: {mode: "visual", subMode: "linewise"}
  *  'vim-command-keypress' - raised when part of a command sequence is input
- *                           in normal mode only, for implementing a vim-like 
+ *                           in normal mode only, for implementing a vim-like
  *                           status bar output
  *  'vim-command-done' - raised when a command sequence has completed and results
  *                       in an edit


### PR DESCRIPTION
I'm refactoring vimderbar for Brackets.io, and had no reliable way of displaying commands as they are entered in the status bar. I think the best way to do this is by extending CodeMirror's vim events to give us the keys as they are pressed and notify us when the commands are complete.
