### PR TITLE
[sparql mode] Identify all characters in prefixes

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -33,6 +33,15 @@ CodeMirror.defineMode("sparql", function(config) {
                              "true", "false", "with",
                              "data", "copy", "to", "move", "add", "create", "drop", "clear", "load", "into"]);
   var operatorChars = /[*+\-<>=&|\^\/!\?]/;
+  var PN_CHARS_BASE =
+  "[A-Z]|[a-z]|[\\u{00C0}-\\u{00D6}]|[\\u{00D8}-\\u{00F6}]|[\\u{00F8}-\\u{02FF}]|" +
+  "[\\u{0370}-\\u{037D}]|[\\u{037F}-\\u{1FFF}]|[\\u{200C}-\\u{200D}]|[\\u{2070}-\\u{218F}]|" +
+  "[\\u{2C00}-\\u{2FEF}]|[\\u{3001}-\\u{D7FF}]|[\\u{F900}-\\u{FDCF}]|[\\u{FDF0}-\\u{FFFD}]|[\\u{10000}-\\u{EFFFF}]";
+  var PN_CHARS_U = PN_CHARS_BASE + "|_";
+  var PN_CHARS = PN_CHARS_U + "|-|[0-9]|\\u{00B7}|[\\u{0300}-\\u{036F}]|[\\u{203F}-\\u{2040}]";
+  var PREFIX_START = new RegExp(PN_CHARS_BASE, "u");
+  var PREFIX_MID = new RegExp(PN_CHARS + "|\\.", "u");
+  var PREFIX_END = new RegExp(PN_CHARS, "u");
 
   function tokenBase(stream, state) {
     var ch = stream.next();
@@ -72,11 +81,19 @@ CodeMirror.defineMode("sparql", function(config) {
       return "meta";
     }
     else {
-      stream.eatWhile(/[_\w\d]/);
-      if (stream.eat(":")) {
-        eatPnLocal(stream);
-        return "atom";
+      if (PREFIX_START.test(ch)) {
+        if (stream.eatWhile(PREFIX_MID)) {
+          stream.backUp(1);
+          if (stream.eat(PREFIX_END) && stream.eat(":")) {
+            eatPnLocal(stream);
+            return "atom";
+          }
+        } else if (stream.eat(":")) {
+          eatPnLocal(stream);
+          return "atom";
+        }
       }
+      stream.eatWhile(/[_\w\d]/);
       var word = stream.current();
       if (ops.test(word))
         return "builtin";

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -34,11 +34,11 @@ CodeMirror.defineMode("sparql", function(config) {
                              "data", "copy", "to", "move", "add", "create", "drop", "clear", "load", "into"]);
   var operatorChars = /[*+\-<>=&|\^\/!\?]/;
   var PN_CHARS_BASE =
-    "[A-Za-z]|[\\u{00C0}-\\u{00D6}]|[\\u{00D8}-\\u{00F6}]|[\\u{00F8}-\\u{02FF}]|" +
-    "[\\u{0370}-\\u{037D}]|[\\u{037F}-\\u{1FFF}]|[\\u{200C}-\\u{200D}]|[\\u{2070}-\\u{218F}]|" +
-    "[\\u{2C00}-\\u{2FEF}]|[\\u{3001}-\\u{D7FF}]|[\\u{F900}-\\u{FDCF}]|[\\u{FDF0}-\\u{FFFD}]|[\\u{10000}-\\u{EFFFF}]";
+    "[A-Za-z\\u{00C0}-\\u{00D6}\\u{00D8}-\\u{00F6}\\u{00F8}-\\u{02FF}" +
+    "\\u{0370}-\\u{037D}\\u{037F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}" +
+    "\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}]";
   var PN_CHARS_U = PN_CHARS_BASE + "|_";
-  var PN_CHARS = PN_CHARS_U + "|-|[0-9]|\\u{00B7}|[\\u{0300}-\\u{036F}]|[\\u{203F}-\\u{2040}]";
+  var PN_CHARS = PN_CHARS_U + "|[\\-0-9\\u{00B7}\\u{0300}-\\u{036F}\\u{203F}-\\u{2040}]";
   var PREFIX_START = new RegExp(PN_CHARS_BASE, "u");
   var PREFIX_REMAINDER = new RegExp("((" + PN_CHARS + "|\\.)*(" + PN_CHARS + "))?:", "u");
 

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -34,9 +34,9 @@ CodeMirror.defineMode("sparql", function(config) {
                              "data", "copy", "to", "move", "add", "create", "drop", "clear", "load", "into"]);
   var operatorChars = /[*+\-<>=&|\^\/!\?]/;
   var PN_CHARS_BASE =
-  "[A-Z]|[a-z]|[\\u{00C0}-\\u{00D6}]|[\\u{00D8}-\\u{00F6}]|[\\u{00F8}-\\u{02FF}]|" +
-  "[\\u{0370}-\\u{037D}]|[\\u{037F}-\\u{1FFF}]|[\\u{200C}-\\u{200D}]|[\\u{2070}-\\u{218F}]|" +
-  "[\\u{2C00}-\\u{2FEF}]|[\\u{3001}-\\u{D7FF}]|[\\u{F900}-\\u{FDCF}]|[\\u{FDF0}-\\u{FFFD}]|[\\u{10000}-\\u{EFFFF}]";
+    "[A-Z]|[a-z]|[\\u{00C0}-\\u{00D6}]|[\\u{00D8}-\\u{00F6}]|[\\u{00F8}-\\u{02FF}]|" +
+    "[\\u{0370}-\\u{037D}]|[\\u{037F}-\\u{1FFF}]|[\\u{200C}-\\u{200D}]|[\\u{2070}-\\u{218F}]|" +
+    "[\\u{2C00}-\\u{2FEF}]|[\\u{3001}-\\u{D7FF}]|[\\u{F900}-\\u{FDCF}]|[\\u{FDF0}-\\u{FFFD}]|[\\u{10000}-\\u{EFFFF}]";
   var PN_CHARS_U = PN_CHARS_BASE + "|_";
   var PN_CHARS = PN_CHARS_U + "|-|[0-9]|\\u{00B7}|[\\u{0300}-\\u{036F}]|[\\u{203F}-\\u{2040}]";
   var PREFIX_START = new RegExp(PN_CHARS_BASE, "u");

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -33,14 +33,9 @@ CodeMirror.defineMode("sparql", function(config) {
                              "true", "false", "with",
                              "data", "copy", "to", "move", "add", "create", "drop", "clear", "load", "into"]);
   var operatorChars = /[*+\-<>=&|\^\/!\?]/;
-  var PN_CHARS_BASE =
-    "[A-Za-z\\u{00C0}-\\u{00D6}\\u{00D8}-\\u{00F6}\\u{00F8}-\\u{02FF}" +
-    "\\u{0370}-\\u{037D}\\u{037F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}" +
-    "\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}]";
-  var PN_CHARS_U = PN_CHARS_BASE + "|_";
-  var PN_CHARS = PN_CHARS_U + "|[\\-0-9\\u{00B7}\\u{0300}-\\u{036F}\\u{203F}-\\u{2040}]";
-  var PREFIX_START = new RegExp(PN_CHARS_BASE, "u");
-  var PREFIX_REMAINDER = new RegExp("((" + PN_CHARS + "|\\.)*(" + PN_CHARS + "))?:", "u");
+  var PN_CHARS = "[A-Za-z_\\-0-9]";
+  var PREFIX_START = new RegExp("[A-Za-z]");
+  var PREFIX_REMAINDER = new RegExp("((" + PN_CHARS + "|\\.)*(" + PN_CHARS + "))?:");
 
   function tokenBase(stream, state) {
     var ch = stream.next();
@@ -79,8 +74,7 @@ CodeMirror.defineMode("sparql", function(config) {
       stream.eatWhile(/[a-z\d\-]/i);
       return "meta";
     }
-    else if (PREFIX_START.test(ch) && stream.match(PREFIX_REMAINDER, false)) {
-        stream.match(PREFIX_REMAINDER)
+    else if (PREFIX_START.test(ch) && stream.match(PREFIX_REMAINDER)) {
         eatPnLocal(stream);
         return "atom";
     }


### PR DESCRIPTION
SPARQL specifies prefixes, for example "bio" in the prefix specification below, according to https://www.w3.org/TR/sparql11-query/ Productions for terminals [168]

`PREFIX bio: <http://purl.org/vocab/bio/0.1/>`

sparql.js has a simple last-chance regular expression that is used to match prefixes, operators and keywords. This does not, for example, allow hyphen and period characters in prefixes despite them being permitted (in different places) according to the specification. This has been augmented with the patterns from the specification to identify prefix atoms before the operators and keywords are processed as before.

Note that the mode continues to treat anything after a prefix as being a PN_LOCAL (Productions for terminals [169]). This is correct in the places within a SPARQL statement where a prefix is actually used but a slightly different set of characters is legal at the end of a prefix specification, like the example above.  I have not attempted to address this.
