### PR TITLE
Added support for two important keywords: 'Rule' and 'Example'.

### DIFF
--- a/mode/gherkin/gherkin.js
+++ b/mode/gherkin/gherkin.js
@@ -155,6 +155,22 @@ CodeMirror.defineMode("gherkin", function () {
         state.inKeywordLine = true;
         return "keyword";
 
+        // RULE
+      } else if (state.allowScenario && stream.match(/(規則|ルール|قانون|قواعد|חוק|قاعدة|Правило|Правила|Reegel|Regel|Règle|Regola|Regla|Regulă|Regul|Regula|Regel|Regel|Regula|Правило|Правила|Regel|Regola|Regul|Reeglid|Rule):/)) {
+        state.allowPlaceholders = false;
+        state.allowSteps = true;
+        state.allowBackground = false;
+        state.allowMultilineArgument = true;
+        return "keyword";
+
+        // EXAMPLE
+      } else if (state.allowScenario && stream.match(/(例子|例|サンプル|예|דוגמה|مثال|Үрнәк|Пример|Παράδειγμα|Exemplo|Exemple|Beispiel|Ejemplo|Example|Esempio|Örnek|Példa|Pavyzdys|Paraugs|Voorbeeld|Příklad|Príklad|Exemplu|Esempi):/)) {
+        state.allowPlaceholders = false;
+        state.allowSteps = true;
+        state.allowBackground = false;
+        state.allowMultilineArgument = true;
+        return "keyword";
+
       // INLINE STRING
       } else if (stream.match(/"[^"]*"?/)) {
         return "string";


### PR DESCRIPTION
In this update, I extended the CodeMirror syntax highlighting to include two additional Gherkin keywords: Rule and Example. These keywords are now recognized in several languages, including Arabic, Hebrew, and more.

Why this change was made:

The previous implementation did not support the Rule and Example keywords, which are crucial for structuring Gherkin feature files. By adding these keywords with multilingual support, the change enhances the experience of writing Gherkin feature files in various languages, improving readability and accuracy for users working with Gherkin-based testing.