### PR TITLE
Make parentheses visible while under `matchingbracket` rule

### DIFF
--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -19,7 +19,7 @@
 .cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute {color: #9ddfe9;}
 .cm-s-mbo span.cm-keyword {color: #ffb928;}
 .cm-s-mbo span.cm-string {color: #ffcf6c;}
-.cm-s-mbo span.cm-string.cm-property {color: #ffffec !important;}
+.cm-s-mbo span.cm-string.cm-property {color: #ffffec;}
 
 .cm-s-mbo span.cm-variable {color: #ffffec;}
 .cm-s-mbo span.cm-variable-2 {color: #00a8c6;}


### PR DESCRIPTION
**Code**: Brackets now become black when they are highlighted as "matching".
**JSON**: key names are now in "white" (json was a bit saturated with orange - keys and string values).
**Cleanup**: removed some unnecessary rules.
**Default face**: color normalized to #ffffec (was #ffffe9).
