### PR TITLE
[vim] Reuse codemirror instance across tests when sensible

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -135,12 +135,14 @@ function resetSharedCm(vimOpts) {
   if (!sharedCm) {
     sharedCm = CodeMirror(place, vimOpts);
   }
-  sharedCm.setValue(vimOpts['value']);
-  sharedCm.setCursor(0, 0);
-  sharedCm.setOption('vimMode', false);
-  delete sharedCm.state.vim;
-  sharedCm.setOption('vimMode', true);
-  doInsertModeKeysFn(sharedCm)('Esc');
+  sharedCm.operation(function() {
+    sharedCm.setValue(vimOpts['value']);
+    sharedCm.setCursor(0, 0);
+    sharedCm.setOption('vimMode', false);
+    delete sharedCm.state.vim;
+    sharedCm.setOption('vimMode', true);
+    doInsertModeKeysFn(sharedCm)('Esc');
+  });
 }
 
 function testVim(name, run, opts, expectedFail) {


### PR DESCRIPTION
I promised to look into reusing `cm` instances across tests in the vim mode a while back. This patch moves a few things around to make it work.

Based on unscientific measurements on my laptop, it shaves ~1 second off of a total of ~22 seconds of running the entire suite. To me, a <5% speedup doesn't seem worth the lack of isolation between tests. What do you think?
