### PR TITLE
Support attach and detach methods for key maps

### DIFF
--- a/demo/vim.html
+++ b/demo/vim.html
@@ -80,7 +80,7 @@ implementation</p>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
         lineNumbers: true,
         mode: "text/x-csrc",
-        vimMode: true,
+        keyMap: "vim",
         matchBrackets: true,
         showCursorWhenSelecting: true
       });

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -273,26 +273,50 @@
       }
     }
 
-    CodeMirror.defineOption('vimMode', false, function(cm, val) {
-      if (val) {
-        cm.setOption('keyMap', 'vim');
-        cm.setOption('disableInput', true);
-        cm.setOption('showCursorWhenSelecting', false);
-        CodeMirror.signal(cm, "vim-mode-change", {mode: "normal"});
-        cm.on('cursorActivity', onCursorActivity);
-        maybeInitVimState(cm);
-        CodeMirror.on(cm.getInputField(), 'paste', getOnPasteFn(cm));
-        cm.on('keypress', handleKeyPress);
-        cm.on('keydown', handleKeyDown);
-      } else if (cm.state.vim) {
-        cm.setOption('keyMap', 'default');
-        cm.setOption('disableInput', false);
-        cm.off('cursorActivity', onCursorActivity);
-        CodeMirror.off(cm.getInputField(), 'paste', getOnPasteFn(cm));
-        cm.state.vim = null;
-        cm.off('keypress', handleKeyPress);
-        cm.off('keydown', handleKeyDown);
-      }
+    function enterVimMode(cm) {
+      console.log("enter");
+      cm.setOption('disableInput', true);
+      cm.setOption('showCursorWhenSelecting', false);
+      CodeMirror.signal(cm, "vim-mode-change", {mode: "normal"});
+      cm.on('cursorActivity', onCursorActivity);
+      maybeInitVimState(cm);
+      CodeMirror.on(cm.getInputField(), 'paste', getOnPasteFn(cm));
+      cm.on('keypress', handleKeyPress);
+      cm.on('keydown', handleKeyDown);
+      CodeMirror.addClass(cm.getWrapperElement(), "cm-fat-cursor");
+    }
+
+    function leaveVimMode(cm) {
+      console.log("leave", setMap);
+      cm.setOption('disableInput', false);
+      cm.off('cursorActivity', onCursorActivity);
+      CodeMirror.off(cm.getInputField(), 'paste', getOnPasteFn(cm));
+      cm.state.vim = null;
+      cm.off('keypress', handleKeyPress);
+      cm.off('keydown', handleKeyDown);
+    }
+
+    function detachVimMap(cm, next) {
+      if (this == CodeMirror.keyMap.vim)
+        CodeMirror.rmClass(cm.getWrapperElement(), "cm-fat-cursor");
+
+      if (!next || next.attach != attachVimMap)
+        leaveVimMode(cm, false);
+    }
+    function attachVimMap(cm, prev) {
+      if (this == CodeMirror.keyMap.vim)
+        CodeMirror.addClass(cm.getWrapperElement(), "cm-fat-cursor");
+
+      if (!prev || prev.attach != attachVimMap)
+        enterVimMode(cm);
+    }
+
+    // Deprecated, simply setting the keymap works again.
+    CodeMirror.defineOption('vimMode', false, function(cm, val, prev) {
+      if (val && cm.getOption("keyMap") != "vim")
+        cm.setOption("keyMap", "vim");
+      else if (!val && prev != CodeMirror.Init && /^vim/.test(cm.getOption("keyMap")))
+        cm.setOption("keyMap", "default");
     });
     function getOnPasteFn(cm) {
       var vim = cm.state.vim;
@@ -4468,9 +4492,10 @@
     }
 
     CodeMirror.keyMap.vim = {
-        'nofallthrough': true,
-        'style': 'fat-cursor'
-      };
+      nofallthrough: true,
+      attach: attachVimMap,
+      detach: detachVimMap
+    };
 
     function exitInsertMode(cm) {
       var vim = cm.state.vim;
@@ -4540,16 +4565,22 @@
             CodeMirror.commands.newlineAndIndent;
         fn(cm);
       },
-      fallthrough: ['default']
+      fallthrough: ['default'],
+      attach: attachVimMap,
+      detach: detachVimMap
     };
 
     CodeMirror.keyMap['await-second'] = {
-      fallthrough: ['vim-insert']
+      fallthrough: ['vim-insert'],
+      attach: attachVimMap,
+      detach: detachVimMap
     };
 
     CodeMirror.keyMap['vim-replace'] = {
       'Backspace': 'goCharLeft',
-      fallthrough: ['vim-insert']
+      fallthrough: ['vim-insert'],
+      attach: attachVimMap,
+      detach: detachVimMap
     };
 
     function executeMacroRegister(cm, vim, macroModeState, registerName) {

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -52,12 +52,12 @@
 .CodeMirror div.CodeMirror-secondarycursor {
   border-left: 1px solid silver;
 }
-.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor {
+.CodeMirror.cm-fat-cursor div.CodeMirror-cursor {
   width: auto;
   border: 0;
   background: #7e7;
 }
-.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursors {
+.CodeMirror.cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -303,10 +303,13 @@
     });
   }
 
-  function keyMapChanged(cm) {
-    var map = keyMap[cm.options.keyMap], style = map.style;
-    cm.display.wrapper.className = cm.display.wrapper.className.replace(/\s*cm-keymap-\S+/g, "") +
-      (style ? " cm-keymap-" + style : "");
+  function keyMapChanged(cm, old) {
+    if (old == cm.options.keyMap) return;
+
+    old = (old == CodeMirror.Init) ? null : getKeyMap(old);
+    var map = getKeyMap(cm.options.keyMap);
+    if (old && old.detach) old.detach(cm, map);
+    if (map.attach) map.attach(cm, old);
   }
 
   function themeChanged(cm) {
@@ -3185,8 +3188,9 @@
     clearTimeout(maybeTransition);
     if (next && !isModifierKey(e)) maybeTransition = setTimeout(function() {
       if (getKeyMap(cm.options.keyMap) == startMap) {
+        var old = cm.options.keyMap;
         cm.options.keyMap = (next.call ? next.call(null, cm) : next);
-        keyMapChanged(cm);
+        keyMapChanged(cm, old);
       }
     }, 50);
 
@@ -4504,7 +4508,7 @@
     themeChanged(cm);
     guttersChanged(cm);
   }, true);
-  option("keyMap", "default", keyMapChanged);
+  option("keyMap", "default", function(cm, val, old) { keyMapChanged(cm, old); });
   option("extraKeys", null);
 
   option("lineWrapping", false, wrappingChanged, true);
@@ -7375,13 +7379,13 @@
   };
 
   function classTest(cls) { return new RegExp("\\b" + cls + "\\b\\s*"); }
-  function rmClass(node, cls) {
+  var rmClass = CodeMirror.rmClass = function(node, cls) {
     var test = classTest(cls);
     if (test.test(node.className)) node.className = node.className.replace(test, "");
-  }
-  function addClass(node, cls) {
+  };
+  var addClass = CodeMirror.addClass = function(node, cls) {
     if (!classTest(cls).test(node.className)) node.className += " " + cls;
-  }
+  };
   function joinClasses(a, b) {
     var as = a.split(" ");
     for (var i = 0; i < as.length; i++)


### PR DESCRIPTION
Hi @mightyguava , this is what I meant with attach/detach methods on keymaps. It is probably more general-purpose than defining options for each one, and easier on users. Please review, since I made quite a lot of changes to `vim.js`, and you might have comments on the approach in general.
