### PR TITLE
Fix a bug in matching ordered list

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -38,7 +38,7 @@
 
       } else {
         var indent = match[1], after = match[4];
-        var bullet = unorderedListRE.test(match[2]) >= 0 || match[2].indexOf(">") >= 0
+        var bullet = unorderedListRE.test(match[2]) || match[2].indexOf(">") >= 0
           ? match[2]
           : (parseInt(match[3], 10) + 1) + ".";
 


### PR DESCRIPTION
If I write **markdown** like this:

``` markdown
    some codes
```

and press the enter button, then `NaN.` will be added in next line:

``` markdown
    some codes
  NaN. 
```
