### PR TITLE
[vim] remove visualBlock check in exitVisualMode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2797,13 +2797,10 @@
       updateLastSelection(cm, vim);
       vim.visualMode = false;
       vim.visualLine = false;
-      if (!cursorEqual(selectionStart, selectionEnd) && !vim.visualBlock) {
-        // Clear the selection and set the cursor only if the selection has not
-        // already been cleared. Otherwise we risk moving the cursor somewhere
-        // it's not supposed to be.
+      vim.visualBlock = false;
+      if (!cursorEqual(selectionStart, selectionEnd)) {
         cm.setCursor(clipCursorToContent(cm, selectionEnd));
       }
-      vim.visualBlock = false;
       CodeMirror.signal(cm, "vim-mode-change", {mode: "normal"});
       if (vim.fakeCursor) {
         vim.fakeCursor.clear();

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1651,6 +1651,11 @@ testVim('visual', function(cm, vim, helpers) {
   helpers.doKeys('d');
   eq('15', cm.getValue());
 }, { value: '12345' });
+testVim('visual_exit', function(cm, vim, helpers) {
+  helpers.doKeys('<C-v>', 'l', 'j', 'j', '<Esc>');
+  eq(cm.getCursor('anchor'), cm.getCursor('head'));
+  eq(vim.visualMode, false);
+}, { value: 'hello\nworld\nfoo' });
 testVim('visual_line', function(cm, vim, helpers) {
   helpers.doKeys('l', 'V', 'l', 'j', 'j', 'd');
   eq(' 4\n 5', cm.getValue());


### PR DESCRIPTION
A small fix to a bug that prevents selection clearing after blockwise visual mode.
