### PR TITLE
Use autocorrect and autocapitalize value of on instead of empty string

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -114,8 +114,8 @@ export function copyableRanges(cm) {
 }
 
 export function disableBrowserMagic(field, spellcheck, autocorrect, autocapitalize) {
-  field.setAttribute("autocorrect", autocorrect ? "" : "off")
-  field.setAttribute("autocapitalize", autocapitalize ? "" : "off")
+  field.setAttribute("autocorrect", autocorrect ? "on" : "off")
+  field.setAttribute("autocapitalize", autocapitalize ? "on" : "off")
   field.setAttribute("spellcheck", !!spellcheck)
 }
 


### PR DESCRIPTION
Fixes https://github.com/codemirror/codemirror5/issues/7009 and ultimately should fix https://github.com/directus/directus/issues/16690.