### PR TITLE
Fixed a bug in matching link

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -396,13 +396,13 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return image;
     }
 
-    if (ch === '[' && stream.match(/.*\](\(| ?\[)/, false)) {
+    if (ch === '[' && stream.match(/.*\](\(.*\)| ?\[.*\])/, false)) {
       state.linkText = true;
       if (modeCfg.highlightFormatting) state.formatting = "link";
       return getType(state);
     }
 
-    if (ch === ']' && state.linkText) {
+    if (ch === ']' && state.linkText && stream.match(/\(.*\)| ?\[.*\]/, false)) {
       if (modeCfg.highlightFormatting) state.formatting = "link";
       var type = getType(state);
       state.linkText = false;


### PR DESCRIPTION
These cases were parsed incorrectly:

``` markdown
[this is a link](url

[this is [another] link](url)
```
