### PR TITLE
 [merge] allowEditingOriginals option to edit all compared files 

### DIFF
--- a/addon/merge/merge.css
+++ b/addon/merge/merge.css
@@ -13,11 +13,6 @@
 .CodeMirror-merge-3pane .CodeMirror-merge-pane { width: 31%; }
 .CodeMirror-merge-3pane .CodeMirror-merge-gap { width: 3.5%; }
 
-.CodeMirror-merge-2pane-both-ways .CodeMirror-merge-pane { width: 47%; }
-.CodeMirror-merge-2pane-both-ways .CodeMirror-merge-gap { width: 12%; }
-.CodeMirror-merge-3pane-both-ways .CodeMirror-merge-pane { width: 31%; }
-.CodeMirror-merge-3pane-both-ways .CodeMirror-merge-gap { width: 7%; }
-
 .CodeMirror-merge-pane {
   display: inline-block;
   white-space: normal;

--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -336,11 +336,7 @@
 
     wrap.push(elt("div", null, null, "height: 0; clear: both;"));
 
-    var bothWays = "";
-    if (options.allowEditingOriginals === true) {
-      bothWays = "-both-ways";
-    }
-    var wrapElt = this.wrap = node.appendChild(elt("div", wrap, "CodeMirror-merge CodeMirror-merge-" + panes + "pane" + bothWays));
+    var wrapElt = this.wrap = node.appendChild(elt("div", wrap, "CodeMirror-merge CodeMirror-merge-" + panes + "pane"));
     this.edit = CodeMirror(editPane, copyObj(options));
 
     if (left) left.init(leftPane, origLeft, options);


### PR DESCRIPTION
![merge](https://cloud.githubusercontent.com/assets/476495/3722489/1c842d12-166a-11e4-9b40-c63bb1282fa4.png)
There is only a small bug remaining: when the size is too small, both arrows overlap.
