### PR TITLE
[vim] visual_o updated for blockwise visual

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1526,12 +1526,12 @@
         var ranges = cm.listSelections();
         var curEnd = cm.getCursor('head');
         var curStart = ranges[0].anchor;
-        var index = cursorEqual(ranges[0].head, curEnd) ? ranges.length-1 : 0;
+        var curIndex = cursorEqual(ranges[0].head, curEnd) ? ranges.length-1 : 0;
         if (motionArgs.sameLine && vim.visualBlock) {
-          curStart = Pos(curEnd.line, ranges[index].anchor.ch);
-          curEnd = Pos(ranges[index].head.line, curEnd.ch);
+          curStart = Pos(curEnd.line, ranges[curIndex].anchor.ch);
+          curEnd = Pos(ranges[curIndex].head.line, curEnd.ch);
         } else {
-          curStart = ranges[index].anchor;
+          curStart = ranges[curIndex].anchor;
         }
         cm.setCursor(curEnd);
         return ([curEnd, curStart]);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1702,9 +1702,9 @@ testVim('o_visual', function(cm, vim, helpers) {
   eq('p',cm.getValue());
 }, { value: 'abcd\nefgh\nijkl\nmnop'});
 testVim('o_visual_block', function(cm, vim, helpers) {
-  cm.setCursor(0,1);
+  cm.setCursor(0, 1);
   helpers.doKeys('<C-v>','3','j','l','l', 'o');
-  helpers.assertCursorAt(0,1);
+  helpers.assertCursorAt(0, 1);
   helpers.doKeys('O');
   helpers.assertCursorAt(0, 4);
   helpers.doKeys('o');


### PR DESCRIPTION
Little patch to change the cursor head of the highlighted text for all visual submodes.
