### PR TITLE
Support generics syntax in JSX with TS

### DIFF
--- a/mode/jsx/jsx.js
+++ b/mode/jsx/jsx.js
@@ -103,7 +103,7 @@
     }
 
     function jsToken(stream, state, cx) {
-      if (stream.peek() == "<" && stream.string.indexOf(',>', stream.start) < 0 && jsMode.expressionAllowed(stream, cx.state)) {
+      if (stream.peek() == "<" && !/,\s*>/.test(stream.string) && jsMode.expressionAllowed(stream, cx.state)) {
         state.context = new Context(CodeMirror.startState(xmlMode, jsMode.indent(cx.state, "", "")),
                                     xmlMode, 0, state.context)
         jsMode.skipExpression(cx.state)

--- a/mode/jsx/jsx.js
+++ b/mode/jsx/jsx.js
@@ -103,7 +103,7 @@
     }
 
     function jsToken(stream, state, cx) {
-      if (stream.peek() == "<" && jsMode.expressionAllowed(stream, cx.state)) {
+      if (stream.peek() == "<" && stream.string.indexOf(',>', stream.start) < 0 && jsMode.expressionAllowed(stream, cx.state)) {
         state.context = new Context(CodeMirror.startState(xmlMode, jsMode.indent(cx.state, "", "")),
                                     xmlMode, 0, state.context)
         jsMode.skipExpression(cx.state)

--- a/mode/jsx/test.js
+++ b/mode/jsx/test.js
@@ -96,5 +96,5 @@
      "[bracket&tag <][tag MyComponent] [attribute foo]={[number 0]} [bracket&tag />]; [comment //error]")
 
    TS("tsx_react_generics",
-      "[variable x] [operator =] [operator <] [type T],[operator >] ([variable v]: [type T]) [operator =>] [variable v];")
+      "[variable x] [operator =] [operator <] [type T],[operator >] ([def v]: [type T]) [operator =>] [variable-2 v];")
 })()

--- a/mode/jsx/test.js
+++ b/mode/jsx/test.js
@@ -96,5 +96,5 @@
      "[bracket&tag <][tag MyComponent] [attribute foo]={[number 0]} [bracket&tag />]; [comment //error]")
 
    TS("tsx_react_generics",
-      "[variable x] [operator =] [operator <] [type T],[operator >] ([def v]: [type T]) [operator =>] [variable-2 v];")
+      "[variable x] [operator =] [operator <] [variable T],[operator >] ([def v]: [type T]) [operator =>] [variable-2 v];")
 })()

--- a/mode/jsx/test.js
+++ b/mode/jsx/test.js
@@ -95,4 +95,6 @@
      "[bracket&tag <][tag MyComponent] [attribute foo]=[string \"bar\"] [bracket&tag />]; [comment //ok]",
      "[bracket&tag <][tag MyComponent] [attribute foo]={[number 0]} [bracket&tag />]; [comment //error]")
 
+   TS("tsx_react_generics",
+      "[variable x] [operator =] [operator <] [type T],[operator >] ([variable v]: [type T]) [operator =>] [variable v];")
 })()


### PR DESCRIPTION
Currently, a function that uses generics will look like this when the mode is JSX with TypeScript.

![Screenshot 2023-10-25 at 17 15 14](https://github.com/codemirror/codemirror5/assets/741344/c43ed592-45eb-466b-bf85-b1bba450571e)

With this fix, it will now be highlighted correctly:

![Screenshot 2023-10-25 at 17 17 19](https://github.com/codemirror/codemirror5/assets/741344/eed6e8e2-ac03-4d42-b16a-8b0ece2564e6)
