### PR TITLE
Add `rebeccapurple` to the list of named CSS/SVG colors

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -491,8 +491,8 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     "navajowhite", "navy", "oldlace", "olive", "olivedrab", "orange", "orangered",
     "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred",
     "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue",
-    "purple", "red", "rosybrown", "royalblue", "saddlebrown", "salmon",
-    "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue",
+    "purple", "rebeccapurple", "red", "rosybrown", "royalblue", "saddlebrown",
+    "salmon", "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue",
     "slateblue", "slategray", "snow", "springgreen", "steelblue", "tan",
     "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white",
     "whitesmoke", "yellow", "yellowgreen"


### PR DESCRIPTION
http://dev.w3.org/csswg/css-color-4/#valuedef-rebeccapurple

(This is needed for Blink: https://codereview.chromium.org/330243002/)

Note that the build failure on Travis is not related to this change.)
