### PR TITLE
Fix bug #2620 (One pixel wide selection appears on empty line)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7264,7 +7264,7 @@
       var test = elt("span", "\u200b");
       removeChildrenAndAdd(measure, elt("span", [test, document.createTextNode("x")]));
       if (measure.firstChild.offsetHeight != 0)
-        zwspSupported = test.offsetWidth <= 1 && test.offsetHeight > 2 && (ie && ie_version < 8);
+        zwspSupported = test.offsetWidth <= 1 && test.offsetHeight > 2 && !(ie && ie_version < 8);
     }
     if (zwspSupported) return elt("span", "\u200b");
     else return elt("span", "\u00a0", null, "display: inline-block; width: 1px; margin-right: -1px");


### PR DESCRIPTION
Fix bug #2620 (One pixel wide selection appears on empty line) -- Restore negation operator that was lost when converting to new IE flags in bbefd22.
