### PR TITLE
Allow a custom global scope

### DIFF
--- a/addon/hint/javascript-hint.js
+++ b/addon/hint/javascript-hint.js
@@ -93,7 +93,7 @@
                   "if in instanceof isnt new no not null of off on or return switch then throw true try typeof until void while with yes").split(" ");
 
   function getCompletions(token, context, keywords, options) {
-    var found = [], start = token.string;
+    var found = [], start = token.string, global = options && options.globalScope || window;
     function maybeAdd(str) {
       if (str.lastIndexOf(start, 0) == 0 && !arrayContains(found, str)) found.push(str);
     }
@@ -112,28 +112,28 @@
         if (options && options.additionalContext)
           base = options.additionalContext[obj.string];
         if (!options || options.useGlobalScope !== false)
-          base = base || window[obj.string];
+          base = base || global[obj.string];
       } else if (obj.type == "string") {
         base = "";
       } else if (obj.type == "atom") {
         base = 1;
       } else if (obj.type == "function") {
-        if (window.jQuery != null && (obj.string == '$' || obj.string == 'jQuery') &&
-            (typeof window.jQuery == 'function'))
-          base = window.jQuery();
-        else if (window._ != null && (obj.string == '_') && (typeof window._ == 'function'))
-          base = window._();
+        if (global.jQuery != null && (obj.string == '$' || obj.string == 'jQuery') &&
+            (typeof global.jQuery == 'function'))
+          base = global.jQuery();
+        else if (global._ != null && (obj.string == '_') && (typeof global._ == 'function'))
+          base = global._();
       }
       while (base != null && context.length)
         base = base[context.pop().string];
       if (base != null) gatherCompletions(base);
     } else {
-      // If not, just look in the window object and any local scope
+      // If not, just look in the global object and any local scope
       // (reading into JS mode internals to get at the local and global variables)
       for (var v = token.state.localVars; v; v = v.next) maybeAdd(v.name);
       for (var v = token.state.globalVars; v; v = v.next) maybeAdd(v.name);
       if (!options || options.useGlobalScope !== false)
-        gatherCompletions(window);
+        gatherCompletions(global);
       forEach(keywords, maybeAdd);
     }
     return found;


### PR DESCRIPTION
Use case: I'm using completion on js code that will be executed in an iframe, which has a different global scope than the context in which codemirror is loaded.
This allows you to pass in an object as a global via the `globalScope` option.
