### PR TITLE
Devoncarew dart 2

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -402,27 +402,6 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     }
   });
 
-  def("application/dart", {
-    name: "clike",
-    keywords: words(
-      "this super static final const abstract class extends external factory " +
-      "implements get native operator set typedef with enum throw rethrow " +
-      "assert break case continue default in return new deferred async await " +
-      "try catch finally do else for if switch while import library export " +
-      "part of show hide is"
-    ),
-    multiLineStrings: true,
-    blockKeywords: words("try catch finally do else for if switch while"),
-    builtin: words("void bool num int double dynamic var String"),
-    atoms: words("true false null"),
-    hooks: {
-      "@": function(stream) {
-        stream.eatWhile(/[\w\$_]/);
-        return "meta";
-      }
-    }
-  });
-
   def(["x-shader/x-vertex", "x-shader/x-fragment"], {
     name: "clike",
     keywords: words("float int bool void " +

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -1,0 +1,59 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../clike/clike"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../clike/clike"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  function def(mimes, mode) {
+    if (typeof mimes == "string") mimes = [mimes];
+    var words = [];
+    function add(obj) {
+      if (obj) for (var prop in obj) if (obj.hasOwnProperty(prop))
+        words.push(prop);
+    }
+    add(mode.keywords);
+    add(mode.builtin);
+    add(mode.atoms);
+    if (words.length) {
+      mode.helperType = mimes[0];
+      CodeMirror.registerHelper("hintWords", mimes[0], words);
+    }
+
+    for (var i = 0; i < mimes.length; ++i)
+      CodeMirror.defineMIME(mimes[i], mode);
+  }
+
+  function words(str) {
+    var obj = {}, words = str.split(" ");
+    for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
+    return obj;
+  }
+
+  def("application/dart", {
+    name: "clike",
+    keywords: words(
+      "this super static final const abstract class extends external factory " +
+      "implements get native operator set typedef with enum throw rethrow " +
+      "assert break case continue default in return new deferred async await " +
+      "try catch finally do else for if switch while import library export " +
+      "part of show hide is"
+    ),
+    multiLineStrings: true,
+    blockKeywords: words("try catch finally do else for if switch while"),
+    builtin: words("void bool num int double dynamic var String"),
+    atoms: words("true false null"),
+    hooks: {
+      "@": function(stream) {
+        stream.eatWhile(/[\w\$_]/);
+        return "meta";
+      }
+    }
+  });
+});

--- a/mode/dart/index.html
+++ b/mode/dart/index.html
@@ -5,7 +5,8 @@
 <link rel=stylesheet href="../../doc/docs.css">
 <link rel="stylesheet" href="../../lib/codemirror.css">
 <script src="../../lib/codemirror.js"></script>
-<script src="clike.js"></script>
+<script src="../clike/clike.js"></script>
+<script src="dart.js"></script>
 <style>.CodeMirror {border: 1px solid #dee;}</style>
 <div id=nav>
   <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>

--- a/mode/index.html
+++ b/mode/index.html
@@ -41,7 +41,7 @@ option.</p>
       <li><a href="cypher/index.html">Cypher</a></li>
       <li><a href="python/index.html">Cython</a></li>
       <li><a href="d/index.html">D</a></li>
-      <li><a href="clike/dart.html">Dart</a></li>
+      <li><a href="dart/index.html">Dart</a></li>
       <li><a href="django/index.html">Django</a> (templating language)</li>
       <li><a href="dockerfile/index.html">Dockerfile</a></li>
       <li><a href="diff/index.html">diff</a></li>


### PR DESCRIPTION
Redux of https://github.com/codemirror/CodeMirror/pull/2947 - add a Dart mode to CodeMirror. This implementation is based on the clike mode, with an example file for it and entries in the `mode/index.html` and `mode/meta.js` files.
