### PR TITLE
Bad require caused dependecy problem

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -3,7 +3,7 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"), require("../xml/xml"), require("../meta")));
+    mod(require("../../lib/codemirror"), require("../xml/xml"), require("../meta"));
   else if (typeof define == "function" && define.amd) // AMD
     define(["../../lib/codemirror", "../xml/xml", "../meta"], mod);
   else // Plain browser env


### PR DESCRIPTION
I tried using CodeMirror with Webpack. The require statement get's resolved very bad in Webpack, causing Syntax errors. 
However i think `require` was used in a bad way here, and everything works fine if i change it like that.
