### PR TITLE
[vim] Corrected macro recording message behavoir

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -574,8 +574,8 @@
           register.clear();
           this.latestRegister = registerName;
           if (cm.openDialog) {
-            this.onRecordingDone = cm.openDialog(
-                '(recording)['+registerName+']', null, {bottom:true});
+            cm.openDialog('(recording)['+registerName+']', null, {bottom:true});
+            this.onRecordingDone = cm.openDialog('', null, {bottom:true});
           }
           this.isRecording = true;
         }


### PR DESCRIPTION
The behavior expected in vim is to have the "recording" appear on the bottom of the screen when you enter macro recording mode, then to have it disappear when you exit macro recording mode.
