### PR TITLE
Always render linter's tooltip inside of viewport

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -26,6 +26,13 @@
       if (!tt.parentNode) return CodeMirror.off(document, "mousemove", position);
       tt.style.top = Math.max(0, e.clientY - tt.offsetHeight - 5) + "px";
       tt.style.left = (e.clientX + 5) + "px";
+
+      var box = tt.getBoundingClientRect()
+      var parentView = tt.ownerDocument.defaultView
+      if ( tt.offsetLeft + box.width > parentView.innerWidth)
+      {
+        tt.style.left = tt.offsetLeft - box.width
+      }
     }
     CodeMirror.on(document, "mousemove", position);
     position(e);


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
