### PR TITLE
Add Embedded Ruby (erb) as a htmlembedded mode in mode/meta.js

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -34,6 +34,7 @@
     {name: "ECL", mime: "text/x-ecl", mode: "ecl", ext: ["ecl"]},
     {name: "Eiffel", mime: "text/x-eiffel", mode: "eiffel", ext: ["e"]},
     {name: "Embedded Javascript", mime: "application/x-ejs", mode: "htmlembedded", ext: ["ejs"]},
+    {name: "Embedded Ruby", mime: "application/x-erb", mode: "htmlembedded", ext: ["erb"]},
     {name: "Erlang", mime: "text/x-erlang", mode: "erlang", ext: ["erl"]},
     {name: "Fortran", mime: "text/x-fortran", mode: "fortran", ext: ["f", "for", "f77", "f90"]},
     {name: "F#", mime: "text/x-fsharp", mode: "mllike", ext: ["fs"], alias: ["fsharp"]},


### PR DESCRIPTION
The mime type is currently accounted for in the htmlembedded definition, but erb
is not listed in the `mode/meta.js` index.
