### PR TITLE
Fix to removeLineClass to remove class from gutter markup

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -6737,7 +6737,7 @@
       });
     }),
     removeLineClass: docMethodOp(function(handle, where, cls) {
-      return changeLine(this, handle, "class", function(line) {
+      return changeLine(this, handle, where == "gutter" ? "gutter" : "class", function(line) {
         var prop = where == "text" ? "textClass"
                  : where == "background" ? "bgClass"
                  : where == "gutter" ? "gutterClass" : "wrapClass";

--- a/test/test.js
+++ b/test/test.js
@@ -1533,33 +1533,48 @@ testCM("jumpTheGap", function(cm) {
 }, {lineWrapping: true, value: "abc\ndef\nghi\njkl\n"});
 
 testCM("addLineClass", function(cm) {
-  function cls(line, text, bg, wrap) {
+  function cls(line, text, bg, wrap, gutter) {
     var i = cm.lineInfo(line);
     eq(i.textClass, text);
     eq(i.bgClass, bg);
     eq(i.wrapClass, wrap);
+    if (typeof i.handle.gutterClass !== 'undefined') {
+        eq(i.handle.gutterClass, gutter);
+    }
   }
   cm.addLineClass(0, "text", "foo");
   cm.addLineClass(0, "text", "bar");
   cm.addLineClass(1, "background", "baz");
   cm.addLineClass(1, "wrap", "foo");
-  cls(0, "foo bar", null, null);
-  cls(1, null, "baz", "foo");
+  cm.addLineClass(1, "gutter", "gutter-class");
+  cls(0, "foo bar", null, null, null);
+  cls(1, null, "baz", "foo", "gutter-class");
   var lines = cm.display.lineDiv;
   eq(byClassName(lines, "foo").length, 2);
   eq(byClassName(lines, "bar").length, 1);
   eq(byClassName(lines, "baz").length, 1);
+  eq(byClassName(lines, "gutter-class").length, 1);
   cm.removeLineClass(0, "text", "foo");
-  cls(0, "bar", null, null);
+  cls(0, "bar", null, null, null);
   cm.removeLineClass(0, "text", "foo");
-  cls(0, "bar", null, null);
+  cls(0, "bar", null, null, null);
   cm.removeLineClass(0, "text", "bar");
   cls(0, null, null, null);
+
   cm.addLineClass(1, "wrap", "quux");
-  cls(1, null, "baz", "foo quux");
+  cls(1, null, "baz", "foo quux", "gutter-class");
   cm.removeLineClass(1, "wrap");
-  cls(1, null, "baz", null);
-}, {value: "hohoho\n"});
+  cls(1, null, "baz", null, "gutter-class");
+  cm.removeLineClass(1, "gutter", "gutter-class");
+  eq(byClassName(lines, "gutter-class").length, 0);
+  cls(1, null, "baz", null, null);
+
+  cm.addLineClass(1, "gutter", "gutter-class");
+  cls(1, null, "baz", null, "gutter-class");
+  cm.removeLineClass(1, "gutter", "gutter-class");
+  cls(1, null, "baz", null, null);
+
+}, {value: "hohoho\n", lineNumbers: true});
 
 testCM("atomicMarker", function(cm) {
   addDoc(cm, 10, 10);


### PR DESCRIPTION
I found that gutter classes aren't being removed from the markup when `removeLineClass` is called. I've fixed the function and also amended the unit tests to support the fix:

I've updated the `addLineClass` unit test to ensure that gutter classes are removed from the markup and also tested that `line.handle.gutterClass` is cleared when `removeLineClass` is called for a gutter class.

I'm happy to amend the tests to make sure other line classes are also being removed from the markup.
