### PR TITLE
Disable replace for readOnly content

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -110,6 +110,7 @@
   var replacementQueryDialog = 'With: <input type="text" style="width: 10em"/>';
   var doReplaceConfirm = "Replace? <button>Yes</button> <button>No</button> <button>Stop</button>";
   function replace(cm, all) {
+    if (cm.options.readOnly === true) return;
     dialog(cm, replaceQueryDialog, "Replace:", cm.getSelection(), function(query) {
       if (!query) return;
       query = parseQuery(query);


### PR DESCRIPTION
Disable the `replace()` when the selected `CodeMirror` is `readOnly`.
