### PR TITLE
Searching multiline text fails when ignore-case flag is on

### DIFF
--- a/addon/search/searchcursor.js
+++ b/addon/search/searchcursor.js
@@ -107,7 +107,7 @@
             var from = Pos(pos.line, cut);
             for (var ln = pos.line + 1, i = 1; i < last; ++i, ++ln)
               if (target[i] != fold(doc.getLine(ln))) return;
-            if (doc.getLine(ln).slice(0, origTarget[last].length) != target[last]) return;
+            if (fold(doc.getLine(ln)).slice(0, origTarget[last].length) != target[last]) return;
             return {from: from, to: Pos(ln, origTarget[last].length)};
           }
         };


### PR DESCRIPTION
The bug is quite obvious. Take a look at reverse search to see that the fold call is missing.
