### PR TITLE
Add pipe operator to mlike keywords

### DIFF
--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -32,7 +32,8 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
     'type': 'keyword',
     'val': 'keyword',
     'while': 'keyword',
-    'with': 'keyword'
+    'with': 'keyword',
+    '|>': 'keyword'
   };
 
   var extraWords = parserConfig.extraWords || {};


### PR DESCRIPTION
I reason that if languages like Clojure have symbols in purple, languages with the pipe operator should also include one of their more heavily used operators.