### PR TITLE
Fixed "Cannot read property 'substr' of null"

### DIFF
--- a/mode/vbscript/vbscript.js
+++ b/mode/vbscript/vbscript.js
@@ -291,7 +291,7 @@ CodeMirror.defineMode("vbscript", function(conf, parserConf) {
             style = state.tokenize(stream, state);
 
             current = stream.current();
-            if (style.substr(0, 8) === 'variable' || style==='builtin' || style==='keyword'){//|| knownWords.indexOf(current.substring(1)) > -1) {
+            if (style && (style.substr(0, 8) === 'variable' || style==='builtin' || style==='keyword')){//|| knownWords.indexOf(current.substring(1)) > -1) {
                 if (style === 'builtin' || style === 'keyword') style='variable';
                 if (knownWords.indexOf(current.substr(1)) > -1) style='variable-2';
 


### PR DESCRIPTION
Error occurs when entering multiple dots
