### PR TITLE
don't let ruby mode get confused  between divide operator and valid regex

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -46,9 +46,23 @@ CodeMirror.defineMode("ruby", function(config) {
     var ch = stream.next(), m;
     if (ch == "`" || ch == "'" || ch == '"') {
       return chain(readQuoted(ch, "string", ch == '"' || ch == "`"), stream, state);
-    } else if (ch == "/" && !stream.eol() && stream.peek() != " ") {
-      if (stream.eat("=")) return "operator";
-      return chain(readQuoted(ch, "string-2", true), stream, state);
+    } else if (ch == "/") {
+      var currentIndex = stream.current().length;
+      if (stream.skipTo("/")) {
+        var search_till = stream.current().length;
+        stream.backUp(stream.current().length - currentIndex);
+        var balance = 0;  // balance brackets
+        while (stream.current().length < search_till) {
+          var chchr = stream.next();
+          if (chchr == "(") balance += 1;
+          else if (chchr == ")") balance -= 1;
+          if (balance < 0) break;
+        }
+        stream.backUp(stream.current().length - currentIndex);
+        if (balance == 0)
+          return chain(readQuoted(ch, "string-2", true), stream, state);
+      }
+      return "operator";
     } else if (ch == "%") {
       var style = "string", embed = true;
       if (stream.eat("s")) style = "atom";


### PR DESCRIPTION
A screenshot before this commit.

![before](https://cloud.githubusercontent.com/assets/1743425/3485449/df04ecf4-03dd-11e4-9ea6-90aea3695012.png)

and a screenshot after this commit

![after](https://cloud.githubusercontent.com/assets/1743425/3485450/f13a0224-03dd-11e4-85cf-bb3763b3d525.png)
