### PR TITLE
[active-line addon] Don't highlight line(s) with a selection.

### DIFF
--- a/addon/selection/active-line.js
+++ b/addon/selection/active-line.js
@@ -49,7 +49,9 @@
   function updateActiveLines(cm, ranges) {
     var active = [];
     for (var i = 0; i < ranges.length; i++) {
-      var line = cm.getLineHandleVisualStart(ranges[i].head.line);
+      var range = ranges[i];
+      if (!range.empty()) continue;
+      var line = cm.getLineHandleVisualStart(range.head.line);
       if (active[active.length - 1] != line) active.push(line);
     }
     if (sameArray(cm.state.activeLines, active)) return;


### PR DESCRIPTION
This fixes non-empty selections having 2 highlights: the selection highlight and the active-line highlight. Non-empty selections should **only** have the selection highlight.

A before-and-after comparison (note the confusing blue active-line highlight on the same line as the purple selection highlight):

Before:
![before](https://cloud.githubusercontent.com/assets/213/3073698/45a9a106-e300-11e3-824b-450300390b7d.gif)

After:
![after](https://cloud.githubusercontent.com/assets/213/3073699/48450126-e300-11e3-8dc8-8beedfaa3ffb.gif)
