### PR TITLE
Add "min-height: 1em" to hiddenTextarea

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -120,7 +120,7 @@ export function disableBrowserMagic(field, spellcheck, autocorrect, autocapitali
 }
 
 export function hiddenTextarea() {
-  let te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none")
+  let te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; min-height: 1em; outline: none")
   let div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
   // The textarea is kept positioned near the cursor to prevent the
   // fact that it'll be scrolled into view on input from scrolling


### PR DESCRIPTION
This patch adds "min-height: 1em" to hiddenTextarea. This keeps the textarea near the cursor even when large min-height is given from css. Without this, the textarea goes above the cursor when large min-height is given as shown in the image below. This is useful to fix the problem where input method window is misplaced as reported [here](https://github.com/go-gitea/gitea/issues/16727).

![test](https://user-images.githubusercontent.com/62025968/136565627-0b01cbbb-5ebe-4070-845d-a20e4cb8a980.png)

Thanks.