### PR TITLE
Don't force any marker class on lint.js

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -109,6 +109,7 @@
 
   function annotationTooltip(ann) {
     var severity = ann.severity;
+    if (!severity) severity = "error";
     var tip = document.createElement("div");
     tip.className = "CodeMirror-lint-message-" + severity;
     tip.appendChild(document.createTextNode(ann.message));
@@ -139,6 +140,7 @@
       for (var i = 0; i < anns.length; ++i) {
         var ann = anns[i];
         var severity = ann.severity;
+        if (!severity) severity = "error";
         maxSeverity = getMaxSeverity(maxSeverity, severity);
 
         if (options.formatAnnotation) ann = options.formatAnnotation(ann);


### PR DESCRIPTION
Hi!,

I am developing an application using codemirror and the lint.js addon. I tried to add other types of markers like notes, information, etc. But the current code enforce specific markers (error or warning) and any other name is resolved as the error type.

Removing such limitation makes defining new types as easy as defining custom CSS classes. Example:

``` css
.CodeMirror-lint-message-info {                  
  padding-left: 18px;                                                           
  background-position: top left;                                                
  background-repeat: no-repeat;                                                 
}                                                                               

.CodeMirror-lint-mark-info {                        
  background-position: left bottom;                                             
  background-repeat: repeat-x;                                                  
}                                                                               

.CodeMirror-lint-marker-info {                    
  background-position: center center;                                           
  background-repeat: no-repeat;                                                 
  cursor: pointer;                                                              
  display: inline-block;                                                        
  height: 16px;                                                                 
  width: 16px;                                                                  
  vertical-align: middle;                                                       
  position: relative;                                                           
}                                                                               

.CodeMirror-lint-marker-info, .CodeMirror-lint-message-info {                   
  background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAKcSURBVDjLpZPLa9RXHMU/d0ysZEwmMQqZiTaP0agoaKGJUiwIxU0hUjtUQaIuXHSVbRVc+R8ICj5WvrCldJquhVqalIbOohuZxjDVxDSP0RgzyST9zdzvvffrQkh8tBs9yy9fPhw45xhV5X1U8+Yhc3U0LcEdVxdOVq20OA0ooQjhpnfhzuDZTx6++m9edfDFlZGMtXKxI6HJnrZGGtauAWAhcgwVnnB/enkGo/25859l3wIcvpzP2EhuHNpWF9/dWs/UnKW4EOGDkqhbQyqxjsKzMgM/P1ymhlO5C4ezK4DeS/c7RdzQoa3x1PaWenJjJZwT9rQ1gSp/js1jYoZdyfX8M1/mp7uFaTR8mrt29FEMQILr62jQ1I5kA8OF59jIItVA78dJertTiBNs1ZKfLNG+MUHX1oaURtIHEAOw3p/Y197MWHEJEUGCxwfHj8MTZIcnsGKxzrIURYzPLnJgbxvG2hMrKdjItjbV11CYKeG8R7ygIdB3sBMFhkem0RAAQ3Fuka7UZtRHrasOqhYNilOwrkrwnhCU/ON5/q04vHV48ThxOCuoAbxnBQB+am65QnO8FqMxNCjBe14mpHhxBBGCWBLxD3iyWMaYMLUKsO7WYH6Stk1xCAGccmR/Ozs/bKJuXS39R/YgIjgROloSDA39Deit1SZWotsjD8pfp5ONqZ6uTfyWn+T7X0f59t5fqDhUA4ry0fYtjJcWeZQvTBu4/VqRuk9/l9Fy5cbnX+6Od26s58HjWWaflwkusKGxjm1bmhkvLXHvh1+WMbWncgPfZN+qcvex6xnUXkzvSiYP7EvTvH4toDxdqDD4+ygT+cKMMbH+3MCZ7H9uAaDnqytpVX8cDScJlRY0YIwpAjcNcuePgXP/P6Z30QuoP4J7WbYhuQAAAABJRU5ErkJggg==");
}  
```

This pull-request remove such limitation.

Thank you.
