### PR TITLE
Change the wrapper caculation to use the scroller #2765

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -731,7 +731,7 @@
             gutterTotalWidth: d.gutters.offsetWidth,
             gutterLeft: left,
             gutterWidth: width,
-            wrapperWidth: d.wrapper.clientWidth};
+            wrapperWidth: d.scroller.clientWidth - scrollerCutOff};
   }
 
   // Sync the actual display DOM structure with display.view, removing


### PR DESCRIPTION
This addresses #2765.
The scroller element seems to be more consistently sized in IE.
