### PR TITLE
Remove support for inline keyword in Dart mode

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -15,7 +15,7 @@
     "implements mixin get native set typedef with enum throw rethrow assert break case " +
     "continue default in return new deferred async await covariant try catch finally " +
     "do else for if switch while import library export part of show hide is as extension " +
-    "on yield late required sealed base interface when inline").split(" ");
+    "on yield late required sealed base interface when").split(" ");
   var blockKeywords = "try catch finally do else for if switch while".split(" ");
   var atoms = "true false null".split(" ");
   var builtins = "void bool num int double dynamic var String Null Never".split(" ");


### PR DESCRIPTION
The [inline classes feature](https://github.com/dart-lang/language/blob/main/working/1426-extension-types/feature-specification-inline-classes.md) this was part of is now obsolete and will not be part of the language. It will likely be replaced by [extension types](https://github.com/dart-lang/language/blob/main/accepted/future-releases/extension-types/feature-specification.md).