### PR TITLE
Focus the window in which CodeMirror is rendered.

### DIFF
--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -73,7 +73,7 @@ export function onMouseDown(e) {
   }
   if (clickInGutter(cm, e)) return
   let pos = posFromMouse(cm, e), button = e_button(e), repeat = pos ? clickRepeat(pos, button) : "single"
-  window.focus()
+  display.wrapper.ownerDocument.defaultView.focus()
 
   // #3261: make sure, that we're not starting a second selection
   if (button == 1 && cm.state.selectingText)


### PR DESCRIPTION
We ran into some issues where under certain conditions Firefox would lose focus of the editor. In particular if CodeMirror is being rendered in a frame different than the frame in which the code itself is running. This PR ensures that the call to `focus()` on mouse clicks happens on the window in which CodeMirror is being rendered, and not the window running the code.

This PR is similar to [#5309](https://github.com/codemirror/codemirror5/pull/5309).

