### PR TITLE
Fix width calculation for individual line numbers

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -521,6 +521,7 @@
                                                  "CodeMirror-linenumber CodeMirror-gutter-elt"));
       var innerW = test.firstChild.offsetWidth, padding = test.offsetWidth - innerW;
       display.lineGutter.style.width = "";
+      display.lineNumPadding = padding;
       display.lineNumInnerWidth = Math.max(innerW, display.lineGutter.offsetWidth - padding);
       display.lineNumWidth = display.lineNumInnerWidth + padding;
       display.lineNumChars = display.lineNumInnerWidth ? last.length : -1;
@@ -876,7 +877,7 @@
           elt("div", lineNumberFor(cm.options, lineN),
               "CodeMirror-linenumber CodeMirror-gutter-elt",
               "left: " + dims.gutterLeft["CodeMirror-linenumbers"] + "px; width: "
-              + cm.display.lineNumInnerWidth + "px"));
+              + (dims.gutterTotalWidth - cm.display.lineNumPadding) + "px"));
       if (markers) for (var k = 0; k < cm.options.gutters.length; ++k) {
         var id = cm.options.gutters[k], found = markers.hasOwnProperty(id) && markers[id];
         if (found)


### PR DESCRIPTION
Since the gutter wrapper for each individual line number element has a `left` of `-totalGutterWidth`:

![Gutter wrapper left](http://f.cl.ly/items/2Y3G3T2c190D2t1o3B14/Image%202014-10-04%20at%203.50.02%20PM.png)

 and the line number element needs to take up the whole width in the gutter wrapper, it should be `gutterTotalWidth - padding`, not `lineNumInnerWidth`.

Otherwise, if the `CodeMirror-gutters` element has borders or such (for instance, separating the gutter from the text), the line number element will be misaligned within its wrapper: 

![Misalignment](http://f.cl.ly/items/390I3P0p2v0P0S2a2z16/Image%202014-10-04%20at%203.52.32%20PM.png)

This commit should fix the issue:

![Fixed](http://f.cl.ly/items/3R1z2k0o3e3G3V18072w/Image%202014-10-04%20at%203.57.30%20PM.png)
