### PR TITLE
Fix one-line require for webpack

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -2,12 +2,16 @@
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 
 (function(mod) {
-  if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"), require("../xml/xml"), require("../meta"));
-  else if (typeof define == "function" && define.amd) // AMD
+  if (typeof exports == "object" && typeof module == "object") { // CommonJS
+    var cm = require("../../lib/codemirror");
+    var xml = require("../xml/xml");
+    var meta = require("../meta");
+    mod(cm, xml, meta);
+  } else if (typeof define == "function" && define.amd) { // AMD
     define(["../../lib/codemirror", "../xml/xml", "../meta"], mod);
-  else // Plain browser env
+  } else { // Plain browser env
     mod(CodeMirror);
+  }
 })(function(CodeMirror) {
 "use strict";
 


### PR DESCRIPTION
Webpack fails to require markdown.js

```
WARNING in ./~/codemirror/mode/markdown/markdown.js
Critical dependencies:
6:8-15 require function is used in a way, in which dependencies cannot be statically extracted
 @ ./~/codemirror/mode/markdown/markdown.js 6:8-15

WARNING in ./~/codemirror/mode/markdown/index.html
Module parse failed: /Users/mizchi/proj/codemirror-kitchen/node_modules/codemirror/mode/markdown/index.html Line 1: Unexpected 
token <
You may need an appropriate loader to handle this file type.
| <!doctype html>
| 
| <title>CodeMirror: Markdown mode</title>
 @ ./~/codemirror/mode/markdown ^\.\/.*$
```

It is perhaps bug of webpack but anyway it works.
