### PR TITLE
[CoffeeScript] Fix auto indentation when returning an object containing ...

### DIFF
--- a/mode/coffeescript/coffeescript.js
+++ b/mode/coffeescript/coffeescript.js
@@ -310,7 +310,7 @@ CodeMirror.defineMode("coffeescript", function(conf) {
       if (state.scope.type == current)
         state.scope = state.scope.prev;
     }
-    if (state.dedent > 0 && stream.eol() && state.scope.type == "coffee") {
+    if (state.dedent > 0 && stream.eol() && ["coffee", "}"].indexOf(state.scope.type) > -1) {
       if (state.scope.prev) state.scope = state.scope.prev;
       state.dedent -= 1;
     }


### PR DESCRIPTION
...a function

For #2807.
Still, I assume the type `}` is **not** intended.
