### PR TITLE
Fixed bug which highlighted the rest of the line

### DIFF
--- a/demo/mustache.html
+++ b/demo/mustache.html
@@ -46,9 +46,10 @@ CodeMirror.defineMode("mustache", function(config, parserConfig) {
       var ch;
       if (stream.match("{{")) {
         while ((ch = stream.next()) != null)
-          if (ch == "}" && stream.next() == "}") break;
-        stream.eat("}");
-        return "mustache";
+          if (ch == "}" && stream.next() == "}") {
+            stream.eat("}");
+            return "mustache";
+          }
       }
       while (stream.next() != null && !stream.match("{{", false)) {}
       return null;


### PR DESCRIPTION
If "{{" was found, the code would highlight the rest of the line regardless if a matching "}}" or "}}}" was found.
