### PR TITLE
Undo closing bracket if added in token type of null

### DIFF
--- a/addon/edit/closebrackets.js
+++ b/addon/edit/closebrackets.js
@@ -99,6 +99,7 @@
           } else if (type == "both") {
             cm.replaceSelection(left + right, null);
             cm.execCommand("goCharLeft");
+            if (!cm.getTokenTypeAt(cm.getCursor())) cm.execCommand("delCharAfter");
           } else if (type == "addFour") {
             cm.replaceSelection(left + left + left + left, "before");
             cm.execCommand("goCharRight");


### PR DESCRIPTION
Re issue: https://groups.google.com/forum/#!topic/codemirror/Ma_4pAdHubE

This patch undo's the closing bracket when typing what appears to be general text. It does go further than just undoing " and ' chars, as there are legitimate uses for singulars of the others too in general text, such as a single ( where a user may want to type :-( and not end up with :-()

Extra line here removes char to right (closing bracket) if user is adding text under a 'both' case and if it has no token type (null etc) at the cursor. Seems to be the cleanest and best way to do this. Undoing what we've done isn't ideal, but we can only establish the token type after adding our chars.

Should be a pretty inexpensive process tho and solves the issue well.
