### PR TITLE
Toggle merge arrows in the merge add on

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -43,6 +43,7 @@
       this.diffOutOfDate = false;
 
       this.showDifferences = options.showDifferences !== false;
+      this.showMergeArrows = options.showMergeArrows !== false;
       this.forceUpdate = registerUpdate(this);
       setScrollLock(this, true, false);
       registerScroll(this);
@@ -51,6 +52,13 @@
       val = val !== false;
       if (val != this.showDifferences) {
         this.showDifferences = val;
+        this.forceUpdate("full");
+      }
+    },
+    setMergeArrows: function(val) {
+      val = val !== false;
+      if (val != this.showMergeArrows) {
+        this.showMergeArrows = val;
         this.forceUpdate("full");
       }
     }
@@ -280,13 +288,14 @@
               "class", dv.classes.connect);
       }
       if (dv.copyButtons) {
-        var copy = dv.copyButtons.appendChild(elt("div", dv.type == "left" ? "\u21dd" : "\u21dc",
-                                                  "CodeMirror-merge-copy"));
-        var editOriginals = dv.mv.options.allowEditingOriginals;
-        copy.title = editOriginals ? "Push to left" : "Revert chunk";
-        copy.chunk = {topEdit: topEdit, botEdit: botEdit, topOrig: topOrig, botOrig: botOrig};
-        copy.style.top = top + "px";
-
+        if(dv.showMergeArrows) {
+          var copy = dv.copyButtons.appendChild(elt("div", dv.type == "left" ? "\u21dd" : "\u21dc",
+                                                    "CodeMirror-merge-copy"));
+          var editOriginals = dv.mv.options.allowEditingOriginals;
+          copy.title = editOriginals ? "Push to left" : "Revert chunk";
+          copy.chunk = {topEdit: topEdit, botEdit: botEdit, topOrig: topOrig, botOrig: botOrig};
+          copy.style.top = top + "px";
+        }
         if (editOriginals) {
           var topReverse = dv.orig.heightAtLine(topEdit, "local") - sTopEdit;
           var copyReverse = dv.copyButtons.appendChild(elt("div", dv.type == "right" ? "\u21dd" : "\u21dc",
@@ -390,6 +399,10 @@
     setShowDifferences: function(val) {
       if (this.right) this.right.setShowDifferences(val);
       if (this.left) this.left.setShowDifferences(val);
+    },
+    setMergeArrows: function(val) {
+      if (this.right) this.right.setMergeArrows(val);
+      if (this.left) this.left.setMergeArrows(val);
     },
     rightChunks: function() {
       return this.right && getChunks(this.right);

--- a/demo/merge.html
+++ b/demo/merge.html
@@ -44,14 +44,16 @@ addon provides an interface for displaying and merging diffs,
 either <span class=clicky onclick="initUI(2)">two-way</span>
 or <span class=clicky onclick="initUI(3)">three-way</span>. The left
 (or center) pane is editable, and the differences with the other
-pane(s) are <span class=clicky onclick="toggleDifferences()">optionally</span> shown live as you edit it.</p>
+pane(s) are <span class=clicky onclick="toggleDifferences()">optionally</span> shown live as you edit it (or
+you can just <span class=clicky onclick="toggleMergeArrows()">toggle</span> the merge arrows for a plain beautiful
+side-by-side diff interface.</p>
 
 <p>This addon depends on
 the <a href="https://code.google.com/p/google-diff-match-patch/">google-diff-match-patch</a>
 library to compute the diffs.</p>
 
 <script>
-var value, orig1, orig2, dv, hilight= true;
+var value, orig1, orig2, dv, showArrows= true, hilight= true;
 function initUI(panes) {
   if (value == null) return;
   var target = document.getElementById("view");
@@ -62,12 +64,17 @@ function initUI(panes) {
     orig: orig2,
     lineNumbers: true,
     mode: "text/html",
-    highlightDifferences: hilight
+    highlightDifferences: hilight,
+    showMergeArrows: showArrows
   });
 }
 
 function toggleDifferences() {
   dv.setShowDifferences(hilight = !hilight);
+}
+
+function toggleMergeArrows() {
+  dv.setMergeArrows(showArrows = !showArrows);
 }
 
 window.onload = function() {

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2682,12 +2682,14 @@
       constructor takes arguments similar to
       the <a href="#CodeMirror"><code>CodeMirror</code></a>
       constructor, first a node to append the interface to, and then
-      an options object. Two extra optional options are
+      an options object. Three extra optional options are
       recognized, <code>origLeft</code> and <code>origRight</code>,
       which may be strings that provide original versions of the
-      document, which will be shown to the left and right of the
-      editor in non-editable CodeMirror instances. The merge interface
-      will highlight changes between the editable document and the
+      document (which will be shown to the left and right of the
+      editor in non-editable CodeMirror instances), as well as
+      <code>showMergeArrows</code>, which provides the possibility
+      to toggle the merge arrows available between panels.
+      The merge interface will highlight changes between the editable document and the
       original(s), and, unless a <code>revertButtons</code> option
       of <code>false</code> is given, show buttons that allow the user
       to revert changes (<a href="../demo/merge.html">demo</a>).</dd>


### PR DESCRIPTION
Could be used to avoid interaction with the contents of the panels and provide a streamlined side-by-side diff view.
