### PR TITLE
Modified markText to allow css

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -6275,7 +6275,7 @@
     var nextChange = 0, spanStyle, spanEndStyle, spanStartStyle, title, collapsed;
     for (;;) {
       if (nextChange == pos) { // Update current marker set
-        spanStyle = spanEndStyle = spanStartStyle = title = "";
+        spanStyle = spanEndStyle = spanStartStyle = title = css = "";
         collapsed = null; nextChange = Infinity;
         var foundBookmarks = [];
         for (var j = 0; j < spans.length; ++j) {


### PR DESCRIPTION
I modified `markText()` to allow css.

Before, you could only style it by using a className

```
cm.markText(startPos, endPos, { className: "someClass" });
```

Now you can add css dynamically.

```
var marker = cm.markText(startPos, endPos, { css: "background-color: blue; color: red" });
marker.clear();
marker = cm.markText(startPos, endPos, { css: "background-color: orange" });
```
