### PR TITLE
[comment addon] Fix corner cases in uncommenting block comment

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -162,7 +162,7 @@
     firstEnd = endLine.indexOf(endString, to.ch);
     var almostLastStart = endLine.slice(to.ch).lastIndexOf(startString, firstEnd - to.ch);
     lastStart = (firstEnd == -1 || almostLastStart == -1) ? -1 : to.ch + almostLastStart;
-    if (firstEnd != -1 && lastStart != -1) return false;
+    if (firstEnd != -1 && lastStart != -1 && lastStart != to.ch) return false;
 
     self.operation(function() {
       self.replaceRange("", Pos(end, close - (pad && endLine.slice(close - pad.length, close) == pad ? pad.length : 0)),


### PR DESCRIPTION
Currently, if the cursor is located in the very end or the very beginning of a block comment, like this:

``` css
/*  background-color: red; */|
```

The toggleComment command will not uncomment the block comment, but intuitively it should. This patch fixes this behavior.
