### PR TITLE
Add <C-u> to delete back a line

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -154,6 +154,7 @@
     { keys: 'C', type: 'operator', operator: 'change', operatorArgs: { linewise: true }, context: 'visual'},
     { keys: '~', type: 'operatorMotion', operator: 'changeCase', motion: 'moveByCharacters', motionArgs: { forward: true }, operatorArgs: { shouldMoveCursor: true }, context: 'normal'},
     { keys: '~', type: 'operator', operator: 'changeCase', context: 'visual'},
+    { keys: '<C-u>', type: 'operatorMotion', operator: 'delete', motion: 'moveToStartOfLine', context: 'insert' },
     { keys: '<C-w>', type: 'operatorMotion', operator: 'delete', motion: 'moveByWords', motionArgs: { forward: false, wordEnd: false }, context: 'insert' },
     //ignore C-w in normal mode
     { keys: '<C-w>', type: 'idle', context: 'normal' },

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -151,7 +151,7 @@ function testVim(name, run, opts, expectedFail) {
     cm.focus();
     // workaround for cm5 slow polling in blurred window
     Object.defineProperty(cm.state, "focused", {
-        set: function(e) {}, 
+        set: function(e) {},
         get: function() {
             return document.activeElement == cm.getInputField();
         }
@@ -1211,7 +1211,7 @@ testVim('gu_and_gU', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
   is(!register.linewise);
-  
+
   cm.setCursor(curStart);
   cm.setValue('abc efg\nxyz');
   helpers.doKeys('g', 'U', 'g', 'U');
@@ -1548,6 +1548,19 @@ testVim('<C-x>/<C-a> search forward', function(cm, vim, helpers) {
     helpers.assertCursorAt(0, 11);
   });
 }, {value: '__jmp1 jmp2 jmp'});
+testVim('insert_ctrl_u', function(cm, vim, helpers) {
+  var curStart = makeCursor(0, 10);
+  cm.setCursor(curStart);
+  helpers.doKeys('a');
+  helpers.doKeys('<C-u>');
+  eq('', cm.getValue());
+  var register = helpers.getRegisterController().getRegister();
+  eq('word1/word2', register.toString());
+  is(!register.linewise);
+  var curEnd = makeCursor(0, 0);
+  eqCursorPos(curEnd, cm.getCursor());
+  eq('vim-insert', cm.getOption('keyMap'));
+}, { value: 'word1/word2' });
 testVim('insert_ctrl_w', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 10);
   cm.setCursor(curStart);
@@ -5010,7 +5023,7 @@ var typeKey = function() {
     if (!prevented && ctrl && !alt && !meta && letter == "c") emitClipboard("copy");
     if (!prevented) updateTextInput();
     emit("keyup", true);
-    
+
     function emitClipboard(type) {
       var data = {bubbles: true, cancelable:true};
       var event = new KeyboardEvent(type, data);
@@ -5033,7 +5046,7 @@ var typeKey = function() {
       data.key = text || keyCodeToKey[keyCode];
       data.code = keyCodeToCode[keyCode];
       var event = new KeyboardEvent(type, data);
-      
+
       var el = document.activeElement;
       el.dispatchEvent(event);
       return event.defaultPrevented;


### PR DESCRIPTION
Adds a new operatorMotion to vim.js

`:help i_CTRL-U`

                                                    *i_CTRL-U*
    CTRL-U          Delete all entered characters before the cursor in the current
                    line.  If there are no newly entered characters and
                    'backspace' is not empty, delete all characters before the
                    cursor in the current line.
                    See |i_backspacing| about joining lines.
                                                    *i_CTRL-U-default*
                    By default, sets a new undo point before deleting.
                    |default-mappings|


<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->