### PR TITLE
[security] Ensure text in tern dialog is escaped

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -589,10 +589,16 @@
   }
 
   function dialog(cm, text, f) {
-    if (cm.openDialog)
-      cm.openDialog(text + ": <input type=text>", f);
-    else
+    if (cm.openDialog) {
+      var fragment = document.createDocumentFragment();
+      fragment.appendChild(document.createTextNode(text + ": "));
+      var input = document.createElement("input");
+      input.type = "text";
+      fragment.appendChild(input);
+      cm.openDialog(fragment, f);
+    } else {
       f(prompt(text, ""));
+    }
   }
 
   // Tooltips


### PR DESCRIPTION
This addresses a potential XSS vulnerability caused by tern's
construction of inline HTML where text input is not escaped, which is
then passed to the openDialog function for rendering. The construction
is replaced with an equivalent DOM fragment construction, which
the openDialog API also supports.

This is currently a blocker for CodeMirror users that want to enforce
Trusted Types in their web application.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
