### PR TITLE
fix 'moveToEol' behaviour for vim visual block mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1329,7 +1329,9 @@
             newHead = copyCursor(origHead);
           }
           if (vim.visualMode) {
-            newHead = clipCursorToContent(cm, newHead, vim.visualBlock);
+            if (!(vim.visualBlock && motion === "moveToEol")) {
+              newHead = clipCursorToContent(cm, newHead, vim.visualBlock);
+            }
             if (newAnchor) {
               newAnchor = clipCursorToContent(cm, newAnchor, true);
             }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1867,6 +1867,14 @@ testVim('visual_line', function(cm, vim, helpers) {
   helpers.doKeys('l', 'V', 'l', 'j', 'j', 'd');
   eq(' 4\n 5', cm.getValue());
 }, { value: ' 1\n 2\n 3\n 4\n 5' });
+testVim('visual_block_move_to_eol', function(cm, vim, helpers) {
+  // moveToEol should move all block cursors to end of line
+  cm.setCursor(0, 0);
+  helpers.doKeys('<C-v>', 'G', '$');
+  var selections = cm.getSelections().join();
+  console.log(selections);
+  eq("123,45,6", selections);
+}, {value: '123\n45\n6'});
 testVim('visual_block_different_line_lengths', function(cm, vim, helpers) {
   // test the block selection with lines of different length
   // i.e. extending the selection


### PR DESCRIPTION
This fixes the `moveToEol` behaviour for visual block mode in Vim. Example of the new behaviour with Ace (which uses CodeMirror's `vim.js` IIUC):
## Before

![vim-before](https://cloud.githubusercontent.com/assets/1976582/5516411/c15eee96-8850-11e4-8617-5ea15e157648.gif)
## After

![vim-after](https://cloud.githubusercontent.com/assets/1976582/5516412/c422966e-8850-11e4-894a-feb4ed76dca2.gif)
