### PR TITLE
Use more specific CSS selector to allow for embedding in fuelux containe...

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -15,7 +15,7 @@
 .CodeMirror-lines {
   padding: 4px 0; /* Vertical padding around content */
 }
-.CodeMirror pre {
+div.CodeMirror pre {
   padding: 0 4px; /* Horizontal padding of content */
 }
 
@@ -214,7 +214,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-lines {
   cursor: text;
 }
-.CodeMirror pre {
+div.CodeMirror pre {
   /* Reset some styles that the rest of the page might have set */
   -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
   border-width: 0;


### PR DESCRIPTION
Hi Marijn,

If you embed codemirror on a fuelux or bootstrap container, I get the effect below (firefox 30.0 on Ubuntu).
This pull request makes the CSS of CodeMirror `pre` elements a bit more specific to make it overrule.  See
image below.

```
Thanks for CodeMirror

   --- Jan
```

![cm-fuelux](https://cloud.githubusercontent.com/assets/3071146/3598746/21201ca0-0ce7-11e4-82aa-a5766c9446d6.png)
