### PR TITLE
Stop coffeescript mode from crashing

### DIFF
--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -103,7 +103,7 @@ exports.getMode = function(options, spec) {
 exports.registerHelper = exports.registerGlobalHelper = Math.min;
 
 exports.runMode = function(string, modespec, callback, options) {
-  var mode = exports.getMode({indentUnit: 2}, modespec);
+  var mode = exports.getMode({indentUnit: 2, mode: {}}, modespec);
   var lines = splitLines(string), state = (options && options.state) || exports.startState(mode);
   for (var i = 0, e = lines.length; i < e; ++i) {
     if (i) callback("\n");


### PR DESCRIPTION
Coffeescript mode is crashing under node for us.

It's not clear if this is the right patch, but the issue is that this line expects a `mode` object: https://github.com/codemirror/CodeMirror/blob/cd17bae3716459028ec973cb2c9511834d978afb/mode/coffeescript/coffeescript.js#L194
