### PR TITLE
[match-highlighter] Added wordsOnly option

### DIFF
--- a/addon/search/match-highlighter.js
+++ b/addon/search/match-highlighter.js
@@ -102,7 +102,7 @@
             var chr = cm.getRange(pos, from);
             if (chr.match(/\W/) === null) return false;
         }
-        if (to.ch < cm.getLine(from.line).length - 1) {
+        if (to.ch < cm.getLine(from.line).length) {
             var pos = {line: to.line, ch: to.ch + 1};
             var chr = cm.getRange(to, pos);
             if (chr.match(/\W/) === null) return false;


### PR DESCRIPTION
Adds the option to highlight the selection _only if_ it's a word.
The "delay" option was missing from the documentation, I added it.
