### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and test
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: '/home/runner/work/codemirror/codemirror5/node_modules'
           key: ${{ runner.os }}-modules


### PR DESCRIPTION
Resolves https://github.com/codemirror/codemirror5/issues/7064

It's important to make sure the SHA's are from the original repositories and not forks. I have manually verified all of them and added references in the commit description.