### PR TITLE
don’t draw scrollbars for one pixel

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -413,8 +413,8 @@
     if (!measure) measure = measureForScrollbars(cm);
     var d = cm.display;
     var scrollHeight = measure.docHeight + scrollerCutOff;
-    var needsH = measure.scrollWidth > measure.clientWidth;
-    var needsV = scrollHeight > measure.clientHeight;
+    var needsH = measure.scrollWidth > (measure.clientWidth + 1);
+    var needsV = scrollHeight > (measure.clientHeight + 1);
     if (needsV) {
       d.scrollbarV.style.display = "block";
       d.scrollbarV.style.bottom = needsH ? scrollbarWidth(d.measure) + "px" : "0";


### PR DESCRIPTION
Sometimes `scrollHeight == measure.clientHeight + 1`, when there should be no scrollbar. This results in CodeMirror drawing incorrect scrollbars over text.

closes #2562

verified fix on Chrome 35 (zoom), 36 (no zoom), 37 (zoom).
