### PR TITLE
Normalized a package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "CodeMirror",
+  "name": "codemirror",
   "version":"4.3.1",
   "main": ["lib/codemirror.js", "lib/codemirror.css"],
   "ignore": [


### PR DESCRIPTION
The package name on http://bower.io/search/ is lowercase.
