### PR TITLE
Do a string search if a bad regexp is entered

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -63,7 +63,12 @@
   function parseQuery(query) {
     var isRE = query.match(/^\/(.*)\/([a-z]*)$/);
     if (isRE) {
-      query = new RegExp(isRE[1], isRE[2].indexOf("i") == -1 ? "" : "i");
+      try {
+        query = new RegExp(isRE[1], isRE[2].indexOf("i") == -1 ? "" : "i");
+      } catch (ex) {
+        // Not a regular expression after all, do a string search
+        return query;
+      }
       if (query.test("")) query = /x^/;
     } else if (query == "") {
       query = /x^/;


### PR DESCRIPTION
http://codemirror.net/demo/search.html

Put `/+/` somewhere in the textbox. Now do a search for `/+/`. Nothing found! Since it starts and ends with `/`, CodeMirror thinks it's a regular expression. `/+/` is not a valid regular expression, so creating a `RegExp` fails, and the search does nothing.

With this PR, if creating the `RegExp` fails, it will perform a regular string search.
