### PR TITLE
add sentence option for around/inner text object operation

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2155,6 +2155,11 @@
         } else if (character === 't') {
           tmp = expandTagUnderCursor(cm, head, inclusive);
         } else if (character === 's') {
+          // account for cursor on end of sentence symbol
+          var content = cm.getLine(head.line);
+          if (head.ch > 0 && isEndOfSentenceSymbol(content[head.ch])) {
+            head.ch -= 1;
+          }
           var end = getSentence(cm, head, motionArgs.repeat, 1, inclusive)
           var start = getSentence(cm, head, motionArgs.repeat, -1, inclusive)
           // closer vim behaviour, 'a' only takes the space after the sentence if there is one before and after

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3828,7 +3828,7 @@
     pos: index in line,
     dir: direction of traversal (-1 or 1)
     }
-    and modifies the line, ln, and pos members to represent the
+    and modifies the pos member to represent the
     next valid position or sets the line to null if there are
     no more valid positions.
    */

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2154,6 +2154,15 @@
           }
         } else if (character === 't') {
           tmp = expandTagUnderCursor(cm, head, inclusive);
+        } else if (character === 's') {
+          var end = getSentence(cm, head, motionArgs.repeat, 1, inclusive)
+          var start = getSentence(cm, head, motionArgs.repeat, -1, inclusive)
+          // closer vim behaviour, 'a' only takes the space after the sentence if there is one before and after
+          if (isWhiteSpaceString(cm.getLine(start.line)[start.ch])
+              && isWhiteSpaceString(cm.getLine(end.line)[end.ch -1])) {
+            start = {line: start.line, ch: start.ch + 1}
+          }
+          tmp = {start: start, end: end};
         } else {
           // No text object defined for this, don't move.
           return null;
@@ -3805,21 +3814,156 @@
       start = new Pos(i, 0);
       return { start: start, end: end };
     }
-
-    function findSentence(cm, cur, repeat, dir) {
-
-      /*
-        Takes an index object
-        {
-          line: the line string,
-          ln: line number,
-          pos: index in line,
-          dir: direction of traversal (-1 or 1)
+  function getSentence(cm, cur, repeat, dir, inclusive /*includes whitespace*/) {
+    /*
+	  Takes an index object
+	  {
+		line: the line string,
+		ln: line number,
+		pos: index in line,
+		dir: direction of traversal (-1 or 1)
+	  }
+	  and modifies the line, ln, and pos members to represent the
+	  next valid position or sets the line to null if there are
+	  no more valid positions.
+	 */
+    function nextChar(cm, curr) {
+      if (curr.pos + curr.dir < 0 || curr.pos + curr.dir >= curr.line.length) {
+          curr.line = null;
         }
-        and modifies the line, ln, and pos members to represent the
-        next valid position or sets them to null if there are
-        no more valid positions.
-       */
+      else {
+        curr.pos += curr.dir;
+      }
+    }
+    /*
+	  Performs one iteration of traversal in forward direction
+	  Returns an index object of the new location
+	 */
+    function forward(cm, ln, pos, dir) {
+      var line = cm.getLine(ln);
+
+      var curr = {
+        line: line,
+        ln: ln,
+        pos: pos,
+        dir: dir,
+      };
+
+      if (curr.line === "") {
+        return { ln: curr.ln, pos: curr.pos };
+      }
+
+      var lastSentencePos = curr.pos;
+
+      // Move one step to skip character we start on
+      nextChar(cm, curr);
+
+      while (curr.line !== null) {
+        lastSentencePos = curr.pos;
+        if (isEndOfSentenceSymbol(curr.line[curr.pos])) {
+          if (!inclusive) {
+            return { ln: curr.ln, pos: curr.pos + 1 };
+          } else {
+            nextChar(cm, curr);
+            while (curr.line !== null ) {
+              if (isWhiteSpaceString(curr.line[curr.pos])) {
+                lastSentencePos = curr.pos;
+                nextChar(cm, curr)
+              } else {
+                break;
+              }
+            }
+            return { ln: curr.ln, pos: lastSentencePos + 1, };
+          }
+        }
+        nextChar(cm, curr);
+      }
+      return { ln: curr.ln, pos: lastSentencePos + 1 };
+    }
+
+    /*
+	  Performs one iteration of traversal in reverse direction
+	  Returns an index object of the new location
+	 */
+    function reverse(cm, ln, pos, dir) {
+      var line = cm.getLine(ln);
+
+      var curr = {
+        line: line,
+        ln: ln,
+        pos: pos,
+        dir: dir,
+      }
+
+      if (curr.line === "") {
+        return { ln: curr.ln, pos: curr.pos };
+      }
+
+      var lastSentencePos = curr.pos;
+
+      // Move one step to skip character we start on
+      nextChar(cm, curr);
+
+      while (curr.line !== null) {
+        if (!isWhiteSpaceString(curr.line[curr.pos]) && !isEndOfSentenceSymbol(curr.line[curr.pos])) {
+          lastSentencePos = curr.pos;
+        }
+
+        else if (isEndOfSentenceSymbol(curr.line[curr.pos]) ) {
+          if (!inclusive) {
+            return { ln: curr.ln, pos: lastSentencePos };
+          } else {
+              if (isWhiteSpaceString(curr.line[curr.pos + 1])) {
+                return { ln: curr.ln, pos: curr.pos + 1, };
+              } else {
+                return {ln: curr.ln, pos: lastSentencePos};
+              }
+          }
+        }
+
+        nextChar(cm, curr);
+      }
+      curr.line = line
+      if (inclusive && isWhiteSpaceString(curr.line[curr.pos])) {
+        return { ln: curr.ln, pos: curr.pos };
+      } else {
+        return { ln: curr.ln, pos: lastSentencePos };
+      }
+
+    }
+
+    var curr_index = {
+      ln: cur.line,
+      pos: cur.ch,
+    };
+
+    while (repeat > 0) {
+      if (dir < 0) {
+        curr_index = reverse(cm, curr_index.ln, curr_index.pos, dir);
+      }
+      else {
+        curr_index = forward(cm, curr_index.ln, curr_index.pos, dir);
+      }
+      repeat--;
+    }
+
+    return new Pos(curr_index.ln, curr_index.pos);
+  }
+
+  function findSentence(cm, cur, repeat, dir) {
+
+    /*
+	  Takes an index object
+	  {
+		line: the line string,
+		ln: line number,
+		pos: index in line,
+		dir: direction of traversal (-1 or 1)
+	  }
+	  and modifies the line, ln, and pos members to represent the
+	  next valid position or sets them to null if there are
+	  no more valid positions.
+	 */
       function nextChar(cm, idx) {
         if (idx.pos + idx.dir < 0 || idx.pos + idx.dir >= idx.line.length) {
           idx.ln += idx.dir;

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3821,18 +3821,18 @@
     }
   function getSentence(cm, cur, repeat, dir, inclusive /*includes whitespace*/) {
     /*
-	  Takes an index object
-	  {
-		line: the line string,
-		ln: line number,
-		pos: index in line,
-		dir: direction of traversal (-1 or 1)
-	  }
-	  and modifies the line, ln, and pos members to represent the
-	  next valid position or sets the line to null if there are
-	  no more valid positions.
-	 */
-    function nextChar(cm, curr) {
+    Takes an index object
+    {
+    line: the line string,
+    ln: line number,
+    pos: index in line,
+    dir: direction of traversal (-1 or 1)
+    }
+    and modifies the line, ln, and pos members to represent the
+    next valid position or sets the line to null if there are
+    no more valid positions.
+   */
+    function nextChar(curr) {
       if (curr.pos + curr.dir < 0 || curr.pos + curr.dir >= curr.line.length) {
           curr.line = null;
         }
@@ -3841,9 +3841,9 @@
       }
     }
     /*
-	  Performs one iteration of traversal in forward direction
-	  Returns an index object of the new location
-	 */
+    Performs one iteration of traversal in forward direction
+    Returns an index object of the new location
+   */
     function forward(cm, ln, pos, dir) {
       var line = cm.getLine(ln);
 
@@ -3861,7 +3861,7 @@
       var lastSentencePos = curr.pos;
 
       // Move one step to skip character we start on
-      nextChar(cm, curr);
+      nextChar(curr);
 
       while (curr.line !== null) {
         lastSentencePos = curr.pos;
@@ -3869,11 +3869,11 @@
           if (!inclusive) {
             return { ln: curr.ln, pos: curr.pos + 1 };
           } else {
-            nextChar(cm, curr);
+            nextChar(curr);
             while (curr.line !== null ) {
               if (isWhiteSpaceString(curr.line[curr.pos])) {
                 lastSentencePos = curr.pos;
-                nextChar(cm, curr)
+                nextChar(curr)
               } else {
                 break;
               }
@@ -3881,15 +3881,15 @@
             return { ln: curr.ln, pos: lastSentencePos + 1, };
           }
         }
-        nextChar(cm, curr);
+        nextChar(curr);
       }
       return { ln: curr.ln, pos: lastSentencePos + 1 };
     }
 
     /*
-	  Performs one iteration of traversal in reverse direction
-	  Returns an index object of the new location
-	 */
+    Performs one iteration of traversal in reverse direction
+    Returns an index object of the new location
+   */
     function reverse(cm, ln, pos, dir) {
       var line = cm.getLine(ln);
 
@@ -3907,7 +3907,7 @@
       var lastSentencePos = curr.pos;
 
       // Move one step to skip character we start on
-      nextChar(cm, curr);
+      nextChar(curr);
 
       while (curr.line !== null) {
         if (!isWhiteSpaceString(curr.line[curr.pos]) && !isEndOfSentenceSymbol(curr.line[curr.pos])) {
@@ -3926,7 +3926,7 @@
           }
         }
 
-        nextChar(cm, curr);
+        nextChar(curr);
       }
       curr.line = line
       if (inclusive && isWhiteSpaceString(curr.line[curr.pos])) {
@@ -3958,17 +3958,17 @@
   function findSentence(cm, cur, repeat, dir) {
 
     /*
-	  Takes an index object
-	  {
-		line: the line string,
-		ln: line number,
-		pos: index in line,
-		dir: direction of traversal (-1 or 1)
-	  }
-	  and modifies the line, ln, and pos members to represent the
-	  next valid position or sets them to null if there are
-	  no more valid positions.
-	 */
+    Takes an index object
+    {
+    line: the line string,
+    ln: line number,
+    pos: index in line,
+    dir: direction of traversal (-1 or 1)
+    }
+    and modifies the line, ln, and pos members to represent the
+    next valid position or sets them to null if there are
+    no more valid positions.
+   */
       function nextChar(cm, idx) {
         if (idx.pos + idx.dir < 0 || idx.pos + idx.dir >= idx.line.length) {
           idx.ln += idx.dir;

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -648,6 +648,86 @@ testVim('paragraph_motions', function(cm, vim, helpers) {
   eq('b\na\na\nc\n', register.toString());
 }, { value: 'a\na\n\n\n\nb\nc\n\n\n\n\n\n\nd\n\ne\nf' });
 
+testVim('sentence_selections', function(cm, vim, helpers) {
+  // vis at beginning of line
+  cm.setCursor(0, 0);
+  helpers.doKeys('v', 'i', 's');
+  eqCursorPos(new Pos(0, 0), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(0, 14), cm.getCursor('head'));
+
+  // vas at beginning of line
+  cm.setCursor(0, 0);
+  helpers.doKeys('v', 'a', 's');
+  eqCursorPos(new Pos(0, 0), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(0, 15), cm.getCursor('head'));
+
+  // vis on sentence end
+  cm.setCursor(0, 13);
+  helpers.doKeys('v', 'i', 's');
+  eqCursorPos(new Pos(0, 0), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(0, 14), cm.getCursor('head'));
+
+  // vas on sentence end
+  cm.setCursor(0, 13);
+  helpers.doKeys('v', 'a', 's');
+  eqCursorPos(new Pos(0, 0), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(0, 15), cm.getCursor('head'));
+
+  // vis at sentence end, no whitespace after it
+  cm.setCursor(1, 18);
+  helpers.doKeys('v', 'i', 's');
+  eqCursorPos(new Pos(1, 13), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(1, 19), cm.getCursor('head'));
+
+  // vas at sentence end, no whitespace after it
+  cm.setCursor(1, 18);
+  helpers.doKeys('v', 'a', 's');
+  eqCursorPos(new Pos(1, 12), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(1, 19), cm.getCursor('head'));
+
+  // vis at sentence beginning, on whitespace
+  cm.setCursor(0, 14);
+  helpers.doKeys('v', 'i', 's');
+  eqCursorPos(new Pos(0, 14), cm.getCursor('anchor'));
+  eqCursorPos(new Pos(0, 29), cm.getCursor('head'));
+
+  cm.setCursor(0, 0);
+  helpers.doKeys('d', 'i', 's');
+  var register = helpers.getRegisterController().getRegister();
+  eq('Test sentence.', register.toString());
+
+  // return to original value
+  helpers.doKeys('u')
+
+  cm.setCursor(0, 0);
+  helpers.doKeys('d', 'a', 's');
+  register = helpers.getRegisterController().getRegister();
+  eq('Test sentence. ', register.toString());
+
+  // return to original value
+  helpers.doKeys('u')
+
+  cm.setCursor(1, 20);
+  helpers.doKeys('c', 'a', 's', '<Esc>');
+  register = helpers.getRegisterController().getRegister();
+  eq('Test.', register.toString());
+
+  // return to original value
+  helpers.doKeys('u')
+
+  cm.setCursor(3, 11);
+  helpers.doKeys('y', 'a', 's');
+  register = helpers.getRegisterController().getRegister();
+  eq('This is more text. ', register.toString());
+
+  cm.setCursor(3, 31);
+  helpers.doKeys('y', 'a', 's');
+  register = helpers.getRegisterController().getRegister();
+  eq(' No end of sentence symbol', register.toString());
+
+}, { value: 'Test sentence. Test question?\nAgain.Never. Again.Test.\n\nHello. This is more text. No end of sentence symbol\n' });
+
+
 // Operator tests
 testVim('dl', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 0);


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->

This PR adds support for the text object operations using the sentence operator (`vis`/`vas`/`dis`/`das`/`cis`/`cas`/`yis`/`yas`).

I've also added tests, they all pass.

This is intended to be added to the cm6 vim repo eventually.
https://github.com/replit/codemirror-vim/pull/19

Closes #5454.