### PR TITLE
[security] Use textContent instead of innerHTML

### DIFF
--- a/addon/runmode/colorize.js
+++ b/addon/runmode/colorize.js
@@ -31,7 +31,7 @@
 
       var text = [];
       textContent(node, text);
-      node.innerHTML = "";
+      node.textContent = "";
       CodeMirror.runMode(text.join(""), mode, node);
 
       node.className += " cm-s-default";

--- a/addon/runmode/runmode.js
+++ b/addon/runmode/runmode.js
@@ -20,7 +20,7 @@ CodeMirror.runMode = function(string, modespec, callback, options) {
     var ie = /MSIE \d/.test(navigator.userAgent);
     var ie_lt9 = ie && (document.documentMode == null || document.documentMode < 9);
     var node = callback, col = 0;
-    node.innerHTML = "";
+    node.textContent = "";
     callback = function(text, style) {
       if (text == "\n") {
         // Emitting LF or CRLF on IE8 or earlier results in an incorrect display.


### PR DESCRIPTION
In general, assigning a plain string to the innerHTML property of an
element can cause XSS vulnerabilities, and is thus considered as a
violation by the [Trusted Types](https://web.dev/trusted-types/) web platform security mechanism. This
PR addresses two such violations in CodeMirror by replacing them
with semantically equivalent assignments to the textContent property.
This is currently a blocker for CodeMirror users that want to enforce
Trusted Types in their web application.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
