### PR TITLE
[vim] simpler way of drawing cursor

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -60,19 +60,13 @@
 .cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
-.cm-fat-cursor-mark {
-  background-color: rgba(20, 255, 20, 0.5);
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-}
-.cm-animate-fat-cursor {
-  width: auto;
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-  background-color: #7e7;
-}
+.cm-fat-cursor .CodeMirror-line::selection,
+.cm-fat-cursor .CodeMirror-line > span::selection, 
+.cm-fat-cursor .CodeMirror-line > span > span::selection { background: transparent; }
+.cm-fat-cursor .CodeMirror-line::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span > span::-moz-selection { background: transparent; }
+.cm-fat-cursor { caret-color: transparent; }
 @-moz-keyframes blink {
   0% {}
   50% { background-color: transparent; }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1106,6 +1106,23 @@ testVim('I_visual_block_replay', function(cm, vim, helpers) {
   eq('12+-34\n5+-6+-78\na+-b+-cdefg\nx+-yz', cm.getValue());
 }, {value: '1234\n5678\nabcdefg\nxyz'});
 
+testVim('visual_block_backwards', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('3', 'l');
+  helpers.doKeys('<C-v>', '2', 'j', '2', '<Left>');
+  eq('123\n678\nbcd', cm.getSelection());
+  helpers.doKeys('A');
+  helpers.assertCursorAt(0, 4);
+  helpers.doKeys('A', '<Esc>');
+  helpers.assertCursorAt(0, 4);
+  helpers.doKeys('g', 'v');
+  eq('123\n678\nbcd', cm.getSelection());
+  helpers.doKeys('x');
+  helpers.assertCursorAt(0, 1);
+  helpers.doKeys('g', 'v');
+  eq('A4 \nA9 \nAef', cm.getSelection());
+}, {value: '01234 line 1\n56789 line 2\nabcdefg line 3\nline 4'});
+
 testVim('d_visual_block', function(cm, vim, helpers) {
   cm.setCursor(0, 1);
   helpers.doKeys('<C-v>', '2', 'j', 'l', 'l', 'l', 'd');


### PR DESCRIPTION
Removes the code for drawing the cursor with mark, at the cost of adding new option for prepareSelection. I did not manage to find a way to make it an option that would be useful in other situations too, but considering that CM5 is not in active development, perhaps a solution with internal only option would be acceptable. 

This also fixes https://github.com/codemirror/CodeMirror/issues/6312 