### PR TITLE
feat: use 'brace' fold on clojure code

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -281,6 +281,7 @@ CodeMirror.defineMode("clojure", function (options) {
     },
 
     closeBrackets: {pairs: "()[]{}\"\""},
+    fold: "brace",
     lineComment: ";;"
   };
 });


### PR DESCRIPTION
Clojure can use 'brace' to fold code