### PR TITLE
Dart: support digit separators

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -44,6 +44,8 @@
     blockKeywords: set(blockKeywords),
     builtin: set(builtins),
     atoms: set(atoms),
+    // clike numbers without the suffixes, and with '_' separators.
+    number: /^(?:0x[a-f\d_]+|(?:[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[-+]?[\d_]+)?)/i,
     hooks: {
       "@": function(stream) {
         stream.eatWhile(/[\w\$_\.]/);


### PR DESCRIPTION
Dart is [adding support for digit separators](https://github.com/dart-lang/language/blob/main/working/digit-separators/feature-specification.md), the underscore, like `1_000_000` or `0x33_33_33`. The Dart playground, [DartPad](https://dartpad.dev/), still runs on codemirror5, so this would be a welcome fix.