### PR TITLE
fix #2925 Ensure that closeOnEnter can preventDefault

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -73,7 +73,7 @@
           CodeMirror.e_stop(e);
           close();
         }
-        if (e.keyCode == 13) callback(inp.value);
+        if (e.keyCode == 13) callback(inp.value, e);
       });
 
       if (options.closeOnBlur !== false) CodeMirror.on(inp, "blur", close);


### PR DESCRIPTION
When closeOnEnter is set the enter event never gets default prevented
this causes issues for IE9/10, this way implementors can optionally
preventDefault if they want
