### PR TITLE
BUG: having meta.js is miessing up aliases

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -3,9 +3,9 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror", require("../xml/xml"), require("../meta.js")));
+    mod(require("../../lib/codemirror", require("../xml/xml"), require("../meta")));
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror", "../xml/xml", "../meta.js"], mod);
+    define(["../../lib/codemirror", "../xml/xml", "../meta"], mod);
   else // Plain browser env
     mod(CodeMirror);
 })(function(CodeMirror) {


### PR DESCRIPTION
quick fix. the `.js` was 404'ing in `IPython`
