### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,15 @@
                     "email": "marijnh@gmail.com",
                     "web": "http://marijnhaverbeke.nl"}],
     "repository": {"type": "git",
-                   "url": "https://github.com/marijnh/CodeMirror.git"}
+                   "url": "https://github.com/marijnh/CodeMirror.git"},
+    "spm": {
+        "main": "lib/codemirror.js",
+        "output": ["lib/codemirror.css"],
+        "ignore": [
+          "bin",
+          "demo",
+          "doc",
+          "test"
+        ]
+    }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/codemirror

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of codemirror in spmjs, I can add it for your account after signing in http://spmjs.io.
