### PR TITLE
[core] create a clean copy of the options object when instantiating

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -61,7 +61,7 @@
   function CodeMirror(place, options) {
     if (!(this instanceof CodeMirror)) return new CodeMirror(place, options);
 
-    this.options = options = options || {};
+    this.options = options = copyObj(options || {}, {}, false);
     // Determine effective options based on given values and defaults.
     copyObj(defaults, options, false);
     setGuttersForLineNumbers(options);


### PR DESCRIPTION
The options object is passed as a reference.

This creates strange results when you have several CodeMirror instances in the same page, with the same options object.

You can check the issue in action: http://jsbin.com/zejipe/5/edit
