### PR TITLE
[tern addon] add optional callback to showType

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -106,7 +106,7 @@
       cm.showHint({hint: this.getHint});
     },
 
-    showType: function(cm, pos) { showType(this, cm, pos); },
+    showType: function(cm, pos, cb) { showType(this, cm, pos, cb); },
 
     updateArgHints: function(cm) { updateArgHints(this, cm); },
 
@@ -239,7 +239,7 @@
 
   // Type queries
 
-  function showType(ts, cm, pos) {
+  function showType(ts, cm, pos, cb) {
     ts.request(cm, "type", function(error, data) {
       if (error) return showError(ts, cm, error);
       if (ts.options.typeTip) {
@@ -254,6 +254,7 @@
         }
       }
       tempTooltip(cm, tip);
+      if (cb) cb();
     }, pos);
   }
 


### PR DESCRIPTION
In Firefox DevTools we are using the tern addon, and we need to be able to be notified once a popup is shown for testing purposes.  We have a [customized showType implementation](http://dxr.mozilla.org/mozilla-central/source/browser/devtools/sourceeditor/codemirror/tern.js#224) for this, but it would be great if we could contribute the change back to the addon.  I'd be happy to add a test for this, but I didn't see any existing tests for the tern addon so I've left that alone for now.
