### PR TITLE
Support upper-case SCRIPT tags in htmlmixed mode

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -30,6 +30,7 @@ CodeMirror.defineMode("htmlmixed", function(config, parserConfig) {
 
   function html(stream, state) {
     var tagName = state.htmlState.tagName;
+    if (tagName) tagName = tagName.toLowerCase();
     var style = htmlMode.token(stream, state.htmlState);
     if (tagName == "script" && /\btag\b/.test(style) && stream.current() == ">") {
       // Script block: mode to change to depends on type attribute


### PR DESCRIPTION
Currently, HTMLMIXED mode does not switch modes in case of upper-case `SCRIPT` or `STYLE` tags.
This is a one-liner to fix the issue. 
