### PR TITLE
[mode/meta.js] Change Markdown name

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -64,7 +64,7 @@
     {name: "LESS", mime: "text/x-less", mode: "css", ext: ["less"]},
     {name: "LiveScript", mime: "text/x-livescript", mode: "livescript", ext: ["ls"], alias: ["ls"]},
     {name: "Lua", mime: "text/x-lua", mode: "lua", ext: ["lua"]},
-    {name: "Markdown (GitHub-flavour)", mime: "text/x-markdown", mode: "markdown", ext: ["markdown", "md", "mkd"]},
+    {name: "Markdown", mime: "text/x-markdown", mode: "markdown", ext: ["markdown", "md", "mkd"]},
     {name: "mIRC", mime: "text/mirc", mode: "mirc"},
     {name: "MariaDB SQL", mime: "text/x-mariadb", mode: "sql"},
     {name: "Modelica", mime: "text/x-modelica", mode: "modelica", ext: ["mo"]},


### PR DESCRIPTION
I think this name is an mistake, as the `gfm` mode is for the GitHub flavor.
