### PR TITLE
Fix infinite loop when adding a capital in puppet syntax

### DIFF
--- a/mode/puppet/puppet.js
+++ b/mode/puppet/puppet.js
@@ -140,11 +140,11 @@ CodeMirror.defineMode("puppet", function () {
       return words[word];
     }
     // Is there a match on a reference?
-    if (/(\s+)?[A-Z]/.test(word)) {
+    if (/(^|\s+)[A-Z][\w:_]+/.test(word)) {
       // Negate the next()
       stream.backUp(1);
       // Match the full reference
-      stream.match(/(\s+)?[A-Z][\w:_]+/);
+      stream.match(/(^|\s+)[A-Z][\w:_]+/);
       return 'def';
     }
     // Have we matched the prior resource regex?


### PR DESCRIPTION
A loop is caused in the Puppet mode when adding a capital letter due to an incomplete regex match and use of the backUp function. Resolving this issue required checking for a full match against the word before calling backUp on the stream.

To replicate, simply type any capital letter after a series of characters or at the beginning of a line:

```
A
```
