### PR TITLE
Fix for issue #2832

### DIFF
--- a/mode/smartymixed/smartymixed.js
+++ b/mode/smartymixed/smartymixed.js
@@ -77,7 +77,11 @@ CodeMirror.defineMode("smartymixed", function(config) {
 
   var parsers = {
     html: function(stream, state) {
-      if (!state.inLiteral && stream.match(regs.htmlHasLeftDelimeter, false) && state.htmlMixedState.htmlState.tagName === null) {
+      var htmlTagName = state.htmlMixedState.htmlState.context && state.htmlMixedState.htmlState.context.tagName
+        ? state.htmlMixedState.htmlState.context.tagName
+        : null;
+
+      if (!state.inLiteral && stream.match(regs.htmlHasLeftDelimeter, false) && htmlTagName === null) {
         state.tokenize = parsers.smarty;
         state.localMode = smartyMode;
         state.localState = smartyMode.startState(htmlMixedMode.indent(state.htmlMixedState, ""));
@@ -177,8 +181,6 @@ CodeMirror.defineMode("smartymixed", function(config) {
       }
       return htmlMixedMode.indent(state.htmlMixedState, textAfter);
     },
-
-    electricChars: "/{}:",
 
     innerMode: function(state) {
       return {


### PR DESCRIPTION
The patch fixes the issue breaking highlighting when a smarty code is written within an HTML attribute. However, there's still an issue with Smarty variables within a scope of a comment. Just look at `mode/smartymixed/index.html`:

```
  {* Multiline smarty
  * comment, no {$variables} here
  *}
```

The last line is not highlighted here. It should be a similar kind of issue.
