### PR TITLE
Toggle Comment: Uncomment: Allow uncomment of selection containing an inner comment

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -174,11 +174,7 @@
     if (open == -1) return false
     var endLine = end == start ? startLine : self.getLine(end)
     var close = endLine.indexOf(endString, end == start ? open + startString.length : 0);
-    var insideStart = Pos(start, open + 1), insideEnd = Pos(end, close + 1)
-    if (close == -1 ||
-        !/comment/.test(self.getTokenTypeAt(insideStart)) ||
-        !/comment/.test(self.getTokenTypeAt(insideEnd)) ||
-        self.getRange(insideStart, insideEnd, "\n").indexOf(endString) > -1)
+    if (close == -1)
       return false;
 
     // Avoid killing block comments completely outside the selection.

--- a/test/comment_test.js
+++ b/test/comment_test.js
@@ -115,4 +115,16 @@ namespace = "comment_";
     cm.setCursor(1, 0)
     cm.execCommand("toggleComment")
   }, "<!-- foo\nbar -->", "<!-- foo\nbar -->")
+  
+  var beforeToggleComment = "\nAAA\n    <!-- BBB -->\nCCC\n\n";
+  var afterToggleComment  = "\n<!-- AAA\n    <!-- BBB -->\nCCC -->\n\n";
+  test("toggleSelectionContainingInnerCommentedLine1", "xml", function(cm) {
+    cm.setSelection({line: 1, ch: 6}, {line: 3, ch: 6});
+    cm.execCommand("toggleComment");
+  }, beforeToggleComment, afterToggleComment);
+  test("toggleSelectionContainingInnerCommentedLine2", "xml", function(cm) {
+    cm.setSelection({line: 1, ch: 6}, {line: 3, ch: 6});
+    cm.execCommand("toggleComment");
+    cm.execCommand("toggleComment");
+  }, beforeToggleComment, beforeToggleComment);
 })();


### PR DESCRIPTION
* [x] Preexisting tests pass
* [x] New tests added
* [x] All new code passes local lint rules

Explanation of changed lines inside the "comment" addon:
![Screenshot 2024-03-27 at 1 59 29 PM](https://github.com/codemirror/codemirror5/assets/764688/810ecbfc-75b6-4815-b6b2-0fb642585de3)