### PR TITLE
Fix anchor target in Release Notes

### DIFF
--- a/doc/releases.html
+++ b/doc/releases.html
@@ -118,7 +118,7 @@
 
 <section id=v3>
 
-  <h2 id="v3">Version 3.x</h2>
+  <h2>Version 3.x</h2>
 
   <p class="rel">22-04-2014: <a href="http://codemirror.net/codemirror-3.24.zip">Version 3.24</a>:</p>
 


### PR DESCRIPTION
Fixed because unlikely to be in motion it is assumed
