### PR TITLE
[python mode] Return to parent indentation level when scope is closed.

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -320,8 +320,10 @@
         var closing = textAfter && textAfter.charAt(0) == scope.type;
         if (scope.align != null)
           return scope.align - (closing ? 1 : 0);
+        else if (closing && state.scopes.length > 1)
+          return state.scopes[state.scopes.length - 2].offset;
         else
-          return scope.offset - (closing ? conf.indentUnit : 0);
+          return scope.offset;
       },
 
       lineComment: "#",


### PR DESCRIPTION
This makes it work correctly when the hanging indent is different from the indent unit.
