### PR TITLE
Fix for new function name clashing with local variable.

### DIFF
--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -9,7 +9,7 @@ import { normalizeSelection, Range, Selection } from "../model/selection.js"
 import { extendRange, extendSelection, replaceOneSelection, setSelection } from "../model/selection_updates.js"
 import { captureRightClick, chromeOS, ie, ie_version, mac, webkit, safari } from "../util/browser.js"
 import { getOrder, getBidiPartAt } from "../util/bidi.js"
-import { activeElt, doc, win } from "../util/dom.js"
+import { activeElt, doc as getDoc, win } from "../util/dom.js"
 import { e_button, e_defaultPrevented, e_preventDefault, e_target, hasHandler, off, on, signal, signalDOMEvent } from "../util/event.js"
 import { dragAndDrop } from "../util/feature_detection.js"
 import { bind, countColumn, findColumn, sel_mouse } from "../util/misc.js"
@@ -128,7 +128,7 @@ function configureMouse(cm, repeat, event) {
 
 function leftButtonDown(cm, pos, repeat, event) {
   if (ie) setTimeout(bind(ensureFocus, cm), 0)
-  else cm.curOp.focus = activeElt(doc(cm))
+  else cm.curOp.focus = activeElt(getDoc(cm))
 
   let behavior = configureMouse(cm, repeat, event)
 
@@ -292,7 +292,7 @@ function leftButtonSelect(cm, event, start, behavior) {
     let cur = posFromMouse(cm, e, true, behavior.unit == "rectangle")
     if (!cur) return
     if (cmp(cur, lastPos) != 0) {
-      cm.curOp.focus = activeElt(doc(cm))
+      cm.curOp.focus = activeElt(getDoc(cm))
       extendTo(cur)
       let visible = visibleLines(display, doc)
       if (cur.line >= visible.to || cur.line < visible.from)


### PR DESCRIPTION
Text selection was broken in the latest commit because the `extend` function is defined within the `leftMouseSelect` function and that caused `doc()` the function to be shadowned by `doc = cm.doc` the local variable. 