### PR TITLE
Check signature of drawn object not just truthyness

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1281,7 +1281,9 @@
   }
 
   function updateSelection(cm, drawn) {
-    if (!drawn) drawn = drawSelection(cm);
+    if (typeof drawn !== 'object' || !drawn.cursors || !drawn.selection) {
+      drawn = drawSelection(cm);
+    }
     removeChildrenAndAdd(cm.display.cursorDiv, drawn.cursors);
     removeChildrenAndAdd(cm.display.selectionDiv, drawn.selection);
     if (drawn.teTop != null) {


### PR DESCRIPTION
This is to get around the bug when setting the 'showCursorWhenSelecting' option to true via the #setOption method which allows the true value to fall through to updateSelection - passing the truthy test but throwing an error when trying to appendChild null

This bug was originally found in jsbin but can be replicated on the [codemirror site](http://codemirror.net/index.html) - just run this into the console:

``` js
document.querySelector('.CodeMirror').CodeMirror.setOption('showCursorWhenSelecting', true)
```
