### PR TITLE
[vim] Fix error when dd the only line.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1862,10 +1862,15 @@
         // including the trailing \n, include the \n before the starting line
         if (operatorArgs.linewise &&
             curEnd.line == cm.lastLine() && curStart.line == curEnd.line) {
-          var tmp = copyCursor(curEnd);
-          curStart.line--;
-          curStart.ch = lineLength(cm, curStart.line);
-          curEnd = tmp;
+          if (curEnd.line == 0) {
+            curStart.ch = 0;
+          }
+          else {
+            var tmp = copyCursor(curEnd);
+            curStart.line--;
+            curStart.ch = lineLength(cm, curStart.line);
+            curEnd = tmp;
+          }
           cm.replaceRange('', curStart, curEnd);
         } else {
           cm.replaceSelections(replacement);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -828,6 +828,15 @@ testVim('dd_lastline', function(cm, vim, helpers) {
   eq(expectedLineCount, cm.lineCount());
   helpers.assertCursorAt(cm.lineCount() - 1, 0);
 });
+testVim('dd_only_line', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  var expectedRegister = cm.getValue() + "\n";
+  helpers.doKeys('d','d');
+  eq(1, cm.lineCount());
+  eq('', cm.getValue());
+  var register = helpers.getRegisterController().getRegister();
+  eq(expectedRegister, register.toString());
+}, { value: "thisistheonlyline" });
 // Yank commands should behave the exact same as d commands, expect that nothing
 // gets deleted.
 testVim('yw_repeat', function(cm, vim, helpers) {


### PR DESCRIPTION
When the buffer has only one line, pressing 'dd' causes CodeMirror to throw an error "There is no line -1 in the document.". Then the cursor behaves in weird way and commands don't work. This can be reproduced in http://codemirror.net/demo/vim.html by keep pressing 'dd'.
Attached change should fix this problem. Tested on Chome 37.0.2062.124, Windows 8.1.
