### PR TITLE
Corrected Show Hint Widget Position

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -230,7 +230,10 @@
     if (overlapY > 0) {
       var height = box.bottom - box.top, curTop = box.top - (pos.bottom - pos.top);
       if (curTop - height > 0) { // Fits above cursor
-        hints.style.top = (top = curTop - height) + "px";
+        var adjustHeight = hints.style.top.substr(0,hints.style.top.length-2);
+        adjustHeight = parseInt(adjustHeight);
+        adjustHeight = adjustHeight - height - (pos.bottom - pos.top);
+        hints.style.top = adjustHeight + "px";
         below = false;
       } else if (height > winH) {
         hints.style.height = (winH - 5) + "px";


### PR DESCRIPTION
The removed code is buggy because the 'curTop' variable is absolute with respect to the window currently visible to the user, where 'hints.style.top' is absolute with respect to the entire page.
Therefore, directly assigning 'hints.style.top' to 'curTop - height), would result in random positioning of the show-hint widget.

Refer to issue :- https://github.com/marijnh/CodeMirror/issues/2662
