### PR TITLE
[markdown mode] Support leading whitespace in fencedCodeBlocks mode name

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -204,7 +204,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.f = state.inline;
       if (modeCfg.highlightFormatting) state.formatting = ["list", "list-" + listType];
       return getType(state);
-    } else if (modeCfg.fencedCodeBlocks && stream.match(/^```([\w+#]*)/, true)) {
+    } else if (modeCfg.fencedCodeBlocks && stream.match(/^```[ \t]*([\w+#]*)/, true)) {
       // try switching mode
       state.localMode = getMode(RegExp.$1);
       if (state.localMode) state.localState = state.localMode.startState();


### PR DESCRIPTION
GFM actually supports whitespace between ``` and the mode for syntax-highlight.
That is, this

`````` markdown
``` javascript
if (foo > 42) return;
``​​`
``````

will result in this

``` javascript
if (foo > 42) return;
```

while CodeMirror doesn't syntax-highlight the code block.
