### PR TITLE
[clike mode] Fix C++11 multiline string parsing bug

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -242,7 +242,11 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
   // C++11 raw string literal is <prefix>"<delim>( anything )<delim>", where
   // <delim> can be a string up to 16 characters long.
   function tokenRawString(stream, state) {
-    var closingSequence = new RegExp(".*?\\)" + state.cpp11RawStringDelim + '"');
+    var closingSequence = new RegExp(
+      ".*?\\)" +
+      // Escape characters that have special regex meanings.
+      state.cpp11RawStringDelim.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') +
+      '"');
     var match = stream.match(closingSequence);
     if (match) {
       state.tokenize = null;


### PR DESCRIPTION
The issue can be seen on http://codemirror.net/mode/clike/index.html. In the C++ raw_string line, place the cursor after 'delim(' and type '('. Currently this causes a regexp error, which this patch fixes.
