### PR TITLE
Mouse selection on Android.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1497,6 +1497,7 @@ window.CodeMirror = (function() {
   function registerEventHandlers(cm) {
     var d = cm.display;
     on(d.scroller, "mousedown", operation(cm, onMouseDown));
+    on(d.scroller, "touchmove", operation(cm, onTouchMove));
     if (ie)
       on(d.scroller, "dblclick", operation(cm, function(e) {
         if (signalDOMEvent(cm, e)) return;
@@ -1624,7 +1625,13 @@ window.CodeMirror = (function() {
     }
     var x, y, space = getRect(display.lineSpace);
     // Fails unpredictably on IE[67] when mouse is dragged around quickly.
-    try { x = e.clientX; y = e.clientY; } catch (e) { return null; }
+    try {
+      x = e.clientX; y = e.clientY;
+      if (!x && !y && e.touches && e.touches.length===1) {
+        x = e.touches[0].clientX;
+        y = e.touches[0].clientY;
+      }
+    } catch (e) { return null; }
     return coordsChar(cm, x - space.left, y - space.top);
   }
 
@@ -1792,6 +1799,38 @@ window.CodeMirror = (function() {
       }
     }
     return true;
+  }
+
+  var touchDrag;
+  function onTouchMove(e) {
+    if (!e.touches || e.touches.length !== 1 || e.touches[0].radiusX>1 || e.touches[0].radiusY>1) return;
+    var cm = this;
+
+    if (touchDrag) {
+      var cur = posFromMouse(cm, e);
+      if (posEq(touchDrag, cur)) return;
+      extendSelection(cm.doc, clipPos(cm.doc, touchDrag), cur);
+      e_preventDefault(e);
+      return;
+    }
+    
+    touchDrag = posFromMouse(cm, e);
+    if (!touchDrag) return;
+    
+    var cm = this;
+    if (signalDOMEvent(cm, e) || eventInWidget(cm.display, e))
+      return;
+    
+    function done(e) {
+      touchDrag = null;
+      e_preventDefault(e);
+      focusInput(cm);
+      off(document, "touchend", up);
+    }
+
+    e_preventDefault(e);
+    var up = operation(cm, done);
+    on(document, "touchend", up);
   }
 
   // Kludge to work around strange IE behavior where it'll sometimes


### PR DESCRIPTION
Android devices allow physical mice, but web pages tend to treat mouse as a precise touch device.

This patch makes CodeMirror treat mouse click-drag as a normal selection, whilst still keeping touch click-drag for panning.

Tested on Android:
- Chrome Mobile,
- Built-in browser (on 4.4, still need to try on older Webkits),
- FireFox,
- Opera
- Opera Classic
  It works totally as expected. Mouse selects, touching pans.

Tested on Windows 8+touchscreen:
- Chrome,
- IE
  Works half-way: Chrome selects with both mouse and single-finger touch, pans with multi-finger touch; IE always pans.

Use the standard demo pages for quick testing:

http://mihailik.github.io/CodeMirror/demo/folding.html
http://mihailik.github.io/CodeMirror/demo/buffers.html
