### PR TITLE
Prevent scrollPosIntoView from going into infinite loop

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3719,7 +3719,7 @@
   // it actually became visible (as line heights are accurately
   // measured, the position of something may 'drift' during drawing).
   function scrollPosIntoView(cm, pos, end, margin) {
-  
+
     // if the view is too narrow or too shallow to accomodate the scroll position,
     //   the math to compute the scroll pos will yield a delta that alternates 
     //   between the same absolute value (positive then negative).
@@ -3748,25 +3748,25 @@
       if (scrollPos.scrollTop != null) {
         setScrollTop(cm, scrollPos.scrollTop);
         if (Math.abs(cm.doc.scrollTop - startTop) > 1) {
-            if (previousTop != -(cm.doc.scrollTop - startTop)) {
-              changed = true;
-              previousTop = cm.doc.scrollTop - startTop;
-            } else {
-              wafflingTop = true;
-              setScrollTop(cm, 0);
-            }
+          if (previousTop != -(cm.doc.scrollTop - startTop)) {
+            changed = true;
+            previousTop = cm.doc.scrollTop - startTop;
+          } else {
+            wafflingTop = true;
+            setScrollTop(cm, 0);
+          }
         }
       }
       if (scrollPos.scrollLeft != null) {
         setScrollLeft(cm, scrollPos.scrollLeft);
         if (Math.abs(cm.doc.scrollLeft - startLeft) > 1)  {
-            if (previousLeft != -(cm.doc.scrollLeft - startLeft)) {
-              changed = true;
-              previousLeft = cm.doc.scrollLeft - startLeft;
-            } else {
-              wafflingLeft = true;
-              setScrollLeft(cm, 0);
-            }
+          if (previousLeft != -(cm.doc.scrollLeft - startLeft)) {
+            changed = true;
+            previousLeft = cm.doc.scrollLeft - startLeft;
+          } else {
+            wafflingLeft = true;
+            setScrollLeft(cm, 0);
+          }
         }
       }
       


### PR DESCRIPTION
This fixes https://github.com/adobe/brackets/issues/9291 

This is a targeted fix to when  the scroll remainder waffles between the same positive and negative value which is what I've seen in every case of this hang.

To test this in brackets,
Sync to master and create a split view 
then open a document to the working set and go to the end of one of the lines
then resize the pane so that only the line numbers are visible
then click in the empty pane then focus the pane using the working set

=> hang
