### PR TITLE
[gfm] Prevent markdown mode from parsing formatting within vanilla links (closes #4079)

### DIFF
--- a/addon/mode/overlay.js
+++ b/addon/mode/overlay.js
@@ -4,8 +4,12 @@
 // Utility function that allows modes to be combined. The mode given
 // as the base argument takes care of most of the normal mode
 // functionality, but a second (typically simple) mode is used, which
-// can override the style of text. Both modes get to parse all of the
-// text, but when both assign a non-null style to a piece of code, the
+// can override the style of text.
+// If state.overlay.freezeBaseState is true,
+// only the overlay mode will parse the text
+// until state.overlay.freezeBaseState is set to false.
+// Otherwise, both modes get to parse all of the text,
+// but when both assign a non-null style to a piece of code, the
 // overlay wins, unless the combine argument was true and not overridden,
 // or state.overlay.combineTokens was true, in which case the styles are
 // combined.
@@ -47,7 +51,7 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
         state.basePos = state.overlayPos = stream.start;
       }
 
-      if (stream.start == state.basePos) {
+      if (stream.start == state.basePos && !state.overlay.freezeBaseState) {
         state.baseCur = base.token(stream, state.base);
         state.basePos = stream.pos;
       }
@@ -55,6 +59,9 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
         stream.pos = stream.start;
         state.overlayCur = overlay.token(stream, state.overlay);
         state.overlayPos = stream.pos;
+      }
+      if (state.overlay.freezeBaseState) {
+        state.basePos = state.overlayPos;
       }
       stream.pos = Math.min(state.basePos, state.overlayPos);
 

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -24,18 +24,13 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
       return {
         code: false,
         codeBlock: false,
-        ateSpace: false
-      };
-    },
-    copyState: function(s) {
-      return {
-        code: s.code,
-        codeBlock: s.codeBlock,
-        ateSpace: s.ateSpace
+        ateSpace: false,
+        freezeBaseState: false
       };
     },
     token: function(stream, state) {
       state.combineTokens = null;
+      state.freezeBaseState = false;
 
       // Hack to prevent formatting override inside code blocks (block and inline)
       if (state.codeBlock) {
@@ -104,6 +99,8 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
         // And then (issue #1160) simplified to make it not crash the Chrome Regexp engine
         // And then limited url schemes to the CommonMark list, so foo:bar isn't matched as a URL
         state.combineTokens = true;
+        // #4079: Freeze base state until after URL to avoid parsing formatting within link
+        state.freezeBaseState = true;
         return "link";
       }
       stream.next();

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -162,6 +162,15 @@
   MT("vanillaLinkEmphasis",
      "foo [em *][em&link http://www.example.com/index.html][em *] bar");
 
+  MT("vanillaLinkUnderscoreInParam",
+     "foo [link http://www.example.com/?bar_baz] hello");
+
+  MT("vanillaLinkUnderscoreStartsParam",
+     "foo [link http://www.example.com/?_bar] hello");
+
+  MT("vanillaLinkUnderscoreStartsParamNoSlash",
+     "foo [link http://www.example.com?_bar] hello");
+
   MT("notALink",
      "foo asfd:asdf bar");
 


### PR DESCRIPTION
The bug that #4079 was coming across was the fact that markdown mode parses separately from gfm mode, and isn't aware of the parsing happening in gfm mode. Additionally, either an asterisk anywhere or an underscore after a non word character had to appear in the url. That leaves a few different routes for fixing that I can think of.

First, we could make markdown mode aware of autolinking, but this is pushing more of the gfm mode logic into markdown mode that should really be avoided. Additionally, putting small hacks to prevent formatting within links would be more fragile than just building in the autolinking entirely in markdown mode (and verbose, as we'd have to put it in all of the formatting logic).

Secondly, we could give gfm mode access to markdown mode's state and have gfm mode try to manage it, but that would make refactoring states within a mode more prone to breaking overlays. So, also not ideal.

Thirdly, we could simply give the gfm mode's tokens priority, which would fix the link, but everything after it would still be in a different state than it should be (italicized when it shouldn't be).

Lastly, we can force markdown to freeze state until after the link, which is ideal and the route I ended up taking. That is, the state before the link in markdown should be exactly the same as after the link. The simplest way I could think of to achieve this was to add a `freezeBaseState` flag to gfm mode that the overlay.js code would look for and skip base mode parsing when it was encountered. It would then set the base position to the overlay position so they both start parsing again from the same spot (after the link).
