### PR TITLE
Fix key-binding behaviour on Mac in wrap mode

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -797,8 +797,14 @@
       <dt class=command id=command_deleteLine><code><strong>deleteLine</strong></code><span class=keybinding>Ctrl-D (PC), Cmd-D (Mac)</span></dt>
       <dd>Deletes the whole line under the cursor, including newline at the end.</dd>
 
-      <dt class=command id=command_delLineLeft><code><strong>delLineLeft</strong></code><span class=keybinding>Cmd-Backspace (Mac)</span></dt>
+      <dt class=command id=command_delLineLeft><code><strong>delLineLeft</strong></code></dt>
       <dd>Delete the part of the line before the cursor.</dd>
+
+      <dt class=command id=command_delVisualLineLeft><code><strong>delVisualLineLeft</strong></code><span class=keybinding>Cmd-Backspace (Mac)</span></dt>
+      <dd>Delete the part of the line from the left side of the visual line the cursor is on to the cursor.</dd>
+
+      <dt class=command id=command_delVisualLineRight><code><strong>delVisualLineRight</strong></code><span class=keybinding>Cmd-Delete (Mac)</span></dt>
+      <dd>Delete the part of the line from the cursor to the right side of the visual line the cursor is on.</dd>
 
       <dt class=command id=command_undo><code><strong>undo</strong></code><span class=keybinding>Ctrl-Z (PC), Cmd-Z (Mac)</span></dt>
       <dd>Undo the last change.</dd>
@@ -821,7 +827,7 @@
       <dt class=command id=command_goDocEnd><code><strong>goDocEnd</strong></code><span class=keybinding>Ctrl-Down (PC), Cmd-End (Mac), Cmd-Down (Mac)</span></dt>
       <dd>Move the cursor to the end of the document.</dd>
 
-      <dt class=command id=command_goLineStart><code><strong>goLineStart</strong></code><span class=keybinding>Alt-Left (PC), Cmd-Left (Mac), Ctrl-A (Mac)</span></dt>
+      <dt class=command id=command_goLineStart><code><strong>goLineStart</strong></code><span class=keybinding>Alt-Left (PC), Ctrl-A (Mac)</span></dt>
       <dd>Move the cursor to the start of the line.</dd>
 
       <dt class=command id=command_goLineStartSmart><code><strong>goLineStartSmart</strong></code><span class=keybinding>Home</span></dt>
@@ -829,14 +835,14 @@
       already there, to the actual start of the line (including
       whitespace).</dd>
 
-      <dt class=command id=command_goLineEnd><code><strong>goLineEnd</strong></code><span class=keybinding>Alt-Right (PC), Cmd-Right (Mac), Ctrl-E (Mac)</span></dt>
+      <dt class=command id=command_goLineEnd><code><strong>goLineEnd</strong></code><span class=keybinding>Alt-Right (PC), Ctrl-E (Mac)</span></dt>
       <dd>Move the cursor to the end of the line.</dd>
 
-      <dt class=command id=command_goLineLeft><code><strong>goLineLeft</strong></code></dt>
+      <dt class=command id=command_goLineLeft><code><strong>goLineLeft</strong></code><span class=keybinding>Cmd-Left (Mac)</span></dt>
       <dd>Move the cursor to the left side of the visual line it is on. If
       this line is wrapped, that may not be the start of the line.</dd>
 
-      <dt class=command id=command_goLineRight><code><strong>goLineRight</strong></code></dt>
+      <dt class=command id=command_goLineRight><code><strong>goLineRight</strong></code><span class=keybinding>Cmd-Right (Mac)</span></dt>
       <dd>Move the cursor to the right side of the visual line it is on.</dd>
 
       <dt class=command id=command_goLineUp><code><strong>goLineUp</strong></code><span class=keybinding>Up, Ctrl-P (Mac)</span></dt>

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4687,6 +4687,20 @@
         return {from: Pos(range.from().line, 0), to: range.from()};
       });
     },
+    delVisualLineLeft: function(cm) {
+      deleteNearSelection(cm, function(range) {
+        var top = cm.charCoords(range.head, "div").top + 5;
+        var leftPos = cm.coordsChar({left: 0, top: top}, "div");
+        return {from: leftPos, to: range.from()};
+      });
+    },
+    delVisualLineRight: function(cm) {
+      deleteNearSelection(cm, function(range) {
+        var top = cm.charCoords(range.head, "div").top + 5;
+        var rightPos = cm.coordsChar({left: cm.display.lineDiv.offsetWidth + 100, top: top}, "div");
+        return {from: range.from(), to: rightPos };
+      });
+    },
     undo: function(cm) {cm.undo();},
     redo: function(cm) {cm.redo();},
     undoSelection: function(cm) {cm.undoSelection();},
@@ -4825,10 +4839,10 @@
   keyMap.macDefault = {
     "Cmd-A": "selectAll", "Cmd-D": "deleteLine", "Cmd-Z": "undo", "Shift-Cmd-Z": "redo", "Cmd-Y": "redo",
     "Cmd-Up": "goDocStart", "Cmd-End": "goDocEnd", "Cmd-Down": "goDocEnd", "Alt-Left": "goGroupLeft",
-    "Alt-Right": "goGroupRight", "Cmd-Left": "goLineStart", "Cmd-Right": "goLineEnd", "Alt-Backspace": "delGroupBefore",
+    "Alt-Right": "goGroupRight", "Cmd-Left": "goLineLeft", "Cmd-Right": "goLineRight", "Alt-Backspace": "delGroupBefore",
     "Ctrl-Alt-Backspace": "delGroupAfter", "Alt-Delete": "delGroupAfter", "Cmd-S": "save", "Cmd-F": "find",
     "Cmd-G": "findNext", "Shift-Cmd-G": "findPrev", "Cmd-Alt-F": "replace", "Shift-Cmd-Alt-F": "replaceAll",
-    "Cmd-[": "indentLess", "Cmd-]": "indentMore", "Cmd-Backspace": "delLineLeft",
+    "Cmd-[": "indentLess", "Cmd-]": "indentMore", "Cmd-Backspace": "delVisualLineLeft", "Cmd-Delete": "delVisualLineRight",
     "Cmd-U": "undoSelection", "Shift-Cmd-U": "redoSelection",
     fallthrough: ["basic", "emacsy"]
   };


### PR DESCRIPTION
Bind Cmd-Left to goLineLeft and Cmd-right to goLineRight instead of goLineStart and goLineEnd
Create and bind delVisualLeft and delVisualRight to Cmd-Backspace and Cmd-Delete
