### PR TITLE
clip-path issue fixed in Chrome 106

### DIFF
--- a/src/display/Display.js
+++ b/src/display/Display.js
@@ -49,7 +49,7 @@ export function Display(place, doc, input, options) {
   // The element in which the editor lives.
   d.wrapper = elt("div", [d.scrollbarFiller, d.gutterFiller, d.scroller], "CodeMirror")
   // See #6982. FIXME remove when this has been fixed for a while in Chrome
-  if (chrome && chrome_version >= 105) d.wrapper.style.clipPath = "inset(0px)"
+  if (chrome && chrome_version === 105) d.wrapper.style.clipPath = "inset(0px)"
 
   // This attribute is respected by automatic translation systems such as Google Translate,
   // and may also be respected by tools used by human translators.


### PR DESCRIPTION
In Chrome 105 due to a bug, `clip-path` needed to be set as pointer events were ineffective outside CodeMirror editor instance but within paddings and margins of its elements. This has been resolved in Chrome 106 as seen [here](https://issues.chromium.org/issues/40863245#comment21).