### PR TITLE
Fix unescaped meta char in regex

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -659,7 +659,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
         }
       },
       ":": function(stream) {
-        if (stream.match(/\s*{/))
+        if (stream.match(/\s*\{/))
           return [null, "{"];
         return false;
       },


### PR DESCRIPTION
It's intended to match a literal `{`, but that must be escaped as it's a meta character in JS regex.
