### PR TITLE
fix the char ranges identifying valid colors in CSS

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -228,7 +228,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     if (type == "}" || type == "{") return popAndPass(type, stream, state);
     if (type == "(") return pushContext(state, stream, "parens");
 
-    if (type == "hash" && !/^#([0-9a-fA-f]{3,4}|[0-9a-fA-f]{6}|[0-9a-fA-f]{8})$/.test(stream.current())) {
+    if (type == "hash" && !/^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(stream.current())) {
       override += " error";
     } else if (type == "word") {
       wordAsValue(stream);


### PR DESCRIPTION
The character class `[A-f]` is equivalent to the character class `[A-Z\[\\\]^_`a-f]`, which I don't think is what you meant to put there.  

You call see the bug if you e.g. go to the [CSS demo page](https://codemirror.net/5/mode/css/) and try "colors" such as `#ZZZ` or `#_X_` and see that they are highlighted as a valid color.  
But e.g. `#xyz` is not highlighted as a valid color.  

I'm making a CodeQL query to identify such mistakes, and that's how I found this bug.  
You can see the WIP query here: https://lgtm.com/query/3452833904737970282/