### PR TITLE
fix bug in show-hints inset

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -255,6 +255,7 @@
     }
 
     var container = completion.options.container || ownerDocument.body;
+    var marginBottom = completion.options.marginBottom || 0;
     var pos = cm.cursorCoords(completion.options.alignWithWord ? data.from : null);
     var left = pos.left, top = pos.bottom, below = true;
     var offsetLeft = 0, offsetTop = 0;
@@ -285,12 +286,12 @@
     var startScroll;
     setTimeout(function() { startScroll = cm.getScrollInfo(); });
 
-    var overlapY = box.bottom - winH;
+    var overlapY = box.bottom + marginBottom - winH;
     if (overlapY > 0) { // Does not fit below
       var height = box.bottom - box.top, spaceAbove = box.top - (pos.bottom - pos.top) - 2
       if (winH - box.top < spaceAbove) { // More room at the top
         if (height > spaceAbove) hints.style.height = (height = spaceAbove) + "px";
-        hints.style.top = ((top = pos.top - height) + offsetTop) + "px";
+        hints.style.top = ((top = pos.top - height) - offsetTop) + "px";
         below = false;
       } else {
         hints.style.height = (winH - box.top - 2) + "px";


### PR DESCRIPTION
When the show-hints box does not have space to be displayed below, the box will be displayed in the wrong place, which is also reported in [this issue](https://github.com/codemirror/codemirror5/issues/6993). I fixed this issue by making some changes, which you can see in the videos below.

The reason I added `marginBottom` is so that I can give the box some space from the bottom (I didn't want the box to stick to the bottom of the page).

before:

[vokoscreenNG-2025-06-24_09-52-21.webm](https://github.com/user-attachments/assets/b79adcc4-659e-4aa7-bfbe-3bb4e2aabcbe)

after:

[vokoscreenNG-2025-06-24_09-49-06.webm](https://github.com/user-attachments/assets/a4267a16-af4b-4c31-a6c8-45958aa136c4)
