### PR TITLE
[Show-Hints] Hint popup exceeds the viewport's height

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -291,7 +291,7 @@
       if (curTop - height > 0) { // Fits above cursor
         hints.style.top = (top = pos.top - height - offsetTop) + "px";
         below = false;
-      } else if (box.top + height > winH) {
+      } else if (height > winH) {
         hints.style.height = (winH - 5) + "px";
         hints.style.top = (top = pos.bottom - box.top - offsetTop) + "px";
         var cursor = cm.getCursor();
@@ -300,6 +300,8 @@
           hints.style.left = (left = pos.left - offsetLeft) + "px";
           box = hints.getBoundingClientRect();
         }
+      } else if (pos.bottom + height > winH) {
+        hints.style.height = (winH - pos.bottom - 5) + "px";
       }
     }
     var overlapX = box.right - winW;

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -291,7 +291,7 @@
       if (curTop - height > 0) { // Fits above cursor
         hints.style.top = (top = pos.top - height - offsetTop) + "px";
         below = false;
-      } else if (height > winH) {
+      } else if (box.top + height > winH) {
         hints.style.height = (winH - 5) + "px";
         hints.style.top = (top = pos.bottom - box.top - offsetTop) + "px";
         var cursor = cm.getCursor();


### PR DESCRIPTION
The current implementation does not taking care of the top-position of the popup window while calculating the final height of it.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
