### PR TITLE
Expand selection after indenting

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4073,6 +4073,11 @@
           end = Math.min(this.lastLine(), to.line - (to.ch ? 0 : 1)) + 1;
           for (var j = start; j < end; ++j)
             indentLine(this, j, how);
+          var head;
+          if (to.ch == 0) head = to;
+          else if (isLine(this.doc, to.line + 1)) head = Pos(to.line + 1, 0);
+          else head = Pos(to.line, getLine(this.doc, to.line).text.length);
+          replaceOneSelection(this.doc, i, new Range(Pos(start, 0), head));
         } else if (range.head.line > end) {
           indentLine(this, range.head.line, how, true);
           end = range.head.line;


### PR DESCRIPTION
When I indent the code, it is to move it somewhere else most of the time. The current behavior changes the selection so that it begins on the first non-whitespace character. When I cut the text then I have to indent the first line manually at the target place and I have to delete the whitespace from the source location. This commit changes the behavior so that it expands the selection to cover all selected lines. It allows me to select lines on any arbitrary position on the line, indent it and move it real quick.
