### PR TITLE
Add dependabot to update GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and test
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:


### PR DESCRIPTION
Fixes #7077.

This PR adds dependabot to periodically update the GitHub Actions used in CodeMirror's workflows.

Dependabot is configured to run once a month and send a single PR updating all the Actions with new versions. See [this example PR](https://github.com/pnacht/libarchive/pull/11).

I've also taken the liberty to update `actions/checkout` to its latest version [v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1). (you'd otherwise receive a dependabot PR moments after merging this PR)