### PR TITLE
[sass mode] fix indent when multiplexed

### DIFF
--- a/mode/sass/sass.js
+++ b/mode/sass/sass.js
@@ -280,7 +280,8 @@ CodeMirror.defineMode("sass", function(config) {
 
     if (style !== null) {
       var startOfToken = stream.pos - current.length;
-      var withCurrentIndent = startOfToken + (config.indentUnit * state.indentCount);
+      var indentCount = state.indentCount || 0;
+      var withCurrentIndent = startOfToken + (config.indentUnit * indentCount);
 
       var newScopes = [];
 


### PR DESCRIPTION
So here I was, multiplexing a Liquid mode on top of Sass, when a user reported an issue: starting the file with something like `{% if foo %}bar{% endif %}` breaks CodeMirror, specifically when you get to the first `%` in `{% endif %}`

The error is that `sass.indent` is being called, but for some reason, `state.scopes` is empty. I poked around for a while and tracked it down to `tokenLexer`. Because it's the very beginning of the sass file, the state is still the default startState, so `indentCount` is not defined. But it's also not the start of the line (because of the liquid), so the `stream.sol()` check fails and `indentCount` never gets initialized to 0. Therefore, when execution gets down to the `withCurrentIndex` line, `state.indentCount` is still undefined, and trying to multiply by undefined results in the entirety of `withCurrentIndex` being `NaN`. Finally, when we get to the line that checks each scope's `offset` against `withCurrentIndex`, the check always fails due to the `NaN`, so the `newStates` array is empty, and down the line ends up causing `indent` to throw.

Phew. Anyway, I'm not sure if this is exactly the right solution; it doesn't set an `indentCount` on the state object if it wasn't there already (so as not to mess with future indents), but instead it just prevents `withCurrentIndex` from being `NaN`, so that at least the check will pass and `newStates` won't be empty.

This is how I felt writing this patch:

![i have no idea what i m doing_9a2f5f_3220475](https://cloud.githubusercontent.com/assets/22133/4067765/9084b6bc-2e31-11e4-8093-b5101f3992e4.gif)

So please feel free to tell me there's a much better way to prevent this, since I'm not super clear on how sass' `indentCount` works :)
