### PR TITLE
[vim] undo changes separately after replaying actions and operators

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1054,6 +1054,8 @@
           default:
             break;
         }
+        // This is to prevent undo operations from merging.
+        cm.changeGeneration(true);
       },
       processMotion: function(cm, vim, command) {
         vim.inputState.motion = command.motion;


### PR DESCRIPTION
Little patch to fix the bug where various changes are undone together instead of one at a time.
