### PR TITLE
[kotlin mode]: Fix unsigned long literal token

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -680,7 +680,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     intendSwitch: false,
     indentStatements: false,
     multiLineStrings: true,
-    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(ul?|l|f)?/i,
     blockKeywords: words("catch class do else finally for if where try while enum"),
     defKeywords: words("class val var object interface fun"),
     atoms: words("true false null this"),


### PR DESCRIPTION
From the [Kotlin Spec](https://kotlinlang.org/spec/pdf/kotlin-spec.pdf) section _1.2.3 Literals_ there are only 3 Rules that define suffixes for literals:
```ebnf
FloatLiteral:
    DoubleLiteral ('f' |'F')
    | DecDigits ('f' |'F')

UnsignedLiteral
    (IntegerLiteral | HexLiteral | BinLiteral) ('u' |'U') ['L']

LongLiteral
    (IntegerLiteral | HexLiteral | BinLiteral)'L'
```

Ignoring casesensitivity we can catch them all with the regex `(ul?|l|f)` however the current regex for Kotlin suffixes looks like `(u|ll?|l|f)` which leads to the following inconsistency:

```kotlin
// Correctly highlighted by Codemirror and valid Kotlin
val a = 13u
val b = 24l

// Incorrectly highlighted by Codemirror but valid Kotlin
val c = 26UL

// Highlighted as one number but invalid Kotlin
val d = 72ll
```
