### PR TITLE
Add INTO keyword to SPARQL mode

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -31,7 +31,7 @@ CodeMirror.defineMode("sparql", function(config) {
                              "graph", "by", "asc", "desc", "as", "having", "undef", "values", "group",
                              "minus", "in", "not", "service", "silent", "using", "insert", "delete", "union",
                              "true", "false", "with",
-                             "data", "copy", "to", "move", "add", "create", "drop", "clear", "load"]);
+                             "data", "copy", "to", "move", "add", "create", "drop", "clear", "load", "into"]);
   var operatorChars = /[*+\-<>=&|\^\/!\?]/;
 
   function tokenBase(stream, state) {


### PR DESCRIPTION
This is an apparently overlooked keyword that only appears in LOAD commands.
See "Grammar" line 31 in
https://www.w3.org/TR/sparql11-query/