### PR TITLE
[go mode] Add new builtin types `any` and `comparable`

### DIFF
--- a/mode/go/go.js
+++ b/mode/go/go.js
@@ -24,7 +24,7 @@ CodeMirror.defineMode("go", function(config) {
     "float32":true, "float64":true, "int8":true, "int16":true, "int32":true,
     "int64":true, "string":true, "uint8":true, "uint16":true, "uint32":true,
     "uint64":true, "int":true, "uint":true, "uintptr":true, "error": true,
-    "rune":true
+    "rune":true, "any":true, "comparable":true
   };
 
   var atoms = {


### PR DESCRIPTION
Go 1.18 introduced two new predeclared identifiers: `any` and `comparable`:
https://go.dev/doc/go1.18#generics

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
