### PR TITLE
Add more config options for openDialog

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -87,7 +87,7 @@
         me.focus();
       });
 
-      CodeMirror.on(button, "blur", close);
+      if (options.closeOnBlur) CodeMirror.on(button, "blur", close);
 
       button.focus();
     }


### PR DESCRIPTION
Hey @marijnh,

I recently had to implement a custom search UI, and needed to customize a lot of the dialog behaviors to work with it. Instead of hacking apart `search.js`, I was able to isolate all the changes to options that can optionally be passed to `openDialog`. All the options keep the same defaults they used to have, so there's no change in behavior if you don't opt in. The options I added are:
- `closeOnEnter`: whether or not the dialog should be closed when you press enter with it focused. Defaults to true.
- `closeOnBlur`: whether or not the dialog should be closed when the textfield or button loses focus. Defaults to true.
- `onClose`: a callback that will be called when the close function completes.
- `onInput`: very similar to `onKeyDown`, but uses the `input` event instead of `keydown`. Just an additional event handler basically.

I figured other people may find these useful in implementing custom dialogs, or changing the default behavior of search. Plus, it'd just be great to have these changes upstream.

Let me know what you think, or what I can do to improve anything. Thanks!
