### PR TITLE
[comment.js] fix corner case for comment.js plugin

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -109,7 +109,7 @@
   CodeMirror.defineExtension("uncomment", function(from, to, options) {
     if (!options) options = noOptions;
     var self = this, mode = self.getModeAt(from);
-    var end = Math.min(to.line, self.lastLine()), start = Math.min(from.line, end);
+    var end = Math.min(to.ch != 0 || to.line == from.line ? to.line : to.line - 1, self.lastLine()), start = Math.min(from.line, end);
 
     // Try finding line comments
     var lineString = options.lineComment || mode.lineComment, lines = [];


### PR DESCRIPTION
In the following text, position cursor at the very beginning of the first line, press shift+down to select the first line and press `ctrl+/` to uncomment it.

``` js
// console.log(1);
// console.log(2);
```

I expect to get the following:

``` js
console.log(1);
// console.log(2);
```

Instead, I get both lines uncommented:

``` js
console.log(1);
console.log(2);
```

Downstream bug: https://crbug.com/414302
