### PR TITLE
Add support for line comments to the Elm mode

### DIFF
--- a/mode/elm/elm.js
+++ b/mode/elm/elm.js
@@ -229,6 +229,8 @@
     return {
       startState: function ()  { return { f: normal() }; },
       copyState:  function (s) { return { f: s.f }; },
+      
+      lineComment: '--',
 
       token: function(stream, state) {
         var type = state.f(stream, function(s) { state.f = s; });


### PR DESCRIPTION
This lets a user toggle comments with a keyboard shortcut when using codemirror to edit Elm code.
