### PR TITLE
[theme demo] Fix dropdown losing choice on solarized light / dark

### DIFF
--- a/demo/theme.html
+++ b/demo/theme.html
@@ -183,9 +183,10 @@ function findSequence(goal) {
   function selectTheme() {
     var theme = input.options[input.selectedIndex].textContent;
     editor.setOption("theme", theme);
-    location.hash = "#" + theme;
+    location.hash = "#" + encodeURIComponent(theme);
   }
-  var choice = (location.hash && location.hash.slice(1)) ||
+  var choice = (location.hash &&
+                decodeURIComponent(location.hash.slice(1))) ||
                (document.location.search &&
                 decodeURIComponent(document.location.search.slice(1)));
   if (choice) {
@@ -193,7 +194,7 @@ function findSequence(goal) {
     editor.setOption("theme", choice);
   }
   CodeMirror.on(window, "hashchange", function() {
-    var theme = location.hash.slice(1);
+    var theme = decodeURIComponent(location.hash.slice(1));
     if (theme) { input.value = theme; selectTheme(); }
   });
 </script>


### PR DESCRIPTION
Mild bug in demo due to space handling.

Before: https://codemirror.net/5/demo/theme.html#solarized%20dark
1. dropdown .value set to non-existant `solarized%20dark` => dropdown reset to blank.
2. picking solarized dark / light from dropdown changes theme ([correctly](https://codemirror.net/doc/manual.html#option_theme) sets `.cm-s-solarized .cm-s-dark` classes),   
   sets URL fragment to `#solarized%20dark` (implicitly encoded by browser?¹),  
   which again triggers dropdown reset to blank (1).
3. can't iterate all dropdown values by Down/Up arrow: once you reach solarized, (2) happens

After: https://raw.githack.com/cben/CodeMirror5/theme-demo-location-hash-DEBUG/demo/theme.html#solarized%20dark (from [debug branch](https://github.com/cben/CodeMirror5/commits/theme-demo-location-hash-DEBUG/) with extra console logging)

¹ ² This commit makes both setting and getting URL fragment reliable.
