### PR TITLE
Linter: Do not filter duplicates by message only

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -201,7 +201,7 @@
 
       // filter out duplicate messages
       var message = [];
-      anns = anns.filter(function(item) { return message.indexOf(item.message) > -1 ? false : message.push(item.message) });
+      anns = anns.filter(function(item) { return message.indexOf(item.message + item.from.ch + item.from.line + item.to.ch + item.to.line) > -1 ? false : message.push(item.message + item.from.ch + item.from.line + item.to.ch + item.to.line) });
 
       var maxSeverity = null;
       var tipLabel = state.hasGutter && document.createDocumentFragment();


### PR DESCRIPTION
Additionally, consider the positions, since there might be the same error message at different places.

Example:
![image](https://github.com/codemirror/codemirror5/assets/16348067/e8b7caa4-f672-4130-ab86-18d7a4c77d3d)

