### PR TITLE
Fixed regex pattern matching in puppet mode

### DIFF
--- a/mode/puppet/puppet.js
+++ b/mode/puppet/puppet.js
@@ -64,6 +64,18 @@ CodeMirror.defineMode("puppet", function () {
     return "string";
   }
 
+  function tokenRegex(stream, state) {
+    var current, prev = false;
+    while (!stream.eol() && (current = stream.next())) {
+      if (current == '/' && prev == '\\') {
+        continue;
+      } else if (current == '/') {
+        return 'variable-3';
+      }
+      prev = current;
+    }
+  }
+
   // Main function
   function tokenize(stream, state) {
     // Matches one whole word
@@ -176,8 +188,7 @@ CodeMirror.defineMode("puppet", function () {
     // Match characters that we are going to assume
     // are trying to be regex
     if (ch == '/') {
-      stream.match(/.*\//);
-      return 'variable-3';
+      return tokenRegex(stream, state);
     }
     // Match all the numbers
     if (ch.match(/[0-9]/)) {


### PR DESCRIPTION
Fixes incorrect regex pattern matching where after a successful match was made, if there existed a '/' beyond what would be considered a valid match, everything between would be included.

Example currently causing incorrect matching:

```
if $php_fpm_ini == undef {
  $php_fpm_ini = $::operatingsystem ? {
    /(?i:Ubuntu|Debian|Mint|SLES|OpenSuSE)/ => '/etc/php5/fpm/php.ini',
    default                                 => '/etc/php.ini',
  }
}
```
