### PR TITLE
mode.allowIndefiniteTokenCalls = true 

### DIFF
--- a/src/line/highlight.js
+++ b/src/line/highlight.js
@@ -158,7 +158,8 @@ function callBlankLine(mode, state) {
 }
 
 function readToken(mode, stream, state, inner) {
-  for (let i = 0; i < 10; i++) {
+  let maxAttempts = mode.allowIndefiniteTokenCalls? Number.MAX_VALUE : 10;
+  for (let i = 0; i < maxAttempts; i++) {
     if (inner) inner[0] = innerMode(mode, state).mode
     let style = mode.token(stream, state)
     if (stream.pos > stream.start) return style


### PR DESCRIPTION
Trying to "fix" this issue https://github.com/codemirror/codemirror5/issues/7023

https://github.com/codemirror/codemirror5/blob/658bff7c56b7829aeabb8a914be5ca728d8aba0b/src/line/highlight.js#L161
I propose letting the mode define a `allowIndefiniteTokenCalls` property and set it to `true` to remove that hardcoded limit.
