### PR TITLE
Add try/finally to endOperation

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1935,66 +1935,68 @@
     var op = cm.curOp, doc = cm.doc, display = cm.display;
     cm.curOp = null;
 
-    if (op.updateMaxLine) findMaxLine(cm);
+    try {
+      if (op.updateMaxLine) findMaxLine(cm);
 
-    // If it looks like an update might be needed, call updateDisplay
-    if (op.viewChanged || op.forceUpdate || op.scrollTop != null ||
-        op.scrollToPos && (op.scrollToPos.from.line < display.viewFrom ||
-                           op.scrollToPos.to.line >= display.viewTo) ||
-        display.maxLineChanged && cm.options.lineWrapping) {
-      var updated = updateDisplay(cm, {top: op.scrollTop, ensure: op.scrollToPos}, op.forceUpdate);
-      if (cm.display.scroller.offsetHeight) cm.doc.scrollTop = cm.display.scroller.scrollTop;
+      // If it looks like an update might be needed, call updateDisplay
+      if (op.viewChanged || op.forceUpdate || op.scrollTop != null ||
+          op.scrollToPos && (op.scrollToPos.from.line < display.viewFrom ||
+                             op.scrollToPos.to.line >= display.viewTo) ||
+          display.maxLineChanged && cm.options.lineWrapping) {
+        var updated = updateDisplay(cm, {top: op.scrollTop, ensure: op.scrollToPos}, op.forceUpdate);
+        if (cm.display.scroller.offsetHeight) cm.doc.scrollTop = cm.display.scroller.scrollTop;
+      }
+      // If no update was run, but the selection changed, redraw that.
+      if (!updated && op.selectionChanged) updateSelection(cm);
+      if (!updated && op.startHeight != cm.doc.height) updateScrollbars(cm);
+  
+      // Abort mouse wheel delta measurement, when scrolling explicitly
+      if (display.wheelStartX != null && (op.scrollTop != null || op.scrollLeft != null || op.scrollToPos))
+        display.wheelStartX = display.wheelStartY = null;
+  
+      // Propagate the scroll position to the actual DOM scroller
+      if (op.scrollTop != null && display.scroller.scrollTop != op.scrollTop) {
+        var top = Math.max(0, Math.min(display.scroller.scrollHeight - display.scroller.clientHeight, op.scrollTop));
+        display.scroller.scrollTop = display.scrollbarV.scrollTop = doc.scrollTop = top;
+      }
+      if (op.scrollLeft != null && display.scroller.scrollLeft != op.scrollLeft) {
+        var left = Math.max(0, Math.min(display.scroller.scrollWidth - display.scroller.clientWidth, op.scrollLeft));
+        display.scroller.scrollLeft = display.scrollbarH.scrollLeft = doc.scrollLeft = left;
+        alignHorizontally(cm);
+      }
+      // If we need to scroll a specific position into view, do so.
+      if (op.scrollToPos) {
+        var coords = scrollPosIntoView(cm, clipPos(cm.doc, op.scrollToPos.from),
+                                       clipPos(cm.doc, op.scrollToPos.to), op.scrollToPos.margin);
+        if (op.scrollToPos.isCursor && cm.state.focused) maybeScrollWindow(cm, coords);
+      }
+    } finally {
+      if (op.selectionChanged) restartBlink(cm);
+  
+      if (cm.state.focused && op.updateInput)
+        resetInput(cm, op.typing);
+  
+      // Fire events for markers that are hidden/unidden by editing or
+      // undoing
+      var hidden = op.maybeHiddenMarkers, unhidden = op.maybeUnhiddenMarkers;
+      if (hidden) for (var i = 0; i < hidden.length; ++i)
+        if (!hidden[i].lines.length) signal(hidden[i], "hide");
+      if (unhidden) for (var i = 0; i < unhidden.length; ++i)
+        if (unhidden[i].lines.length) signal(unhidden[i], "unhide");
+  
+      var delayed;
+      if (!--delayedCallbackDepth) {
+        delayed = delayedCallbacks;
+        delayedCallbacks = null;
+      }
+      // Fire change events, and delayed event handlers
+      if (op.changeObjs)
+        signal(cm, "changes", cm, op.changeObjs);
+      if (delayed) for (var i = 0; i < delayed.length; ++i) delayed[i]();
+      if (op.cursorActivityHandlers)
+        for (var i = 0; i < op.cursorActivityHandlers.length; i++)
+          op.cursorActivityHandlers[i](cm);
     }
-    // If no update was run, but the selection changed, redraw that.
-    if (!updated && op.selectionChanged) updateSelection(cm);
-    if (!updated && op.startHeight != cm.doc.height) updateScrollbars(cm);
-
-    // Abort mouse wheel delta measurement, when scrolling explicitly
-    if (display.wheelStartX != null && (op.scrollTop != null || op.scrollLeft != null || op.scrollToPos))
-      display.wheelStartX = display.wheelStartY = null;
-
-    // Propagate the scroll position to the actual DOM scroller
-    if (op.scrollTop != null && display.scroller.scrollTop != op.scrollTop) {
-      var top = Math.max(0, Math.min(display.scroller.scrollHeight - display.scroller.clientHeight, op.scrollTop));
-      display.scroller.scrollTop = display.scrollbarV.scrollTop = doc.scrollTop = top;
-    }
-    if (op.scrollLeft != null && display.scroller.scrollLeft != op.scrollLeft) {
-      var left = Math.max(0, Math.min(display.scroller.scrollWidth - display.scroller.clientWidth, op.scrollLeft));
-      display.scroller.scrollLeft = display.scrollbarH.scrollLeft = doc.scrollLeft = left;
-      alignHorizontally(cm);
-    }
-    // If we need to scroll a specific position into view, do so.
-    if (op.scrollToPos) {
-      var coords = scrollPosIntoView(cm, clipPos(cm.doc, op.scrollToPos.from),
-                                     clipPos(cm.doc, op.scrollToPos.to), op.scrollToPos.margin);
-      if (op.scrollToPos.isCursor && cm.state.focused) maybeScrollWindow(cm, coords);
-    }
-
-    if (op.selectionChanged) restartBlink(cm);
-
-    if (cm.state.focused && op.updateInput)
-      resetInput(cm, op.typing);
-
-    // Fire events for markers that are hidden/unidden by editing or
-    // undoing
-    var hidden = op.maybeHiddenMarkers, unhidden = op.maybeUnhiddenMarkers;
-    if (hidden) for (var i = 0; i < hidden.length; ++i)
-      if (!hidden[i].lines.length) signal(hidden[i], "hide");
-    if (unhidden) for (var i = 0; i < unhidden.length; ++i)
-      if (unhidden[i].lines.length) signal(unhidden[i], "unhide");
-
-    var delayed;
-    if (!--delayedCallbackDepth) {
-      delayed = delayedCallbacks;
-      delayedCallbacks = null;
-    }
-    // Fire change events, and delayed event handlers
-    if (op.changeObjs)
-      signal(cm, "changes", cm, op.changeObjs);
-    if (delayed) for (var i = 0; i < delayed.length; ++i) delayed[i]();
-    if (op.cursorActivityHandlers)
-      for (var i = 0; i < op.cursorActivityHandlers.length; i++)
-        op.cursorActivityHandlers[i](cm);
   }
 
   // Run the given function in an operation


### PR DESCRIPTION
Currently, if there is an error thrown somewhere in the endOperation function it will fail to decrement delayedCallbackDepth, which makes events scheduled for firing with signalLater never get fired. This is especially bad since the delayedCallbacks list is used by all CodeMirror instances, so in our application when we had an error happen here in one CodeMirror instance, _all_ the CodeMirror instances immediately stopped sending 'change' events.

The place where the try ends and the finally begins was chosen somewhat randomly here; I'd even be fine with just having the --delayedCallbackDepth part in the finally, but I didn't know if it was safe to move around.
