### PR TITLE
Have updateLineClasses keep existing classes, and add on new ones

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -846,8 +846,10 @@
       ensureLineWrapped(lineView).className = lineView.line.wrapClass;
     else if (lineView.node != lineView.text)
       lineView.node.className = "";
-    var textClass = lineView.textClass ? lineView.textClass + " " + (lineView.line.textClass || "") : lineView.line.textClass;
-    lineView.text.className = textClass || "";
+    var textClass = (lineView.textClass || " ")
+      + (lineView.line.textClass || " ")
+      + (lineView.text.className || " ");
+    lineView.text.className = textClass;
   }
 
   function updateLineGutter(cm, lineView, lineN, dims) {


### PR DESCRIPTION
In callbacks to "renderLine", the documentation suggests `The handler may mess with the style of the resulting (pre) element`. However, updateLineClasses is called afterwards, which completely replaces the class of that element with other stuff. This fix allows the classes assigned directly to that pre element to be retained.
