### PR TITLE
make cursor display above marked text whose background is colored

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -243,7 +243,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 div.CodeMirror-cursors {
   visibility: hidden;
   position: relative;
-  z-index: 1;
+  z-index: 3;
 }
 .CodeMirror-focused div.CodeMirror-cursors {
   visibility: visible;


### PR DESCRIPTION
When creating a range with markText and giving it a class, a background-color makes the cursor invisible because it goes under the text. This picture is from my installation
![image](https://cloud.githubusercontent.com/assets/1429912/3004116/7120a7b6-dd7a-11e3-8abe-10cd33bc998f.png)
but you can replicate it on http://codemirror.net/index.html with

```
editor.markText({line:2,ch:2}, {line:2,ch:12}, {className:"markedText"});
var css = document.createElement("style");
css.type = "text/css";
css.innerHTML = ".markedText {background-color: yellow}";
document.body.appendChild(css);
```

This commit fixes this by increasing the z-index of the cursors. Then it looks like so:
![image](https://cloud.githubusercontent.com/assets/1429912/3004119/9e79e574-dd7a-11e3-984e-44b45e1d4abb.png)
