### PR TITLE
SQL hint support fot default table for hinting columns

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -12,6 +12,7 @@
   "use strict";
 
   var tables;
+  var defaultTable;
   var keywords;
   var CONS = {
     QUERY_DIV: ";",
@@ -78,16 +79,18 @@
       }
     }
     else {
-      //Suggest table names
+      //Suggest table names or colums in defaultTable
       while (token.start && string.charAt(0) == ".") {
         token = editor.getTokenAt(Pos(cur.line, token.start - 1));
         string = token.string + string;
       }
       if (useBacktick) {
         addMatches(result, string, tables, function(w) {return "`" + w + "`";});
+        addMatches(result, string, defaultTable, function(w) {return "`" + w + "`";});
       }
       else {
         addMatches(result, string, tables, function(w) {return w;});
+        addMatches(result, string, defaultTable, function(w) {return w;});
       }
     }
   }
@@ -163,6 +166,13 @@
 
   CodeMirror.registerHelper("hint", "sql", function(editor, options) {
     tables = (options && options.tables) || {};
+    defaultTable = (options && options.defaultTable) || false;
+    if ((defaultTable) && (defaultTable in tables)) {
+      defaultTable = tables[defaultTable];
+    }
+    else {
+      defaultTable = [];
+    }
     keywords = keywords || getKeywords(editor);
     var cur = editor.getCursor();
     var result = [];
@@ -179,6 +189,7 @@
       nameCompletion(result, editor);
     } else {
       addMatches(result, search, tables, function(w) {return w;});
+      addMatches(result, search, defaultTable, function(w) {return w;});
       addMatches(result, search, keywords, function(w) {return w.toUpperCase();});
     }
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2527,7 +2527,11 @@
       should scan when completing (defaults to 500).</dd>
 
       <dt id="addon_sql-hint"><a href="../addon/hint/sql-hint.js"><code>hint/sql-hint.js</code></a></dt>
-      <dd>A simple SQL hinter. Defines <code>CodeMirror.hint.sql</code>.</dd>
+      <dd>A simple SQL hinter. Defines <code>CodeMirror.hint.sql</code>.
+      Takes two optional options, <code>tables</code>, a object with
+      table names as keys and array of respective column names as values,
+      and <code>defaultTable</code>, a string corresponding to a
+      table name in <code>tables</code> for autocompletion.</dd>
 
       <dt id="addon_match-highlighter"><a href="../addon/search/match-highlighter.js"><code>search/match-highlighter.js</code></a></dt>
       <dd>Adds a <code>highlightSelectionMatches</code> option that


### PR DESCRIPTION
Because it is very common practice to just write column names instead of `table.column` format.
